### PR TITLE
BOM folder path location change

### DIFF
--- a/deploy/ansible/roles-sap/0.1-bom-validator/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/0.1-bom-validator/tasks/main.yaml
@@ -66,10 +66,6 @@
     bom_name:                          "{{ bom_base_name }}"
 # -------------------------------------+---------------------------------------8
 
-- name: Bom folder path
-  ansible.builtin.debug:
-    msg:                               "{{ sapbits_location_base_path }}/{{ sapbits_bom_files }}/boms/{{ bom_base_name }}/{{ bom_base_name }}.yaml"
-
 # -------------------------------------+---------------------------------------8
 #
 # Description:  Call BOM processor, passing dependent BOM names.
@@ -86,6 +82,14 @@
     - bom.materials.dependencies is defined
     - bom.materials.dependencies|length>0
 # -------------------------------------+---------------------------------------8
+
+# -------------------------------------+---------------------------------------8
+#
+# Description:  Print BOM folder output path to console.
+#
+- name: BOM folder path
+  ansible.builtin.debug:
+    msg:                               "{{ sapbits_location_base_path }}/{{ sapbits_bom_files }}/boms/{{ bom_base_name }}/{{ bom_base_name }}.yaml"
 
 # /*---------------------------------------------------------------------------8
 # |                                   END                                      |

--- a/deploy/ansible/roles-sap/0.1-bom-validator/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/0.1-bom-validator/tasks/main.yaml
@@ -90,7 +90,6 @@
 - name: BOM folder path
   ansible.builtin.debug:
     msg:                               "{{ sapbits_location_base_path }}/{{ sapbits_bom_files }}/boms/{{ bom_base_name }}/{{ bom_base_name }}.yaml"
-
 # /*---------------------------------------------------------------------------8
 # |                                   END                                      |
 # +------------------------------------4--------------------------------------*/


### PR DESCRIPTION
## Problem
BOM folder path was getting printed in the middle of the output making it difficult to read by the user.

## Solution
Changed the location of code to print the bom folder path at the end of output.

## Tests
Validated the playbook by download/upload sapbits for S4 hana v10 bom.
![Screenshot 2022-02-11 174620](https://user-images.githubusercontent.com/22003339/153590144-61e77825-7d92-4261-898f-5eefcfafcdd6.jpg)



## Notes
<Additional comments for the PR>