### PR TITLE
Update HANA_2_00_055_v0006ms.yaml

### DIFF
--- a/deploy/ansible/BOM-catalog/HANA_2_00_055_v0006ms/HANA_2_00_055_v0006ms.yaml
+++ b/deploy/ansible/BOM-catalog/HANA_2_00_055_v0006ms/HANA_2_00_055_v0006ms.yaml
@@ -4,8 +4,6 @@ target:  'HANA 2.0'
 version: 6
 
 materials:
-  dependencies:
-    - name:         HCMT_v0001ms
 
   media:
     # SAPCAR 7.22


### PR DESCRIPTION
## Problem
If HCMT binary changes download fails

## Solution
remove dependency to HCMT binary
When someone whant to run HCMT he'll need to download explicitely

## Tests
done

## Notes
n.a.