### PR TITLE
Update installer.sh Error retrieving keys for Storage Account "${REMOTE_STATE_SA}": 

### DIFF
--- a/deploy/pipelines/03-sap-system-deployment.yaml
+++ b/deploy/pipelines/03-sap-system-deployment.yaml
@@ -138,7 +138,7 @@ stages:
               ARM_CLIENT_ID:           $(ARM_CLIENT_ID)
               ARM_CLIENT_SECRET:       $(ARM_CLIENT_SECRET)
               ARM_TENANT_ID:           $(ARM_TENANT_ID)
-              REMOTE_STATE_SA:         ${REMOTE_STATE_SA}
+              REMOTE_STATE_SA:         $(REMOTE_STATE_SA)
               SYSTEM_ACCESSTOKEN:      $(System.AccessToken)
             failOnStderr:              false
 ...

--- a/deploy/pipelines/03-sap-system-deployment.yaml
+++ b/deploy/pipelines/03-sap-system-deployment.yaml
@@ -138,7 +138,6 @@ stages:
               ARM_CLIENT_ID:           $(ARM_CLIENT_ID)
               ARM_CLIENT_SECRET:       $(ARM_CLIENT_SECRET)
               ARM_TENANT_ID:           $(ARM_TENANT_ID)
-              REMOTE_STATE_SA:         $(REMOTE_STATE_SA)
               SYSTEM_ACCESSTOKEN:      $(System.AccessToken)
             failOnStderr:              false
 ...

--- a/deploy/scripts/installer.sh
+++ b/deploy/scripts/installer.sh
@@ -172,7 +172,7 @@ then
     deployer_tfstate_key=${key}.terraform.tfstate
 fi
 
-if [[ -n ${REMOTE_STATE_SA} ]];
+if [[ -z ${REMOTE_STATE_SA} ]];
 then
     echo "Loading the State file information"
     load_config_vars "${system_config_information}" "REMOTE_STATE_SA"

--- a/deploy/scripts/installer.sh
+++ b/deploy/scripts/installer.sh
@@ -172,7 +172,7 @@ then
     deployer_tfstate_key=${key}.terraform.tfstate
 fi
 
-if [[ -z ${REMOTE_STATE_SA} ]];
+if [[ -n ${REMOTE_STATE_SA} ]];
 then
     echo "Loading the State file information"
     load_config_vars "${system_config_information}" "REMOTE_STATE_SA"

--- a/deploy/scripts/installer.sh
+++ b/deploy/scripts/installer.sh
@@ -172,7 +172,7 @@ then
     deployer_tfstate_key=${key}.terraform.tfstate
 fi
 
-if [[ -z ${REMOTE_STATE_SA} ]];
+if [[ -z $REMOTE_STATE_SA ]];
 then
     echo "Loading the State file information"
     load_config_vars "${system_config_information}" "REMOTE_STATE_SA"


### PR DESCRIPTION
## Problem
**SAP System deployment fails**
│ Error: Failed to get existing workspaces: Error retrieving keys for Storage Account "${REMOTE_STATE_SA}": storage.AccountsClient#ListKeys: Failure responding to request: StatusCode=404 -- Original Error: autorest/azure: Service returned an error. Status=404 Code="ResourceNotFound" Message="The Resource 'Microsoft.Storage/storageAccounts/${REMOTE_STATE_SA}' under resource group 'MGMT-WEEU-SAP_LIBRARY' was not found. For more details please go to https://aka.ms/ARMResourceNotFoundFix"

## Solution
 REMOTE_STATE_SA:         ${REMOTE_STATE_SA}
must be
 REMOTE_STATE_SA:         $(REMOTE_STATE_SA)
or removed in the pipeline 3

## Tests
done

## Notes
none