### PR TITLE
Revert outputs to facilitate anydb deployments

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/outputs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/outputs.tf
@@ -1,10 +1,14 @@
 output "anydb_vms" {
   value = local.enable_deployment ? (
-    coalesce(azurerm_linux_virtual_machine.observer[*].id, azurerm_windows_virtual_machine.observer[*].id)) : (
+    coalesce(azurerm_linux_virtual_machine.dbserver[*].id, 
+              azurerm_linux_virtual_machine.observer[*].id, 
+              azurerm_windows_virtual_machine.dbserver[*].id, 
+              azurerm_windows_virtual_machine.observer[*].id
+            )
+    ) : (
     [""]
   )
 }
-
 output "nics_anydb" {
   value = local.enable_deployment ? azurerm_network_interface.anydb_db : []
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/outputs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/outputs.tf
@@ -1,9 +1,7 @@
 output "anydb_vms" {
   value = local.enable_deployment ? (
     coalesce(azurerm_linux_virtual_machine.dbserver[*].id, 
-              azurerm_linux_virtual_machine.observer[*].id, 
-              azurerm_windows_virtual_machine.dbserver[*].id, 
-              azurerm_windows_virtual_machine.observer[*].id
+              azurerm_windows_virtual_machine.dbserver[*].id
             )
     ) : (
     [""]


### PR DESCRIPTION
(cherry picked from commit 817ee43844b2d708252117eb651dac980761c901)

## Problem
Currently deployments fail with the following error.
```terraform
Error: Error in function call

  on module.tf line 170, in module "app_tier":
 170:       coalesce(try(module.hdb_node.hdb_vms[0], ""), try(module.anydb_node.anydb_vms[0], ""))
    ├────────────────
    │ module.anydb_node.anydb_vms is empty list of string
    │ module.hdb_node.hdb_vms[0] is ""

Call to function "coalesce" failed: no non-null, non-empty-string arguments.
```

## Solution
The outputs currently contain the observer vm ids, while they should be containing the anydb vm ids. This was the case originally.

## Tests
run system deployment pipeline
