### PR TITLE
Update setup_ado.sh

### DIFF
--- a/deploy/scripts/setup_ado.sh
+++ b/deploy/scripts/setup_ado.sh
@@ -4,7 +4,7 @@
 
   mkdir -p ~/agent; cd $_
 
-  wget https://vstsagentpackage.azureedge.net/agent/2.196.1/vsts-agent-linux-x64-2.196.1.tar.gz agent.tar.gz
+  wget https://vstsagentpackage.azureedge.net/agent/2.196.1/vsts-agent-linux-x64-2.196.1.tar.gz -O agent.tar.gz
 
   tar zxvf agent.tar.gz
 


### PR DESCRIPTION
## Problem
The file is not renamed after downloading it using wget

## Solution
wget command needs -O option to be able to rename it.

## Tests
Tested successfully 

## Notes
<Additional comments for the PR>