### PR TITLE
Update SAP HANA database system local variables

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
@@ -206,6 +206,12 @@ locals {
   enable_auth_password = try(var.databases[0].authentication.type, "key") == "password"
   enable_auth_key      = try(var.databases[0].authentication.type, "key") == "key"
 
+  authentication = {
+    "type"     = local.sid_auth_type
+    "username" = var.sid_username
+    "password" = var.sid_password
+  }
+  
   enable_db_lb_deployment = var.database_server_count > 0 && (var.use_loadbalancers_for_standalone_deployments || var.database_server_count > 1)
 
 


### PR DESCRIPTION
## Problem
Password based deployment of SAP HANA database VMs fails with the following message:
![image](https://user-images.githubusercontent.com/71097261/146495404-8dd679de-4011-4302-9529-87f605b6d4d1.png)


## Solution
Add authentication object for SAP HANA database deployments to support password based authentication for the VMs

## Tests
update the following parameters in `env-region-vnet-sid.tfvars` file as listed below:

```terraform

 database_vm_authentication_type = "password"
 app_tier_authentication_type = "password"

```
Run `installer.sh -p env-region-vnet-sid.tfvars -t sap_system`

## Notes
