### PR TITLE
Add support for running all the SAP roles on a single server

### DIFF
--- a/deploy/ansible/BOM-catalog/S41909SPS03_v0009ms/templates/S41909SPS03_v0009ms-dbload-inifile-param.j2
+++ b/deploy/ansible/BOM-catalog/S41909SPS03_v0009ms/templates/S41909SPS03_v0009ms-dbload-inifile-param.j2
@@ -36,6 +36,9 @@ NW_SCS_Instance.scsVirtualHostname                                   = {{ sap_sc
 NW_adaptProfile.skipSecurityProfileSettings                          = true
 NW_getFQDN.FQDN                                                      = {{ sap_fqdn }}
 
+
+
+
 HDB_Schema_Check_Dialogs.schemaName                                   = SAPHANADB
 HDB_Schema_Check_Dialogs.schemaPassword                               = {{ main_password }}
 HDB_Schema_Check_Dialogs.dropSchema                                   = true

--- a/deploy/ansible/BOM-catalog/S41909SPS03_v0009ms/templates/S41909SPS03_v0009ms-dbload-inifile-param.j2
+++ b/deploy/ansible/BOM-catalog/S41909SPS03_v0009ms/templates/S41909SPS03_v0009ms-dbload-inifile-param.j2
@@ -36,11 +36,9 @@ NW_SCS_Instance.scsVirtualHostname                                   = {{ sap_sc
 NW_adaptProfile.skipSecurityProfileSettings                          = true
 NW_getFQDN.FQDN                                                      = {{ sap_fqdn }}
 
-
-
-
 HDB_Schema_Check_Dialogs.schemaName                                   = SAPHANADB
 HDB_Schema_Check_Dialogs.schemaPassword                               = {{ main_password }}
+HDB_Schema_Check_Dialogs.dropSchema                                   = true
 
 NW_HDB_DB.abapSchemaName                                              = SAPHANADB
 NW_HDB_DB.abapSchemaPassword                                          = {{ main_password }}
@@ -53,7 +51,8 @@ NW_HDB_getDBInfo.systemPassword                                       = {{ main_
 NW_HDB_getDBInfo.systemid                                             = {{ db_sid|upper }}
 NW_HDB_getDBInfo.usingSSL                                             = true
 
-NW_Recovery_Install_HDB.extractLocation                               = /usr/sap/{{ db_sid|upper }}/{{ db_sid|upper }}{{ hdb_instance_number }}/backup/data/DB_HDB
+NW_Recovery_Install_HDB.extractLocation                               = /hana/backup/{{ db_sid|upper }}/HDB{{ hdb_instance_number }}/backup/data/DB_{{ db_sid|upper }}{{ hdb_instance_number }}
+
 NW_Recovery_Install_HDB.extractParallelJobs                           = 24
 NW_Recovery_Install_HDB.sidAdmName                                    = {{ db_sid|lower }}adm
 NW_Recovery_Install_HDB.sidAdmPassword                                = {{ main_password }}

--- a/deploy/ansible/BOM-catalog/S41909SPS03_v0009ms/templates/S41909SPS03_v0009ms-dbload-inifile-param.j2
+++ b/deploy/ansible/BOM-catalog/S41909SPS03_v0009ms/templates/S41909SPS03_v0009ms-dbload-inifile-param.j2
@@ -41,7 +41,9 @@ NW_getFQDN.FQDN                                                      = {{ sap_fq
 
 HDB_Schema_Check_Dialogs.schemaName                                   = SAPHANADB
 HDB_Schema_Check_Dialogs.schemaPassword                               = {{ main_password }}
-HDB_Schema_Check_Dialogs.dropSchema                                   = true
+
+# Specify if Software Provisioning Manager is to drop the schema if it exists.
+# HDB_Schema_Check_Dialogs.dropSchema                                   = true
 
 NW_HDB_DB.abapSchemaName                                              = SAPHANADB
 NW_HDB_DB.abapSchemaPassword                                          = {{ main_password }}

--- a/deploy/ansible/BOM-catalog/S41909SPS03_v0009ms/templates/S41909SPS03_v0009ms-pas-inifile-param.j2
+++ b/deploy/ansible/BOM-catalog/S41909SPS03_v0009ms/templates/S41909SPS03_v0009ms-pas-inifile-param.j2
@@ -63,7 +63,7 @@ NW_readProfileDir.profileDir                                          = {{ sap_p
 
 NW_CI_Instance.ascsVirtualHostname                                    = {{ sap_scs_hostname }}
 NW_CI_Instance.ciInstanceNumber                                       = {{ sap_ciInstanceNumber }}
-NW_CI_Instance.ciMSPort                                               = 36{{ scs_instance_number }}
+NW_CI_Instance.ciMSPort                                               = 36{{ sap_ciInstanceNumber }}
 NW_CI_Instance.ciVirtualHostname                                      = {{ sap_ciVirtualHostname }}
 NW_CI_Instance.scsVirtualHostname                                     = {{ sap_scs_hostname }}
 

--- a/deploy/ansible/BOM-catalog/archives/S41909SPS03_v0008ms/S41909SPS03_v0008ms.yaml
+++ b/deploy/ansible/BOM-catalog/archives/S41909SPS03_v0008ms/S41909SPS03_v0008ms.yaml
@@ -2,7 +2,6 @@
 # Download time:  70 Minutes (Full - 63GB)
 # Download time:  43 Minutes (Partial - 38GB)
 #
-
 name:    'S41909SPS03_v0008ms'
 target:  'S/4 HANA 1909 SPS 03'
 version: 8
@@ -22,6 +21,7 @@ product_ids:
 materials:
   dependencies:
     - name:     HANA_2_00_055_v0005ms
+    - name:     SWPM20SP10_latest
 
   media:
     # SAPCAR 7.22

--- a/deploy/ansible/configuration_menu.sh
+++ b/deploy/ansible/configuration_menu.sh
@@ -98,21 +98,21 @@ PS3='Please select playbook: '
 # all_playbooks array defined below
 options=(
         # Specific playbook entries
-        "Base OS Config"
-        "SAP specific OS Config"
+        "Base Operating System configuration"
+        "SAP specific Operating System configuration"
         "BOM Processing"
-        "HANA DB Install"
+        "Database Instance installation"
         "SCS Install"
-        "DB Load"
-        "PAS Install"
-        "APP Install"
-        "WebDisp Install"
-        "HANA HA Setup"
+        "Database Load"
+        "Primary Application Server installation"
+        "Application Server installations"
+        "Web Dispatcher installations"
+        "Database High Availability Setup"
 
         # Special menu entries
         "BOM Download"
-        "Install SAP (1-7)"
-        "Post SAP Install (8-10)"
+        "Configure and install SAP (1-7)"
+        "Post SAP Installation tasks (8-10)"
         "All Playbooks"
         "Quit"
 )

--- a/deploy/ansible/configuration_menu.sh
+++ b/deploy/ansible/configuration_menu.sh
@@ -101,17 +101,16 @@ options=(
         "Base OS Config"
         "SAP specific OS Config"
         "BOM Processing"
-        "DB Install"
+        "HANA DB Install"
         "SCS Install"
         "DB Load"
         "PAS Install"
         "APP Install"
         "WebDisp Install"
-        "Database HA Setup"
+        "HANA HA Setup"
 
         # Special menu entries
         "BOM Download"
-        "Tester"
         "Install SAP (1-7)"
         "Post SAP Install (8-10)"
         "All Playbooks"
@@ -132,9 +131,8 @@ all_playbooks=(
         # Post SAP Install Steps
         ${cmd_dir}/playbook_05_03_sap_app_install.yaml
         ${cmd_dir}/playbook_05_04_sap_web_install.yaml
-        ${cmd_dir}/playbook_04_00_01_db_ha.yaml
-        ${cmd_dir}/playbook_bom_downloader
-        ${cmd_dir}/playbook_tester.yaml
+        ${cmd_dir}/playbook_04_00_01_hana_hsr.yaml
+        ${cmd_dir}/playbook_bom_downloader.yaml
 )
 
 # Set of options that will be passed to the ansible-playbook command

--- a/deploy/ansible/playbook_03_bom_processing.yaml
+++ b/deploy/ansible/playbook_03_bom_processing.yaml
@@ -40,7 +40,7 @@
 # |                                                                            |
 # +------------------------------------4--------------------------------------*/
 
-- hosts:                               "{{ sap_sid|upper }}_SCS"
+- hosts:                               "{{ sap_sid|upper }}_SCS : {{ sap_sid|upper }}_DB"
 
   name:                                BOM Processing
   remote_user:                         "{{ orchestration_ansible_user }}"
@@ -57,7 +57,12 @@
 #
 # -------------------------------------+---------------------------------------8
 
-    - name: Set facts
+
+    - name:                            Show hosts
+      ansible.builtin.debug:
+        msg:                           "{{ ansible_play_hosts | first }}"
+
+    - name:                            Set facts
       ansible.builtin.set_fact:
         tier:                          preparation
         sapbits_location_base_path:    "{{ hostvars.localhost.sapbits_location_base_path }}"
@@ -68,6 +73,8 @@
         - name:                        Include the 3.3-bom-processing role
           ansible.builtin.include_role:
             name:                      roles-sap/3.3-bom-processing
+          vars:
+            selected_host:             "{{ ansible_play_hosts | first }}"
           tags:
             - 3.3-bom-processing
 

--- a/deploy/ansible/playbook_03_bom_processing.yaml
+++ b/deploy/ansible/playbook_03_bom_processing.yaml
@@ -56,27 +56,24 @@
 # Build the list of tasks to be executed in order here.
 #
 # -------------------------------------+---------------------------------------8
-
-
-    - name:                            Show hosts
-      ansible.builtin.debug:
-        msg:                           "{{ ansible_play_hosts | first }}"
-
-    - name:                            Set facts
-      ansible.builtin.set_fact:
-        tier:                          preparation
-        sapbits_location_base_path:    "{{ hostvars.localhost.sapbits_location_base_path }}"
-        sapbits_sas_token:             "{{ hostvars.localhost.sapbits_sas_token }}"
-
-    - name:                            3.3-bom-processing role
+    - name:                            "Perform BoM processing"
       block:
-        - name:                        Include the 3.3-bom-processing role
-          ansible.builtin.include_role:
-            name:                      roles-sap/3.3-bom-processing
-          vars:
-            selected_host:             "{{ ansible_play_hosts | first }}"
-          tags:
-            - 3.3-bom-processing
+
+        - name:                        Set facts
+          ansible.builtin.set_fact:
+            tier:                      preparation
+            sapbits_location_base_path:    "{{ hostvars.localhost.sapbits_location_base_path }}"
+            sapbits_sas_token:         "{{ hostvars.localhost.sapbits_sas_token }}"
+
+        - name:                        3.3-bom-processing role
+          block:
+            - name:                    Include the 3.3-bom-processing role
+              ansible.builtin.include_role:
+                name:                  roles-sap/3.3-bom-processing
+              tags:
+                - 3.3-bom-processing
+      when:
+        - "'scs' in supported_tiers"
 
 # /*----------------------------------------------------------------------------8
 # |                                                                            |

--- a/deploy/ansible/playbook_05_00_00_sap_scs_install.yaml
+++ b/deploy/ansible/playbook_05_00_00_sap_scs_install.yaml
@@ -66,8 +66,8 @@
 # +------------------------------------4--------------------------------------*/
 
 
-- hosts:                               "{{ sap_sid|upper }}_DB  :
-                                        {{ sap_sid|upper }}_SCS"
+- hosts:                               "{{ sap_sid|upper }}_SCS  :
+                                        {{ sap_sid|upper }}_DB"
 
   name:                                SAP Installation - SCS
   remote_user:                         "{{ orchestration_ansible_user }}"
@@ -105,11 +105,14 @@
             - name:                    Include 5.0.0-scs-install role
               ansible.builtin.include_role:
                 name:                  roles-sap/5.0.0-scs-install
+          vars:
+            selected_host:             "{{ ansible_play_hosts | first }}"
+            tier:                      "{{ tier }}"
           tags:
             - 5.0.0-scs-install
-      when:                            
-       - not scs_high_availability
-       - "'scs' in supported_tiers"
+      when:
+        - not scs_high_availability
+        - "'scs' in supported_tiers"
 
 # /*---------------------------------------------------------------------------8
 # |                                                                            |
@@ -216,9 +219,9 @@
                 name:                  roles-sap/5.6-scsers-pacemaker
           tags:
             - 5.6-scsers-pacemaker
-      when:                            
-       - scs_high_availability
-       - "'scs' in supported_tiers or 'ers' in supported_tiers "
+      when:
+        - scs_high_availability
+        - "'scs' in supported_tiers or 'ers' in supported_tiers "
 
 
 - hosts:                               localhost

--- a/deploy/ansible/playbook_05_00_00_sap_scs_install.yaml
+++ b/deploy/ansible/playbook_05_00_00_sap_scs_install.yaml
@@ -106,7 +106,6 @@
               ansible.builtin.include_role:
                 name:                  roles-sap/5.0.0-scs-install
           vars:
-            selected_host:             "{{ ansible_play_hosts | first }}"
             tier:                      "{{ tier }}"
           tags:
             - 5.0.0-scs-install

--- a/deploy/ansible/playbook_05_00_00_sap_scs_install.yaml
+++ b/deploy/ansible/playbook_05_00_00_sap_scs_install.yaml
@@ -86,6 +86,19 @@
     - name:                            Standalone SCS Setup
       block:
 
+        - block:
+            - ansible.builtin.debug:
+                msg:
+                  - "hdb_instance_number: {{ hdb_instance_number }}"
+                  - "scs_instance_number: {{ scs_instance_number }}"
+                verbosity:             2
+
+            - ansible.builtin.assert:
+                that:
+                  - "scs_instance_number != hdb_instance_number"
+                fail_msg:              "Please ensure that the scs_instance_number is different from the hdb_instance_number"
+          when:                        (ansible_play_hosts_all | length) == 1
+
         - name:                        Set 'scs' tier facts
           ansible.builtin.set_fact:
             tier:                      scs

--- a/deploy/ansible/playbook_05_02_sap_pas_install.yaml
+++ b/deploy/ansible/playbook_05_02_sap_pas_install.yaml
@@ -76,16 +76,18 @@
       block:
 
         - block:
-            - name:                        Include 2.6-sap-mounts role
+            - name:                    Include 2.6-sap-mounts role
               ansible.builtin.include_role:
-                name:                      roles-sap-os/2.6-sap-mounts
+                name:                  roles-sap-os/2.6-sap-mounts
           tags:
             - 2.6-sap-mounts
 
         - block:
-            - name:                        Include 5.2-pas-install
+            - name:                    Include 5.2-pas-install
               ansible.builtin.include_role:
-                name:     roles-sap/5.2-pas-install
+                name:                  roles-sap/5.2-pas-install
+              vars:
+                instance_number:       "{% if pas_instance_number is defined %}{{ pas_instance_number }}{% else %}00{% endif %}"
           tags:
             - 5.2-pas-install
       when:                            

--- a/deploy/ansible/playbook_05_02_sap_pas_install.yaml
+++ b/deploy/ansible/playbook_05_02_sap_pas_install.yaml
@@ -49,14 +49,13 @@
   gather_facts:                        true
   vars_files:
     - vars/ansible-input-api.yaml                                               # API Input template with defaults
-
-
-  tasks:
 # -------------------------------------+---------------------------------------8
 #
 # Build the list of tasks to be executed in order here.
 #
 # -------------------------------------+---------------------------------------8
+
+  tasks:
 
     - name:                            Set 'pas' tier facts
       ansible.builtin.set_fact:
@@ -76,11 +75,18 @@
       block:
 
         - block:
-            - name:                    Include 2.6-sap-mounts role
-              ansible.builtin.include_role:
-                name:                  roles-sap-os/2.6-sap-mounts
-          tags:
-            - 2.6-sap-mounts
+            - ansible.builtin.debug:
+                msg:
+                  - "pas_instance_number: {{ pas_instance_number }}"
+                  - "scs_instance_number: {{ scs_instance_number }}"
+                verbosity:             2
+
+            - ansible.builtin.assert:
+                that:
+                  - "pas_instance_number is defined"
+                  - "scs_instance_number != pas_instance_number"
+                fail_msg:              "Please ensure that the scs_instance_number is different from the pas_instance_number"
+          when:                        (ansible_play_hosts_all | length) <= 2
 
         - block:
             - name:                    Include 5.2-pas-install

--- a/deploy/ansible/roles-db/4.0.0-hdb-install/tasks/main.yaml
+++ b/deploy/ansible/roles-db/4.0.0-hdb-install/tasks/main.yaml
@@ -53,7 +53,7 @@
     - name:                            "SAP HANA: debug hdblcm password file"
       ansible.builtin.debug:
         msg:
-          - "FILE: {{ dir_params }}/hdbserver_{{ ansible_hostname }}_{{ db_sid }}_passwords.xml"
+          - "FILE: {{ dir_params }}/hdbserver_{{ ansible_hostname }}_{{ sap_sid }}_passwords.xml"
           - "PWD:  {{ main_password }}"
         verbosity:                     2
 
@@ -61,7 +61,7 @@
     - name:                            "SAP HANA: deploy hdblcm password file"
       ansible.builtin.template:
         src:                           HANA_2_00_055_v1_install.rsp.xml.j2
-        dest:                          "{{ dir_params }}/hdbserver_{{ ansible_hostname }}_{{ db_sid }}_passwords.xml"
+        dest:                          "{{ dir_params }}/hdbserver_{{ ansible_hostname }}_{{ sap_sid }}_passwords.xml"
         mode:                          0644
         force:                         true
 
@@ -82,7 +82,7 @@
     - name:                            "SAP HANA: deploy hdblcm install response file"
       ansible.builtin.template:
         src:                           HANA_2_00_055_v1_install.rsp.j2
-        dest:                          "{{ dir_params }}/hdbserver_{{ ansible_hostname }}_{{ db_sid }}_install.rsp"
+        dest:                          "{{ dir_params }}/hdbserver_{{ ansible_hostname }}_{{ sap_sid }}_install.rsp"
         mode:                          0644
         force:                         true
   # Template parameter mapping
@@ -97,7 +97,7 @@
         main_password:                 " {{ main_password }}"
 
     - name:                            "SAP HANA: Execute hdblcm on {{ ansible_hostname }}"
-      ansible.builtin.command:         ./hdblcm --batch --action=install  --configfile='{{ dir_params }}/hdbserver_{{ ansible_hostname }}_{{ db_sid }}_install.rsp'
+      ansible.builtin.command:         ./hdblcm --batch --action=install  --configfile='{{ dir_params }}/hdbserver_{{ ansible_hostname }}_{{ sap_sid }}_install.rsp'
       args:
         chdir:                         /usr/sap/install/CD_HDBSERVER/SAP_HANA_DATABASE
         creates:                       /etc/sap_deployment_automation/sap_deployment_hdb.txt
@@ -116,13 +116,20 @@
 
     - name:                            "REMOVE install password file "
       ansible.builtin.file:
-        path:                          "{{ dir_params }}/hdbserver_{{ ansible_hostname }}_{{ db_sid }}_passwords.xml"
+        path:                          "{{ dir_params }}/hdbserver_{{ ansible_hostname }}_{{ sap_sid }}_passwords.xml"
         state:                         absent
 
     - name:                            "REMOVE install response file"
       ansible.builtin.file:
-        path:                          "{{ dir_params }}/hdbserver_{{ ansible_hostname }}_{{ db_sid }}_install.rsp"
+        path:                          "{{ dir_params }}/hdbserver_{{ ansible_hostname }}_{{ sap_sid }}_install.rsp"
         state:                         absent
+
+    - name:                            "Create backup folder"
+      ansible.builtin.file:
+        path:                          "/hana/backup"
+        state:                         directory
+        group:                         sapsys
+        owner:                         "{{ db_sid | lower}}adm"
 
     - name:                            "HANA Install: flag"
       ansible.builtin.file:

--- a/deploy/ansible/roles-db/4.0.0-hdb-install/tasks/main.yaml
+++ b/deploy/ansible/roles-db/4.0.0-hdb-install/tasks/main.yaml
@@ -53,7 +53,7 @@
     - name:                            "SAP HANA: debug hdblcm password file"
       ansible.builtin.debug:
         msg:
-          - "FILE: {{ dir_params }}/hdbserver_{{ ansible_hostname }}_{{ sap_sid }}_passwords.xml"
+          - "FILE: {{ dir_params }}/hdbserver_{{ ansible_hostname }}_{{ db_sid }}_passwords.xml"
           - "PWD:  {{ main_password }}"
         verbosity:                     2
 
@@ -61,7 +61,7 @@
     - name:                            "SAP HANA: deploy hdblcm password file"
       ansible.builtin.template:
         src:                           HANA_2_00_055_v1_install.rsp.xml.j2
-        dest:                          "{{ dir_params }}/hdbserver_{{ ansible_hostname }}_{{ sap_sid }}_passwords.xml"
+        dest:                          "{{ dir_params }}/hdbserver_{{ ansible_hostname }}_{{ db_sid }}_passwords.xml"
         mode:                          0644
         force:                         true
 
@@ -82,7 +82,7 @@
     - name:                            "SAP HANA: deploy hdblcm install response file"
       ansible.builtin.template:
         src:                           HANA_2_00_055_v1_install.rsp.j2
-        dest:                          "{{ dir_params }}/hdbserver_{{ ansible_hostname }}_{{ sap_sid }}_install.rsp"
+        dest:                          "{{ dir_params }}/hdbserver_{{ ansible_hostname }}_{{ db_sid }}_install.rsp"
         mode:                          0644
         force:                         true
   # Template parameter mapping
@@ -97,7 +97,7 @@
         main_password:                 " {{ main_password }}"
 
     - name:                            "SAP HANA: Execute hdblcm on {{ ansible_hostname }}"
-      ansible.builtin.command:         ./hdblcm --batch --action=install  --configfile='{{ dir_params }}/hdbserver_{{ ansible_hostname }}_{{ sap_sid }}_install.rsp'
+      ansible.builtin.command:         ./hdblcm --batch --action=install  --configfile='{{ dir_params }}/hdbserver_{{ ansible_hostname }}_{{ db_sid }}_install.rsp'
       args:
         chdir:                         /usr/sap/install/CD_HDBSERVER/SAP_HANA_DATABASE
         creates:                       /etc/sap_deployment_automation/sap_deployment_hdb.txt
@@ -116,12 +116,12 @@
 
     - name:                            "REMOVE install password file "
       ansible.builtin.file:
-        path:                          "{{ dir_params }}/hdbserver_{{ ansible_hostname }}_{{ sap_sid }}_passwords.xml"
+        path:                          "{{ dir_params }}/hdbserver_{{ ansible_hostname }}_{{ db_sid }}_passwords.xml"
         state:                         absent
 
     - name:                            "REMOVE install response file"
       ansible.builtin.file:
-        path:                          "{{ dir_params }}/hdbserver_{{ ansible_hostname }}_{{ sap_sid }}_install.rsp"
+        path:                          "{{ dir_params }}/hdbserver_{{ ansible_hostname }}_{{ db_sid }}_install.rsp"
         state:                         absent
 
     - name:                            "HANA Install: flag"

--- a/deploy/ansible/roles-os/1.5-disk-setup/tasks/main.yml
+++ b/deploy/ansible/roles-os/1.5-disk-setup/tasks/main.yml
@@ -37,10 +37,6 @@
 
 - name:                                Load the disk configuration settings
   ansible.builtin.include_vars:        disks_config.yml
-  
-
-
-
 
 - name:                                Append sapmnt
   ansible.builtin.set_fact:
@@ -75,9 +71,6 @@
   register:                            vgscreated
   when:
     - tier == "sapos"
-    
-  
-
 
 - name:                                "Filter the vg name from vgscreated results"
   ansible.builtin.set_fact:
@@ -118,7 +111,7 @@
   register:                            lvscreated
   when:
     - tier == "sapos"
-    - item.node_tier in ["all", node_tier]
+    - "item.node_tier in {{ [ 'all', supported_tiers] | flatten(levels=1) }}"
     - item.vg in vgcreatedlist
 
 # Debug for testing

--- a/deploy/ansible/roles-os/1.5-disk-setup/tasks/main.yml
+++ b/deploy/ansible/roles-os/1.5-disk-setup/tasks/main.yml
@@ -48,6 +48,11 @@
     logical_volumes:                   "{{ logical_volumes + logical_volumes_install }}"
   when: usr_sap_install_mountpoint is not defined
 
+- name:                                "usr_sap_install_mountpoint is not defined"
+  ansible.builtin.debug:
+    var:                               logical_volumes
+    verbosity:                         2
+
 - name:                                "Print unique disks"
   ansible.builtin.debug:
     var:                               disktypes
@@ -111,7 +116,7 @@
   register:                            lvscreated
   when:
     - tier == "sapos"
-    - "item.node_tier in {{ [ 'all', supported_tiers] | flatten(levels=1) }}"
+    - item.node_tier in [ 'all', supported_tiers ] | flatten(levels=1)
     - item.vg in vgcreatedlist
 
 # Debug for testing
@@ -160,7 +165,7 @@
   register :                           filesystemscreated
   when:
     - item.tier in ["all", tier ]
-    - item.node_tier in ["all", node_tier]
+    - item.node_tier in [ 'all', supported_tiers ] | flatten(levels=1)
     - item.fstype is defined
     - item.lv in lvcreatedlist
 

--- a/deploy/ansible/roles-os/1.5.1-disk-setup-asm/tasks/main.yml
+++ b/deploy/ansible/roles-os/1.5.1-disk-setup-asm/tasks/main.yml
@@ -69,6 +69,19 @@
 - name:                                Load the disk configuration settings
   ansible.builtin.include_vars:        disks_config_asm.yml
 
+- name:                                Set the NFS Server name list
+  ansible.builtin.set_fact:
+    nfs_server_temp:                   "{{ nfs_server_temp | default([]) + [item] }}"
+  with_items:
+    - "{{ query('inventory_hostnames', '{{ sap_sid|upper }}_SCS') }}"
+    - "{{ query('inventory_hostnames', '{{ sap_sid|upper }}_DB') }}"
+
+- name:                                Set the NFS Server name
+  ansible.builtin.set_fact:
+    nfs_server:                        "{{ nfs_server_temp | first }}"
+  when:                                NFS_provider == "NONE"
+
+
 # - name:                                "Print unique disks and volume group details"
 #   ansible.builtin.debug:
 #     var:
@@ -191,9 +204,6 @@
     fstype: "{{ item.type }}"
     opts:   defaults
     state:  mounted
-  vars:
-    # Get all the hostnames in <SID>_SCS group and return only the first hostname
-    nfs_server:   "{{ query('inventory_hostnames', '{{ sap_sid|upper }}_SCS') | first }}"
   loop:
     - { tier: 'ora',            type: 'xfs',     src: '/dev/vg_sap/lv_usrsap',                             path: '/usr/sap' }
     - { tier: 'ora',            type: 'nfs4',    src: '{{ nfs_server }}:/usr/sap/install',                 path: '/usr/sap/install' }                # Special Install Structure; Destroy on Completion

--- a/deploy/ansible/roles-sap-os/2.6-sap-mounts/defaults/main.yaml
+++ b/deploy/ansible/roles-sap-os/2.6-sap-mounts/defaults/main.yaml
@@ -6,8 +6,6 @@ distro_family:                         "{{ ansible_os_family|upper }}"
 distro_name:                           "{{ ansible_os_family|upper }}-{{ ansible_distribution_major_version }}"
 distro_id:                             "{{ ansible_os_family|lower ~ ansible_distribution_major_version }}"
 
-nfs_server:                            "{{ query('inventory_hostnames', '{{ sap_sid|upper }}_SCS') | first }}"
-
 use_AFS:                               "{{ NFS_provider == 'AFS' }}"
 usr_sap_install_path:                  "{% if use_AFS %}{{ usr_sap_install_mountpoint }}{% else %}{{ nfs_server }}:/usr/sap/install{% endif %}"
 

--- a/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.0-afs-mounts.yaml
+++ b/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.0-afs-mounts.yaml
@@ -1,3 +1,4 @@
+---
 # /*---------------------------------------------------------------------------8
 # |                                                                            |
 # |                Perform the AFS system mounts                              |
@@ -11,9 +12,9 @@
     state:                             directory
     group:                             sapsys
   when:
-    - node_tier == 'scs'
     - tier == 'sapos'
     - sap_mnt is defined
+    - "'scs' in supported_tiers"
   tags:
     - skip_ansible_lint
 
@@ -23,7 +24,7 @@
     state:                             directory
     group:                             sapsys
   when:
-    - node_tier == 'scs'
+    - "'scs' in supported_tiers"
     - tier == 'sapos'
     - sap_trans is defined
   tags:
@@ -42,7 +43,7 @@
         state:                         mounted
   when:
     - tier == 'sapos'
-    - node_tier == 'scs'
+    - "'scs' in supported_tiers"
     - sap_mnt is defined
 
 - name:                                "AFS Mount: Create SAP Directories (AFS)"
@@ -57,7 +58,7 @@
     - { path: '/saptmp/usrsap{{ sap_sid|upper }}sys'                           }
   when:
     - tier == 'sapos'
-    - node_tier == 'scs'
+    - "'scs' in supported_tiers"
     - sap_mnt is defined
 
 # Mount Filesystem on AFS
@@ -73,7 +74,7 @@
         state:                         mounted
   when:
     - tier == 'sapos'
-    - node_tier == 'scs'
+    - "'scs' in supported_tiers"
     - sap_trans is defined
 
 - name:                                "AFS Mount: Create SAP Directories (AFS) (transport)"
@@ -85,7 +86,7 @@
     - { path: '/saptrans/usrsaptrans' }
   when:
     - tier == 'sapos'
-    - node_tier == 'scs'
+    - "'scs' in supported_tiers"
     - sap_trans is defined
 
 - name:                                "AFS Mount: Unmount file systems (sapmnt)"
@@ -95,7 +96,7 @@
     state:                             unmounted
   when:
     - tier == 'sapos'
-    - node_tier == 'scs'
+    - "'scs' in supported_tiers"
     - sap_mnt is defined
 
 - name:                                "AFS Mount: Unmount file systems (transport)"
@@ -105,7 +106,7 @@
     state:                             unmounted
   when:
     - tier == 'sapos'
-    - node_tier == 'scs'
+    - "'scs' in supported_tiers"
     - sap_trans is defined
 
 
@@ -120,7 +121,7 @@
     - { path: '/saptmp/usrsap{{ sap_sid|upper }}sys'                           }
   when:
     - tier == 'sapos'
-    - node_tier == 'scs'
+    - "'scs' in supported_tiers"
     - sap_mnt is defined
 
 - name:                                "AFS Mount: Delete locally created SAP Directories (AFS) (transport)"
@@ -131,7 +132,7 @@
     - { path: '/saptrans/usrsaptrans'}
   when:
     - tier == 'sapos'
-    - node_tier == 'scs'
+    - "'scs' in supported_tiers"
     - sap_trans is defined
 
 
@@ -144,7 +145,7 @@
     state:                             absent
   when:
     - tier == 'sapos'
-    - node_tier == 'scs'
+    - "'scs' in supported_tiers"
     - sap_mnt is defined
 
 - name:                                "AFS Mount: Cleanup fstab and directory (AFS) (transport)"
@@ -156,7 +157,7 @@
     state:                             absent
   when:
     - tier == 'sapos'
-    - node_tier == 'scs'
+    - "'scs' in supported_tiers"
     - sap_trans is defined
 
 
@@ -234,7 +235,7 @@
     - { path: '/usr/sap/{{ sap_sid|upper }}/ERS{{ ers_instance_number }}' }
   when:
     - tier == 'sapos'
-    - node_tier in ['scs','ers']
+    - "'scs' in supported_tiers or 'ers' in supported_tiers "
     - sap_mnt is defined
   register: is_created_now3
 
@@ -309,3 +310,5 @@
     - tier in ['sapos']
     - node_tier in ['scs','ers']
     - sap_mnt is defined
+
+...

--- a/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.1-anf-mounts.yaml
+++ b/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.1-anf-mounts.yaml
@@ -5,10 +5,6 @@
 # +------------------------------------4--------------------------------------*/
 ---
 
-- name:                                "ANF Mount: Set the NFS Server name"
-  ansible.builtin.set_fact:
-    nfs_server:                        "{{ query('inventory_hostnames', '{{ sap_sid|upper }}_SCS') | first }}"
-
 - name:                                "ANF Mount: Set the NFS Service name"
   ansible.builtin.set_fact:
     nfs_service:                       "{% if distro_id == 'redhat8' %}nfs-server{% else %}{% if distro_id == 'redhat7' %}nfs{% else %}nfsserver{% endif %}{% endif %}"

--- a/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/main.yaml
+++ b/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/main.yaml
@@ -154,7 +154,6 @@
   ansible.builtin.import_tasks:        2.6.0-afs-mounts.yaml
   when:
     - sap_mnt is defined or sap_trans is defined
-    - sap_mnt | trim | length != 0
     - tier == 'sapos'
     - NFS_provider == 'AFS'
 
@@ -163,7 +162,6 @@
   ansible.builtin.import_tasks:        2.6.1-anf-mounts.yaml
   when:
     - sap_mnt is defined or sap_trans is defined
-    - sap_mnt | trim | length != 0
     - tier == 'sapos'
     - NFS_provider == 'ANF'
 # Import this task only if the tier is ora.

--- a/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/main.yaml
+++ b/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/main.yaml
@@ -18,6 +18,27 @@
   ansible.builtin.set_fact:
     sharedpath:                       "{% if shareddisk == 1 %}/dev/vg_hana_shared/lv_hana_shared{% else %}/dev/vg_sap/lv_hana_shared{% endif %}"
 
+- name:                                Show NFS_provider
+  ansible.builtin.debug:
+    var:                               NFS_provider
+
+- name:                                Show usr_sap_install_path
+  ansible.builtin.debug:
+    var:                               usr_sap_install_path
+    verbosity:                         2
+
+- name:                                Set the NFS Server name list
+  ansible.builtin.set_fact:
+    nfs_server_temp:                   "{{ nfs_server_temp | default([]) + [item] }}"
+  with_items:
+    - "{{ query('inventory_hostnames', '{{ sap_sid|upper }}_SCS') }}"
+    - "{{ query('inventory_hostnames', '{{ sap_sid|upper }}_DB') }}"
+
+- name:                                Set the NFS Server name
+  ansible.builtin.set_fact:
+    nfs_server:                        "{{ nfs_server_temp | first }}"
+  when:                                NFS_provider == "NONE"
+
 # Mount Filesystems
 - name:                                Mount local filesystems
   ansible.builtin.mount:
@@ -26,9 +47,6 @@
     fstype:                            "{{ item.type }}"
     opts:                              defaults
     state:                             mounted
-  vars:
-    # Get all the hostnames in <SID>_SCS group and return only the first hostname
-    nfs_server:                        "{{ query('inventory_hostnames', '{{ sap_sid|upper }}_SCS') | first }}"
   loop:
     - { node_tier: 'all',  type: 'xfs',   src: '/dev/vg_sap/lv_usrsap',                 path: '/usr/sap'         }
     - { node_tier: 'hana', type: 'xfs',   src: "{{ sharedpath }}",                      path: '/hana/shared'     }
@@ -44,28 +62,11 @@
     fstype:                            "{{ item.type }}"
     opts:                              defaults
     state:                             mounted
-  vars:
-    # Get all the hostnames in <SID>_SCS group and return only the first hostname
-    nfs_server:                        "{{ query('inventory_hostnames', '{{ sap_sid|upper }}_SCS') | first }}"
   loop:
     - { node_tier: 'scs',  type: 'xfs',   src: '/dev/vg_sap/lv_usrsapinstall',          path: '/usr/sap/install' }
   when:         
-    - item.node_tier == node_tier
+    - item.node_tier in supported_tiers
     - not use_AFS
-
-- name:                                Show NFS_provider
-  ansible.builtin.debug:
-    var:                               NFS_provider
-
-- name:                                Show usr_sap_install_path
-  ansible.builtin.debug:
-    var:                               usr_sap_install_path
-    verbosity:                         2
-
-- name:                                Set the NFS Server name
-  ansible.builtin.set_fact:
-    nfs_server:                        "{{ query('inventory_hostnames', '{{ sap_sid|upper }}_SCS') | first }}"
-  when:                                NFS_provider == "NONE"
 
 # Mount Filesystems
 - name:                                Mount local sapmnt (scs)
@@ -80,7 +81,7 @@
   when:
     - tier == 'sapos'
     - sap_mnt is undefined
-    - node_tier == 'scs'
+    - "'scs' in supported_tiers"
 
 # Mount Filesystems
 - name:                                Mount Filesystems block
@@ -98,6 +99,7 @@
         - tier == 'sapos'
         - node_tier in ['pas', 'app', 'ers']
         - sap_mnt is undefined
+        - nfs_server !=  ansible_hostname
   rescue:
     - name:                            Re-mount Filesystems when not using external NFS (app & pas)
       ansible.builtin.debug:
@@ -115,6 +117,7 @@
         - tier == 'sapos'
         - node_tier in ['pas', 'app', 'ers']
         - sap_mnt is undefined
+        - nfs_server !=  ansible_hostname
 
 
 # Mount Filesystems

--- a/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/oracle-asm.yaml
+++ b/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/oracle-asm.yaml
@@ -59,7 +59,7 @@
     state:  mounted
   vars:
     # Get all the hostnames in <SID>_SCS group and return only the first hostname
-    nfs_server:   "{{ query('inventory_hostnames', '{{ sap_sid|upper }}_SCS') | first }}"
+    nfs_server:   "{{ query('inventory_hostnames', '{{ sap_sid|upper }}_SCS') + query('inventory_hostnames', '{{ sap_sid|upper }}_DB')  | first }}"
   loop:
     - { tier: 'sapos',          type: 'xfs',   src: '/dev/vg_sap/lv_usrsap',                             path: '/usr/sap' }
     - { tier: 'ora',            type: 'nfs4',    src: '{{ nfs_server }}:/usr/sap/install',               path: '/usr/sap/install' }                # Special Install Structure; Destroy on Completion

--- a/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/oracle.yaml
+++ b/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/oracle.yaml
@@ -120,7 +120,7 @@
     state:  mounted
   vars:
     # Get all the hostnames in <SID>_SCS group and return only the first hostname
-    nfs_server:   "{{ query('inventory_hostnames', '{{ sap_sid|upper }}_SCS') | first }}"
+    nfs_server:   "{{ query('inventory_hostnames', '{{ sap_sid|upper }}_SCS') + query('inventory_hostnames', '{{ sap_sid|upper }}_DB')  | first }}"
   loop:
     - { tier: 'ora',            type: 'nfs4',    src: '{{ nfs_server }}:/sapmnt/{{ sap_sid|upper }}',    path: '/sapmnt/{{ sap_sid|upper }}' }
   

--- a/deploy/ansible/roles-sap/3.3-bom-processing/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/3.3-bom-processing/tasks/main.yaml
@@ -38,6 +38,7 @@
 #
 - name:                                Run pre-checks
   ansible.builtin.import_tasks:        pre_checks.yaml
+  when:                                selected_host == ansible_hostname
 # -------------------------------------+---------------------------------------8
 
 - name:                                Run the bom-register
@@ -46,12 +47,14 @@
     tasks_from:                        bom-register
   vars:
     bom_name:                          "{{ bom_base_name }}"
+  when:                                selected_host == ansible_hostname
 
 
 - name:                                Save the BOM
   ansible.builtin.set_fact:
     bom_base:                          "{{ bom }}"
     cacheable:                         true
+  when:                                selected_host == ansible_hostname
 
 
 # -------------------------------------+---------------------------------------8
@@ -66,6 +69,7 @@
   include_tasks:                       "bom_processor.yaml"
   vars:
     bom_name:                          "{{ bom_base_name }}"
+  when:                                selected_host == ansible_hostname
 # -------------------------------------+---------------------------------------8
 
 
@@ -84,6 +88,7 @@
   when:
     - bom_base.materials.dependencies is defined
     - bom_base.materials.dependencies|length>0
+    - selected_host == ansible_hostname
 # -------------------------------------+---------------------------------------8
 
 ...

--- a/deploy/ansible/roles-sap/3.3-bom-processing/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/3.3-bom-processing/tasks/main.yaml
@@ -38,7 +38,6 @@
 #
 - name:                                Run pre-checks
   ansible.builtin.import_tasks:        pre_checks.yaml
-  when:                                selected_host == ansible_hostname
 # -------------------------------------+---------------------------------------8
 
 - name:                                Run the bom-register
@@ -47,15 +46,11 @@
     tasks_from:                        bom-register
   vars:
     bom_name:                          "{{ bom_base_name }}"
-  when:                                selected_host == ansible_hostname
-
 
 - name:                                Save the BOM
   ansible.builtin.set_fact:
     bom_base:                          "{{ bom }}"
     cacheable:                         true
-  when:                                selected_host == ansible_hostname
-
 
 # -------------------------------------+---------------------------------------8
 #
@@ -69,7 +64,6 @@
   include_tasks:                       "bom_processor.yaml"
   vars:
     bom_name:                          "{{ bom_base_name }}"
-  when:                                selected_host == ansible_hostname
 # -------------------------------------+---------------------------------------8
 
 
@@ -88,7 +82,6 @@
   when:
     - bom_base.materials.dependencies is defined
     - bom_base.materials.dependencies|length>0
-    - selected_host == ansible_hostname
 # -------------------------------------+---------------------------------------8
 
 ...

--- a/deploy/ansible/roles-sap/3.3.1-bom-utility/tasks/bom-template.yaml
+++ b/deploy/ansible/roles-sap/3.3.1-bom-utility/tasks/bom-template.yaml
@@ -67,26 +67,26 @@
 - name:                                Parameters
   ansible.builtin.debug:
     msg:
-      - "SAP SID              : {{ sap_sid }}"
-      - "Instance Number - SCS: {{ scs_instance_number }}"
-      - "SCS Virtual Hostname : {{ sap_scs_hostname }}"
-      - "DB Hostname          : {{ sap_db_hostname }}"
-      - "FQDN                 : {{ sap_fqdn }}"
-      - "Master Password      : {{ main_password }}"
-      - "sapadm UID           : {{ sapadm_uid }}"
-      - "sapsys GID           : {{ sapsys_gid }}"
-      - "<sid>adm UID         : {{ sidadm_uid }}"
+      - "SAP SID              :        {{ sap_sid }}"
+      - "Instance Number - SCS:        {{ scs_instance_number }}"
+      - "SCS Virtual Hostname :        {{ sap_scs_hostname }}"
+      - "DB Hostname          :        {{ sap_db_hostname }}"
+      - "FQDN                 :        {{ sap_fqdn }}"
+      - "Master Password      :        {{ main_password }}"
+      - "sapadm UID           :        {{ sapadm_uid }}"
+      - "sapsys GID           :        {{ sapsys_gid }}"
+      - "<sid>adm UID         :        {{ sidadm_uid }}"
     verbosity:                         2
 # ------------------</DEBUGGING>------------------
 
 
-- name:                                "Check for Microsoft Supplied BOM ({{ bom_base_name }}) template for {{ node_tier | upper }} tier"
+- name:                                "Check for Microsoft Supplied BOM ({{ bom_base_name }}) template"
   ansible.builtin.stat:
     path:                              BOM-catalog/{{ bom_base_name }}/templates/{{ sap_inifile_template }}
   register:                            microsoft_supplied_bom_template
   delegate_to:                         localhost
 
-- name:                                "Check for Microsoft Supplied BOM ({{ bom_base_name }}) template in archive for {{ node_tier | upper }} tier"
+- name:                                "Check for Microsoft Supplied BOM ({{ bom_base_name }}) template in archive"
   ansible.builtin.stat:
     path:                              BOM-catalog/archives/{{ bom_base_name }}/templates/{{ sap_inifile_template }}
   register:                            microsoft_supplied_bom_template_archive
@@ -94,7 +94,7 @@
 
 
 # If Microsoft supplied BOM template found
-- name:                                "Deploy parameter file install template for {{ node_tier | upper }} tier"
+- name:                                "Deploy parameter file install template"
   ansible.builtin.template:
     src:                               "{% if microsoft_supplied_bom_template.stat.exists %}{{ microsoft_supplied_bom_template.stat.path }}{% else %}{{ microsoft_supplied_bom_template_archive.stat.path }}{% endif %}"
     dest:                              /usr/sap/install/downloads/{{ sap_inifile }}
@@ -103,9 +103,9 @@
   when:                                microsoft_supplied_bom_template.stat.exists or microsoft_supplied_bom_template_archive.stat.exists
 
 # If Microsoft supplied BOM template not found
-- name:                                "Retrieve BOM ({{ bom_base_name }}) template from Storage Account for {{ node_tier | upper }} tier"
+- name:                                "Retrieve BOM ({{ bom_base_name }}) template from Storage Account"
   block:
-    - name:                            "Download BOM ({{ bom_base_name }}) template from Storage Account for {{ node_tier | upper }} tier"
+    - name:                            "Download BOM ({{ bom_base_name }}) template from Storage Account"
       ansible.builtin.get_url:
         url:                           "{{ sapbits_location_base_path }}/{{ sapbits_bom_files }}/boms/{{ bom_base_name }}/templates/\
                                         {{ sap_inifile_template }}{{ sapbits_sas_token }}"
@@ -118,7 +118,7 @@
       delegate_to:                     localhost                                               # Causes action to occur on the Ansible Controller
       become:                          false
 
-    - name:                            "Deploy {{ node_tier | upper }} Parameter file install template for {{ node_tier | upper }} tier"
+    - name:                            "Deploy {{ node_tier | upper }} Parameter file install template"
       ansible.builtin.template:
         src:                           "{{ inventory_dir }}/{{ sap_inifile_template }}"
         dest:                          /usr/sap/install/downloads/{{ sap_inifile }}

--- a/deploy/ansible/roles-sap/5.0.0-scs-install/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.0.0-scs-install/tasks/main.yaml
@@ -24,7 +24,7 @@
   ansible.builtin.stat:
     path:                              /etc/sap_deployment_automation/sap_deployment_scs.txt
   register:                            scs_installed
-  when:                                node_tier == 'scs'
+  when:                                "'scs' in supported_tiers"
 
 - name:                                "SCS Install: check if installed"
   ansible.builtin.debug:
@@ -33,6 +33,20 @@
 
 - name:                                "SCS Install"
   block:
+    - name:                            Set the SCS Server name list
+      ansible.builtin.set_fact:
+        scs_server_temp:               "{{ scs_server_temp | default([]) + [item] }}"
+      with_items:
+        - "{{ query('inventory_hostnames', '{{ sap_sid|upper }}_SCS') }}"
+        - "{{ query('inventory_hostnames', '{{ sap_sid|upper }}_DB') }}"
+
+    - name:                            Show the tier
+      ansible.builtin.debug:
+        var:                           tier
+
+    - name:                            Set the SCS Server name
+      ansible.builtin.set_fact:
+        scs_server:                    "{{ scs_server_temp | first }}"
 
     - name:                            "SCS Install: Set BOM facts"
       ansible.builtin.set_fact:
@@ -46,6 +60,7 @@
         tasks_from:                    bom-register
       vars:
         bom_name:                      "{{ bom_base_name }}"
+        tier:                          "{{ tier }}"
 
     - name:                            "SCS Install: Include roles-sap/3.3.1-bom-utility role"
       ansible.builtin.include_role:
@@ -64,10 +79,11 @@
         sap_ciBtcWPNumber:
         sap_installSAPHostAgent:
         sap_profile_dir:
-        sap_scs_hostname:              "{{ query('inventory_hostnames', '{{ sap_sid|upper }}_SCS') | first }}"
+        sap_scs_hostname:              "{{ scs_server }}"
         sap_db_hostname:
         sap_ciVirtualHostname:
         sap_appVirtualHostname:
+        tier:                          "{{ tier }}"
       tags:
         - skip_ansible_lint
 
@@ -92,7 +108,6 @@
                                                  SAPINST_EXECUTE_PRODUCT_ID={{ bom.product_ids.scs }}                          \
                                                  SAPINST_SKIP_DIALOGS=true                                                     \
                                                  SAPINST_START_GUISERVER=false
-
       args:
         chdir:                         /usr/sap/install/SWPM
         creates:                       /etc/sap_deployment_automation/sap_deployment_scs.txt
@@ -102,7 +117,6 @@
       failed_when:                     scs_installation.rc > 0
       tags:
         - skip_ansible_lint
-      when:                            node_tier == 'scs'
 
     - name:                            "SCS Install: flag"
       ansible.builtin.file:
@@ -111,10 +125,8 @@
         mode:                          0755
 
   when:
-    - node_tier == 'scs'
+    - "'scs' in supported_tiers"
     - not scs_installed.stat.exists
-      # Skip when TRUE (test mode)
-      # when: not test_new_bom
 
 ...
 # /*---------------------------------------------------------------------------8

--- a/deploy/ansible/roles-sap/5.0.0-scs-install/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.0.0-scs-install/tasks/main.yaml
@@ -97,6 +97,11 @@
         msg:                           "{{ bom.product_ids.scs }}"
         verbosity:                     2
 
+    - name:                            "SCS Install: instance number"
+      debug:
+        msg:                           "{{ scs_instance_number }}"
+        verbosity:                     2
+
 # *====================================4=======================================8
 # |  SAP SCS: Install                                                          |
 # | 2230669 - System Provisioning Using a Parameter Input File                 |

--- a/deploy/ansible/roles-sap/5.1-dbload/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.1-dbload/tasks/main.yaml
@@ -61,7 +61,7 @@
         sap_cd_package_cd3:
         sap_cd_package_cd4:
         sap_cd_package_cd5:
-        sap_ciInstanceNumber:
+        sap_ciInstanceNumber:          
         app_instance_number:
         sap_ciDialogWPNumber:
         sap_ciBtcWPNumber:

--- a/deploy/ansible/roles-sap/5.1-dbload/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.1-dbload/tasks/main.yaml
@@ -31,6 +31,16 @@
 
 - name:                                "DBLOAD Install"
   block:
+    - name:                            Set the SCS Server name list
+      ansible.builtin.set_fact:
+        scs_server_temp:               "{{ scs_server_temp | default([]) + [item] }}"
+      with_items:
+        - "{{ query('inventory_hostnames', '{{ sap_sid|upper }}_SCS') }}"
+        - "{{ query('inventory_hostnames', '{{ sap_sid|upper }}_DB') }}"
+
+    - name:                            Set the SCS Server name
+      ansible.builtin.set_fact:
+        scs_server:                    "{{ scs_server_temp | first }}"
 
     - name:                            Include 3.3.1-bom-utility role for registering the BoM
       ansible.builtin.include_role:
@@ -38,6 +48,7 @@
         tasks_from:                    bom-register
       vars:
         bom_name:                      "{{ bom_base_name }}"
+        tier:                          "{{ tier }}"
 
     - name:                            Include 3.3.1-bom-utility role
       ansible.builtin.include_role:
@@ -56,10 +67,11 @@
         sap_ciBtcWPNumber:
         sap_installSAPHostAgent:
         sap_profile_dir:               /sapmnt/{{ sap_sid|upper }}/profile
-        sap_scs_hostname:              "{{ query('inventory_hostnames', '{{ sap_sid|upper }}_SCS') | first }}"
+        sap_scs_hostname:              "{{ scs_server }}"
         sap_db_hostname:               "{{ query('inventory_hostnames', '{{ sap_sid|upper }}_DB')  | first }}"
         sap_ciVirtualHostname:
         sap_appVirtualHostname:
+        tier:                          "{{ tier }}"
       tags:
         - skip_ansible_lint
 

--- a/deploy/ansible/roles-sap/5.2-pas-install/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.2-pas-install/tasks/main.yaml
@@ -31,6 +31,24 @@
 
 - name:                                "PAS Install"
   block:
+    - name:                            Set the SCS Server name list
+      ansible.builtin.set_fact:
+        scs_server_temp:               "{{ scs_server_temp | default([]) + [item] }}"
+      with_items:
+        - "{{ query('inventory_hostnames', '{{ sap_sid|upper }}_SCS') }}"
+        - "{{ query('inventory_hostnames', '{{ sap_sid|upper }}_DB') }}"
+
+    - name:                            Set the SCS Server name
+      ansible.builtin.set_fact:
+        scs_server:                    "{{ scs_server_temp | first }}"
+
+    - name:                            Show the instance number
+      ansible.builtin.debug:
+        msg:                          "{% if node_tier=='pas' %}'00'{% else %}'01'{% endif %}"
+
+    - name:                            Show the SCS host name
+      ansible.builtin.debug:
+        msg:                          "{% if scs_high_availability %}{{ sap_sid | lower }}scs{{ scs_instance_number }}cl1{% else %}{{ scs_server }}{% endif %}"
 
     - name:                            "PAS Install: Include 3.3.1-bom-utility role"
       ansible.builtin.include_role:
@@ -50,14 +68,13 @@
         sap_cd_package_cd3:
         sap_cd_package_cd4:
         sap_cd_package_cd5:
-        sap_ciInstanceNumber:          '00'
+        sap_ciInstanceNumber:          "{% if node_tier=='pas' %}00{% else %}01{% endif %}"
         app_instance_number:
         sap_ciDialogWPNumber:          12
         sap_ciBtcWPNumber:             8
         sap_installSAPHostAgent:       "false"
-#        sap_profile_dir:               /usr/sap/{{ sap_sid|upper }}/SYS/profile
         sap_profile_dir:               /sapmnt/{{ sap_sid|upper }}/profile
-        sap_scs_hostname:              "{% if scs_high_availability %}{{ sap_sid | lower }}scs{{ scs_instance_number }}cl1{% else %}{{ query('inventory_hostnames', '{{ sap_sid|upper }}_SCS') | first }}{% endif %}"
+        sap_scs_hostname:              "{% if scs_high_availability %}{{ sap_sid | lower }}scs{{ scs_instance_number }}cl1{% else %}{{ scs_server }}{% endif %}"
         sap_db_hostname:               "{{ query('inventory_hostnames', '{{ sap_sid|upper }}_DB')  | first }}"
         sap_ciVirtualHostname:         
         sap_appVirtualHostname:

--- a/deploy/ansible/roles-sap/5.2-pas-install/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.2-pas-install/tasks/main.yaml
@@ -68,7 +68,7 @@
         sap_cd_package_cd3:
         sap_cd_package_cd4:
         sap_cd_package_cd5:
-        sap_ciInstanceNumber:          "{% if node_tier=='pas' %}00{% else %}01{% endif %}"
+        sap_ciInstanceNumber:          "{{ instance_number }}"
         app_instance_number:
         sap_ciDialogWPNumber:          12
         sap_ciBtcWPNumber:             8

--- a/deploy/ansible/vars/disks_config.yml
+++ b/deploy/ansible/vars/disks_config.yml
@@ -67,13 +67,6 @@ logical_volumes:
 
   - tier:       'sapos'
     node_tier:  'hana'
-    vg:         "{% if shareddisk == 1 %}vg_hana_shared{% else %}vg_sap{% endif %}"
-    lv:         'lv_hana_shared'
-    size:       '100%FREE'
-    fstype:     'xfs'
-
-  - tier:       'sapos'
-    node_tier:  'hana'
     vg:         'vg_hana_data'
     lv:         'lv_hana_data'
     size:       '100%FREE'
@@ -100,6 +93,13 @@ logical_volumes:
     vg:         'vg_sap'
     lv:         'lv_sapmnt'
     size:       '1g'
+    fstype:     'xfs'
+
+  - tier:       'sapos'
+    node_tier:  'hana'
+    vg:         "{% if shareddisk == 1 %}vg_hana_shared{% else %}vg_sap{% endif %}"
+    lv:         'lv_hana_shared'
+    size:       "{% if shareddisk == 1 %}100%FREE{% else %}32g{% endif %}"
     fstype:     'xfs'
 
 logical_volumes_sapmnt:


### PR DESCRIPTION
## Problem
The current playbooks do not allow for collapsing all of the roles to a single server

## Solution
Add logic to enable the single server deployment by
- ensuring that the instance ID for PAS is different from the default 00
- creating the installation media volume on the standalone server instead of on the SCS server

## Tests
Run an deployment with 
enable_app_tier_deployment = false

## Notes
<Additional comments for the PR>