### PR TITLE
deployer_kv_name in BOMS/sap-parameters.yaml

### DIFF
--- a/samples/WORKSPACES/BOMS/sap-parameters.yaml
+++ b/samples/WORKSPACES/BOMS/sap-parameters.yaml
@@ -1,6 +1,6 @@
 ---
 
-bom_base_name:                 S41909SPS03_v0007ms
+bom_base_name:                 S41909SPS03_vxxxxxx
 
 #Name of the key vault containing the S user credentials
 deployer_kv_name:              MGMTWEEUDEP00user###

--- a/samples/WORKSPACES/BOMS/sap-parameters.yaml
+++ b/samples/WORKSPACES/BOMS/sap-parameters.yaml
@@ -3,7 +3,7 @@
 bom_base_name:                 S41909SPS03_v0007ms
 
 #Name of the key vault containing the S user credentials
-kv_name:                       MGMTWEEUDEP00user###
+deployer_kv_name:              MGMTWEEUDEP00user###
 
 # Set the following value to true to calculate checksums for the downloaded files
 # Not needed for the Microsoft provided BOMs


### PR DESCRIPTION
## Problem
ADO pipeline needs to pass the variable to ansible and stores the deployer_kv_name in this file.

## Solution
use the new vairable 

## Tests
done, works in devops. please check and make sure it works when deplyoing via menu script

## Notes
none