### PR TITLE
Create S/4HANA 2021 Bill of materials

### DIFF
--- a/deploy/ansible/BOM-catalog/S42021SPS00_v0001ms/S42021SPS00_v0001ms.yaml
+++ b/deploy/ansible/BOM-catalog/S42021SPS00_v0001ms/S42021SPS00_v0001ms.yaml
@@ -28,229 +28,473 @@ materials:
 
     # kernel components
 
-    - name:                            "SP12 Patch6 for UMML4HANA 1"
-      archive:                         HANAUMML12_6-70001054.ZIP
-      url:                             https://softwaredownloads.sap.com/file/0020000000356792022
-      path:                            download_basket
+        # kernel components
 
-    - name:                            "SAP HANA CLIENT Version 2.12"
-      archive:                         IMDB_CLIENT20_012_20-80002082.SAR
-      url:                             https://softwaredownloads.sap.com/file/0020000000378322022
-      path:                            download_basket
+    - name:          "SP12 Patch6 for UMML4HANA 1"
+      archive:       HANAUMML12_6-70001054.ZIP
+      url:           https://softwaredownloads.sap.com/file/0020000000356792022
+      path:          download_basket
 
-    - name:                            "Revision 2.00.061.0 (SPS06) for HANA DB 2.0"
-      archive:                         IMDB_SERVER20_061_0-80002031.SAR
-      url:                             https://softwaredownloads.sap.com/file/0020000000198352022
-      path:                            download_basket
+    - name:    "SAP HANA CLIENT Version 2.12"
+      archive: IMDB_CLIENT20_012_20-80002082.SAR
+      url:     https://softwaredownloads.sap.com/file/0020000000378322022
+      path:    download_basket
 
-    - name:                            "Kernel Part II (785)"
-      archive:                         SAPEXEDB_100-80005373.SAR
-      url:                             https://softwaredownloads.sap.com/file/0020000000250002022
-      path:                            download_basket
+    - name: "Revision 2.00.061.0 (SPS06) for HANA DB 2.0"
+      archive: IMDB_SERVER20_061_0-80002031.SAR
+      url: https://softwaredownloads.sap.com/file/0020000000198352022
+      path: download_basket
 
-    - name:                            "Kernel Part I (785)"
-      archive:                         SAPEXE_100-80005374.SAR
-      url:                             https://softwaredownloads.sap.com/file/0020000000249732022
-      path:                            download_basket
+    - name: "Kernel Part II (785)"
+      archive: SAPEXEDB_100-80005373.SAR
+      url: https://softwaredownloads.sap.com/file/0020000000250002022
+      path: download_basket
 
-    - name:                            "SAP HOST AGENT 7.22 SP55"
-      archive:                         SAPHOSTAGENT55_55-80004822.SAR
-      url:                             https://softwaredownloads.sap.com/file/0020000000239812022
-      path:                            download_basket
+    - name: "Kernel Part I (785)"
+      archive: SAPEXE_100-80005374.SAR
+      url: https://softwaredownloads.sap.com/file/0020000000249732022
+      path: download_basket
 
-    - name:                            "Predi. Analy. APL 2008 for SAP HANA 2.0 SPS03 and beyond"
-      archive:                         SAPPAAPL4_2008_0-80004547.ZIP
-      url:                             https://softwaredownloads.sap.com/file/0020000000410162020
-      path:                            download_basket
+    - name: "SAP HOST AGENT 7.22 SP55"
+      archive: SAPHOSTAGENT55_55-80004822.SAR
+      url: https://softwaredownloads.sap.com/file/0020000000239812022
+      path: download_basket
 
-    - name:                            "Patch 2 for SOFTWARE UPDATE MANAGER 2.0 SP13"
-      archive:                         SUM20SP13_2-80002456.SAR
-      url:                             https://softwaredownloads.sap.com/file/0020000000363352022
-      path:                            download_basket
+    - name: "Predi. Analy. APL 2008 for SAP HANA 2.0 SPS03 and beyond"
+      archive: SAPPAAPL4_2008_0-80004547.ZIP
+      url: https://softwaredownloads.sap.com/file/0020000000410162020
+      path: download_basket
 
-    - name:                            "Installation for SAP IGS integrated in SAP Kernel"
-      archive:                         igsexe_1-70005417.sar
-      url:                             https://softwaredownloads.sap.com/file/0020000000535042021
-      path:                            download_basket
+    - name: "Patch 2 for SOFTWARE UPDATE MANAGER 2.0 SP13"
+      archive: SUM20SP13_2-80002456.SAR
+      url: https://softwaredownloads.sap.com/file/0020000000363352022
+      path: download_basket
 
-    - name:                            "SAP IGS Fonts and Textures"
-      archive:                         igshelper_17-10010245.sar
-      url:                             https://softwaredownloads.sap.com/file/0020000000703122018
-      path:                            download_basket
+    - name: "SWPM20SP11"
+      archive: SWPM20SP11_2-80003424.SAR
+      override_target_filename: "SWPM.SAR"
+      extract: true
+      extractDir: SWPM
+      url: https://softwaredownloads.sap.com/file/0020000000369162022
+      path: download_basket
+
+    - name: "Installation for SAP IGS integrated in SAP Kernel"
+      archive: igsexe_1-70005417.sar
+      url: https://softwaredownloads.sap.com/file/0020000000535042021
+      path: download_basket
+
+    - name: "SAP IGS Fonts and Textures"
+      archive: igshelper_17-10010245.sar
+      url: https://softwaredownloads.sap.com/file/0020000000703122018
+      path: download_basket
 
     # db export components
 
-    - name:                            "File on DVD - S4CORE106_INST_EXPORT_1.zip"
-      archive:                         S4CORE106_INST_EXPORT_1.zip
-      url:                             https://softwaredownloads.sap.com/file/0030000001440322021
-      path:                            download_basket
+    - name: "File on DVD - S4CORE106_INST_EXPORT_1.zip"
+      archive: S4CORE106_INST_EXPORT_1.zip
+      url: https://softwaredownloads.sap.com/file/0030000001440322021
+      path: download_basket
 
-    - name:                            "File on DVD - S4CORE106_INST_EXPORT_2.zip"
-      archive:                         S4CORE106_INST_EXPORT_2.zip
-      url:                             https://softwaredownloads.sap.com/file/0030000001440482021
-      path:                            download_basket
+    - name: "File on DVD - S4CORE106_INST_EXPORT_10.zip"
+      archive: S4CORE106_INST_EXPORT_10.zip
+      url: https://softwaredownloads.sap.com/file/0030000001440332021
+      path: download_basket
 
-    - name:                            "File on DVD - S4CORE106_INST_EXPORT_3.zip"
-      archive:                         S4CORE106_INST_EXPORT_3.zip
-      url:                             https://softwaredownloads.sap.com/file/0030000001440602021
-      path:                            download_basket
+    - name: "File on DVD - S4CORE106_INST_EXPORT_11.zip"
+      archive: S4CORE106_INST_EXPORT_11.zip
+      url: https://softwaredownloads.sap.com/file/0030000001440352021
+      path: download_basket
 
-    - name:                            "File on DVD - S4CORE106_INST_EXPORT_4.zip"
-      archive:                         S4CORE106_INST_EXPORT_4.zip
-      url:                             https://softwaredownloads.sap.com/file/0030000001440612021
-      path:                            download_basket
+    - name: "File on DVD - S4CORE106_INST_EXPORT_12.zip"
+      archive: S4CORE106_INST_EXPORT_12.zip
+      url: https://softwaredownloads.sap.com/file/0030000001440382021
+      path: download_basket
 
-    - name:                            "File on DVD - S4CORE106_INST_EXPORT_5.zip"
-      archive:                         S4CORE106_INST_EXPORT_5.zip
-      url:                             https://softwaredownloads.sap.com/file/0030000001440622021
-      path:                            download_basket
+    - name: "File on DVD - S4CORE106_INST_EXPORT_13.zip"
+      archive: S4CORE106_INST_EXPORT_13.zip
+      url: https://softwaredownloads.sap.com/file/0030000001440392021
+      path: download_basket
 
-    - name:                            "File on DVD - S4CORE106_INST_EXPORT_6.zip"
-      archive:                         S4CORE106_INST_EXPORT_6.zip
-      url:                             https://softwaredownloads.sap.com/file/0030000001440632021
-      path:                            download_basket
+    - name: "File on DVD - S4CORE106_INST_EXPORT_14.zip"
+      archive: S4CORE106_INST_EXPORT_14.zip
+      url: https://softwaredownloads.sap.com/file/0030000001440402021
+      path: download_basket
 
-    - name:                            "File on DVD - S4CORE106_INST_EXPORT_7.zip"
-      archive:                         S4CORE106_INST_EXPORT_7.zip
-      url:                             https://softwaredownloads.sap.com/file/0030000001440642021
-      path:                            download_basket
+    - name: "File on DVD - S4CORE106_INST_EXPORT_15.zip"
+      archive: S4CORE106_INST_EXPORT_15.zip
+      url: https://softwaredownloads.sap.com/file/0030000001440412021
+      path: download_basket
 
-    - name:                            "File on DVD - S4CORE106_INST_EXPORT_8.zip"
-      archive:                         S4CORE106_INST_EXPORT_8.zip
-      url:                             https://softwaredownloads.sap.com/file/0030000001440662021
-      path:                            download_basket
+    - name: "File on DVD - S4CORE106_INST_EXPORT_16.zip"
+      archive: S4CORE106_INST_EXPORT_16.zip
+      url: https://softwaredownloads.sap.com/file/0030000001440422021
+      path: download_basket
 
-    - name:                            "File on DVD - S4CORE106_INST_EXPORT_9.zip"
-      archive:                         S4CORE106_INST_EXPORT_9.zip
-      url:                             https://softwaredownloads.sap.com/file/0030000001440672021
-      path:                            download_basket
+    - name: "File on DVD - S4CORE106_INST_EXPORT_17.zip"
+      archive: S4CORE106_INST_EXPORT_17.zip
+      url: https://softwaredownloads.sap.com/file/0030000001440442021
+      path: download_basket
 
-    - name:                            "File on DVD - S4CORE106_INST_EXPORT_10.zip"
-      archive:                         S4CORE106_INST_EXPORT_10.zip
-      url:                             https://softwaredownloads.sap.com/file/0030000001440332021
-      path:                            download_basket
+    - name: "File on DVD - S4CORE106_INST_EXPORT_18.zip"
+      archive: S4CORE106_INST_EXPORT_18.zip
+      url: https://softwaredownloads.sap.com/file/0030000001440452021
+      path: download_basket
 
-    - name:                            "File on DVD - S4CORE106_INST_EXPORT_11.zip"
-      archive:                         S4CORE106_INST_EXPORT_11.zip
-      url:                             https://softwaredownloads.sap.com/file/0030000001440352021
-      path:                            download_basket
+    - name: "File on DVD - S4CORE106_INST_EXPORT_19.zip"
+      archive: S4CORE106_INST_EXPORT_19.zip
+      url: https://softwaredownloads.sap.com/file/0030000001440472021
+      path: download_basket
 
-    - name:                            "File on DVD - S4CORE106_INST_EXPORT_12.zip"
-      archive:                         S4CORE106_INST_EXPORT_12.zip
-      url:                             https://softwaredownloads.sap.com/file/0030000001440382021
-      path:                            download_basket
+    - name: "File on DVD - S4CORE106_INST_EXPORT_2.zip"
+      archive: S4CORE106_INST_EXPORT_2.zip
+      url: https://softwaredownloads.sap.com/file/0030000001440482021
+      path: download_basket
 
-    - name:                            "File on DVD - S4CORE106_INST_EXPORT_13.zip"
-      archive:                         S4CORE106_INST_EXPORT_13.zip
-      url:                             https://softwaredownloads.sap.com/file/0030000001440392021
-      path:                            download_basket
+    - name: "File on DVD - S4CORE106_INST_EXPORT_20.zip"
+      archive: S4CORE106_INST_EXPORT_20.zip
+      url: https://softwaredownloads.sap.com/file/0030000001440492021
+      path: download_basket
 
-    - name:                            "File on DVD - S4CORE106_INST_EXPORT_14.zip"
-      archive:                         S4CORE106_INST_EXPORT_14.zip
-      url:                             https://softwaredownloads.sap.com/file/0030000001440402021
-      path:                            download_basket
+    - name: "File on DVD - S4CORE106_INST_EXPORT_21.zip"
+      archive: S4CORE106_INST_EXPORT_21.zip
+      url: https://softwaredownloads.sap.com/file/0030000001440502021
+      path: download_basket
 
-    - name:                            "File on DVD - S4CORE106_INST_EXPORT_15.zip"
-      archive:                         S4CORE106_INST_EXPORT_15.zip
-      url:                             https://softwaredownloads.sap.com/file/0030000001440412021
-      path:                            download_basket
+    - name: "File on DVD - S4CORE106_INST_EXPORT_22.zip"
+      archive: S4CORE106_INST_EXPORT_22.zip
+      url: https://softwaredownloads.sap.com/file/0030000001440512021
+      path: download_basket
 
-    - name:                            "File on DVD - S4CORE106_INST_EXPORT_16.zip"
-      archive:                         S4CORE106_INST_EXPORT_16.zip
-      url:                             https://softwaredownloads.sap.com/file/0030000001440422021
-      path:                            download_basket
+    - name: "File on DVD - S4CORE106_INST_EXPORT_23.zip"
+      archive: S4CORE106_INST_EXPORT_23.zip
+      url: https://softwaredownloads.sap.com/file/0030000001440532021
+      path: download_basket
 
-    - name:                            "File on DVD - S4CORE106_INST_EXPORT_17.zip"
-      archive:                         S4CORE106_INST_EXPORT_17.zip
-      url:                             https://softwaredownloads.sap.com/file/0030000001440442021
-      path:                            download_basket
+    - name: "File on DVD - S4CORE106_INST_EXPORT_24.zip"
+      archive: S4CORE106_INST_EXPORT_24.zip
+      url: https://softwaredownloads.sap.com/file/0030000001440542021
+      path: download_basket
 
-    - name:                            "File on DVD - S4CORE106_INST_EXPORT_18.zip"
-      archive:                         S4CORE106_INST_EXPORT_18.zip
-      url:                             https://softwaredownloads.sap.com/file/0030000001440452021
-      path:                            download_basket
+    - name: "File on DVD - S4CORE106_INST_EXPORT_25.zip"
+      archive: S4CORE106_INST_EXPORT_25.zip
+      url: https://softwaredownloads.sap.com/file/0030000001440562021
+      path: download_basket
 
-    - name:                            "File on DVD - S4CORE106_INST_EXPORT_19.zip"
-      archive:                         S4CORE106_INST_EXPORT_19.zip
-      url:                             https://softwaredownloads.sap.com/file/0030000001440472021
-      path:                            download_basket
+    - name: "File on DVD - S4CORE106_INST_EXPORT_26.zip"
+      archive: S4CORE106_INST_EXPORT_26.zip
+      url: https://softwaredownloads.sap.com/file/0030000001440572021
+      path: download_basket
 
-    - name:                            "File on DVD - S4CORE106_INST_EXPORT_20.zip"
-      archive:                         S4CORE106_INST_EXPORT_20.zip
-      url:                             https://softwaredownloads.sap.com/file/0030000001440492021
-      path:                            download_basket
+    - name: "File on DVD - S4CORE106_INST_EXPORT_27.zip"
+      archive: S4CORE106_INST_EXPORT_27.zip
+      url: https://softwaredownloads.sap.com/file/0030000001440582021
+      path: download_basket
 
-    - name:                            "File on DVD - S4CORE106_INST_EXPORT_21.zip"
-      archive:                         S4CORE106_INST_EXPORT_21.zip
-      url:                             https://softwaredownloads.sap.com/file/0030000001440502021
-      path:                            download_basket
+    - name: "File on DVD - S4CORE106_INST_EXPORT_28.zip"
+      archive: S4CORE106_INST_EXPORT_28.zip
+      url: https://softwaredownloads.sap.com/file/0030000001440592021
+      path: download_basket
 
-    - name:                            "File on DVD - S4CORE106_INST_EXPORT_22.zip"
-      archive:                         S4CORE106_INST_EXPORT_22.zip
-      url:                             https://softwaredownloads.sap.com/file/0030000001440512021
-      path:                            download_basket
+    - name: "File on DVD - S4CORE106_INST_EXPORT_3.zip"
+      archive: S4CORE106_INST_EXPORT_3.zip
+      url: https://softwaredownloads.sap.com/file/0030000001440602021
+      path: download_basket
 
-    - name:                            "File on DVD - S4CORE106_INST_EXPORT_23.zip"
-      archive:                         S4CORE106_INST_EXPORT_23.zip
-      url:                             https://softwaredownloads.sap.com/file/0030000001440532021
-      path:                            download_basket
+    - name: "File on DVD - S4CORE106_INST_EXPORT_4.zip"
+      archive: S4CORE106_INST_EXPORT_4.zip
+      url: https://softwaredownloads.sap.com/file/0030000001440612021
+      path: download_basket
 
-    - name:                            "File on DVD - S4CORE106_INST_EXPORT_24.zip"
-      archive:                         S4CORE106_INST_EXPORT_24.zip
-      url:                             https://softwaredownloads.sap.com/file/0030000001440542021
-      path:                            download_basket
+    - name: "File on DVD - S4CORE106_INST_EXPORT_5.zip"
+      archive: S4CORE106_INST_EXPORT_5.zip
+      url: https://softwaredownloads.sap.com/file/0030000001440622021
+      path: download_basket
 
-    - name:                            "File on DVD - S4CORE106_INST_EXPORT_25.zip"
-      archive:                         S4CORE106_INST_EXPORT_25.zip
-      url:                             https://softwaredownloads.sap.com/file/0030000001440562021
-      path:                            download_basket
+    - name: "File on DVD - S4CORE106_INST_EXPORT_6.zip"
+      archive: S4CORE106_INST_EXPORT_6.zip
+      url: https://softwaredownloads.sap.com/file/0030000001440632021
+      path: download_basket
 
-    - name:                            "File on DVD - S4CORE106_INST_EXPORT_26.zip"
-      archive:                         S4CORE106_INST_EXPORT_26.zip
-      url:                             https://softwaredownloads.sap.com/file/0030000001440572021
-      path:                            download_basket
+    - name: "File on DVD - S4CORE106_INST_EXPORT_7.zip"
+      archive: S4CORE106_INST_EXPORT_7.zip
+      url: https://softwaredownloads.sap.com/file/0030000001440642021
+      path: download_basket
 
-    - name:                            "File on DVD - S4CORE106_INST_EXPORT_27.zip"
-      archive:                         S4CORE106_INST_EXPORT_27.zip
-      url:                             https://softwaredownloads.sap.com/file/0030000001440582021
-      path:                            download_basket
+    - name: "File on DVD - S4CORE106_INST_EXPORT_8.zip"
+      archive: S4CORE106_INST_EXPORT_8.zip
+      url: https://softwaredownloads.sap.com/file/0030000001440662021
+      path: download_basket
 
-    - name:                            "File on DVD - S4CORE106_INST_EXPORT_28.zip"
-      archive:                         S4CORE106_INST_EXPORT_28.zip
-      url:                             https://softwaredownloads.sap.com/file/0030000001440592021
-      path:                            download_basket
-    
-    # LANGUAGE PACKS: Includes only English, German and Japanese language packs.
-    - name:                            "File on DVD - S4HANAOP106_ERP_LANG_DE.SAR"
-      archive:                         S4HANAOP106_ERP_LANG_DE.SAR
-      url:                             https://softwaredownloads.sap.com/file/0030000001437352021
-      path:                            download_basket
+    - name: "File on DVD - S4CORE106_INST_EXPORT_9.zip"
+      archive: S4CORE106_INST_EXPORT_9.zip
+      url: https://softwaredownloads.sap.com/file/0030000001440672021
+      path: download_basket
 
-    - name:                            "File on DVD - S4HANAOP106_ERP_LANG_EN.SAR"
-      archive:                         S4HANAOP106_ERP_LANG_EN.SAR
-      url:                             https://softwaredownloads.sap.com/file/0030000001437362021
-      path:                            download_basket
+    - name: "File on DVD - S4HANAOP106_ERP_LANG_DE.SAR"
+      archive: S4HANAOP106_ERP_LANG_DE.SAR
+      url: https://softwaredownloads.sap.com/file/0030000001437352021
+      path: download_basket
 
-    - name:                            "File on DVD - S4HANAOP106_ERP_LANG_JA.SAR"
-      archive:                         S4HANAOP106_ERP_LANG_JA.SAR
-      url:                             https://softwaredownloads.sap.com/file/0030000001437732021
-      path:                            download_basket
+    - name: "File on DVD - S4HANAOP106_ERP_LANG_EN.SAR"
+      archive: S4HANAOP106_ERP_LANG_EN.SAR
+      url: https://softwaredownloads.sap.com/file/0030000001437362021
+      path: download_basket
 
     # other components
 
-    - name:                            "ST-PI 740: SP 0016"
-      archive:                         K-74016INSTPI.SAR
-      url:                             https://softwaredownloads.sap.com/file/0010000001454472021
-      download:                        false
+    - name: "Attribute Change Package 17 for EA-HR 608"
+      archive: EA-HR608.SAR
+      url: https://softwaredownloads.sap.com/file/0010000000059642016
+      download: false
 
-    - name:                            "ST-PI 740: SP 0017"
-      archive:                         K-74017INSTPI.SAR
-      url:                             https://softwaredownloads.sap.com/file/0010000000096822022
-      download:                        false
+    - name: "Attribute Change Package 22 for GBX01HR5 605"
+      archive: GBX01HR5605.SAR
+      url: https://softwaredownloads.sap.com/file/0010000000033172015
+      download: false
 
-    - name:                            "SPAM/SAINT Update - Version 756/0081"
-      archive:                         KD75681.SAR
-      url:                             https://softwaredownloads.sap.com/file/0010000000247182022
-      download:                        false
+    - name: "Attribute Change Package 19 for GBX01HR 600"
+      archive: GBX01HR600.SAR
+      url: https://softwaredownloads.sap.com/file/0010000000029982015
+      download: false
+
+    - name: "UIHR002 100: SP 0001"
+      archive: K-10001INUIHR002.SAR
+      url: https://softwaredownloads.sap.com/file/0010000020421312017
+      download: false
+
+    - name: "UIHR002 100: SP 0002"
+      archive: K-10002INUIHR002.SAR
+      url: https://softwaredownloads.sap.com/file/0010000000493432018
+      download: false
+
+    - name: "UIHR002 100: SP 0003"
+      archive: K-10003INUIHR002.SAR
+      url: https://softwaredownloads.sap.com/file/0010000001141912018
+      download: false
+
+    - name: "UIHR002 100: SP 0004"
+      archive: K-10004INUIHR002.SAR
+      url: https://softwaredownloads.sap.com/file/0010000001934802018
+      download: false
+
+    - name: "UIHR002 100: SP 0005"
+      archive: K-10005INUIHR002.SAR
+      url: https://softwaredownloads.sap.com/file/0010000000045522019
+      download: false
+
+    - name: "UIHR002 100: SP 0006"
+      archive: K-10006INUIHR002.SAR
+      url: https://softwaredownloads.sap.com/file/0010000000464552019
+      download: false
+
+    - name: "UIHR002 100: SP 0007"
+      archive: K-10007INUIHR002.SAR
+      url: https://softwaredownloads.sap.com/file/0010000001273902019
+      download: false
+
+    - name: "UIHR002 100: SP 0008"
+      archive: K-10008INUIHR002.SAR
+      url: https://softwaredownloads.sap.com/file/0010000001810332019
+      download: false
+
+    - name: "UIHR002 100: SP 0009"
+      archive: K-10009INUIHR002.SAR
+      url: https://softwaredownloads.sap.com/file/0010000000341482020
+      download: false
+
+    - name: "UIHR002 100: SP 0010"
+      archive: K-10010INUIHR002.SAR
+      url: https://softwaredownloads.sap.com/file/0010000000979992020
+      download: false
+
+    - name: "UIHR002 100: SP 0011"
+      archive: K-10011INUIHR002.SAR
+      url: https://softwaredownloads.sap.com/file/0010000001525832020
+      download: false
+
+    - name: "UIHR002 100: SP 0012"
+      archive: K-10012INUIHR002.SAR
+      url: https://softwaredownloads.sap.com/file/0010000002085752020
+      download: false
+
+    - name: "UIHR002 100: SP 0013"
+      archive: K-10013INUIHR002.SAR
+      url: https://softwaredownloads.sap.com/file/0010000000335032021
+      download: false
+
+    - name: "UIHR002 100: SP 0014"
+      archive: K-10014INUIHR002.SAR
+      url: https://softwaredownloads.sap.com/file/0010000000819382021
+      download: false
+
+    - name: "UIHR002 100: Add-On Installation"
+      archive: K-100AGINUIHR002.SAR
+      url: https://softwaredownloads.sap.com/file/0010000019183952017
+      download: false
+
+    - name: "UIMDG001 200: Support Package 0001"
+      archive: K-20001INUIMDG001.SAR
+      url: https://softwaredownloads.sap.com/file/0010000001029322016
+      download: false
+
+    - name: "UIMDG001 200: SP 0002"
+      archive: K-20002INUIMDG001.SAR
+      url: https://softwaredownloads.sap.com/file/0010000014298612017
+      download: false
+
+    - name: "UIMDG001 200: SP 0003"
+      archive: K-20003INUIMDG001.SAR
+      url: https://softwaredownloads.sap.com/file/0010000019125502017
+      download: false
+
+    - name: "UIMDG001 200: SP 0004"
+      archive: K-20004INUIMDG001.SAR
+      url: https://softwaredownloads.sap.com/file/0010000019849022017
+      download: false
+
+    - name: "UIMDG001 200: SP 0005"
+      archive: K-20005INUIMDG001.SAR
+      url: https://softwaredownloads.sap.com/file/0010000020421762017
+      download: false
+
+    - name: "UIMDG001 200: SP 0006"
+      archive: K-20006INUIMDG001.SAR
+      url: https://softwaredownloads.sap.com/file/0010000000493392018
+      download: false
+
+    - name: "UIMDG001 200: SP 0007"
+      archive: K-20007INUIMDG001.SAR
+      url: https://softwaredownloads.sap.com/file/0010000001935022018
+      download: false
+
+    - name: "UIMDG001 200: SP 0008"
+      archive: K-20008INUIMDG001.SAR
+      url: https://softwaredownloads.sap.com/file/0010000000464372019
+      download: false
+
+    - name: "UIMDG001 200: SP 0009"
+      archive: K-20009INUIMDG001.SAR
+      url: https://softwaredownloads.sap.com/file/0010000001525852020
+      download: false
+
+    - name: "UIMDG001 200: SP 0010"
+      archive: K-20010INUIMDG001.SAR
+      url: https://softwaredownloads.sap.com/file/0010000002085772020
+      download: false
+
+    - name: "UIMDG001 200: Add-On Installation"
+      archive: K-200AGINUIMDG001.SAR
+      url: https://softwaredownloads.sap.com/file/0010000000696272016
+      download: false
+
+    - name: "UITRV001 300: SP 0001"
+      archive: K-30001INUITRV001.SAR
+      url: https://softwaredownloads.sap.com/file/0010000000045572019
+      download: false
+
+    - name: "UITRV001 300: SP 0002"
+      archive: K-30002INUITRV001.SAR
+      url: https://softwaredownloads.sap.com/file/0010000001273832019
+      download: false
+
+    - name: "UITRV001 300: SP 0003"
+      archive: K-30003INUITRV001.SAR
+      url: https://softwaredownloads.sap.com/file/0010000001810452019
+      download: false
+
+    - name: "UITRV001 300: SP 0004"
+      archive: K-30004INUITRV001.SAR
+      url: https://softwaredownloads.sap.com/file/0010000000341512020
+      download: false
+
+    - name: "UITRV001 300: SP 0005"
+      archive: K-30005INUITRV001.SAR
+      url: https://softwaredownloads.sap.com/file/0010000001616922020
+      download: false
+
+    - name: "UITRV001 300: SP 0006"
+      archive: K-30006INUITRV001.SAR
+      url: https://softwaredownloads.sap.com/file/0010000000335052021
+      download: false
+
+    - name: "UITRV001 300: Add-On Installation"
+      archive: K-300AGINUITRV001.SAR
+      url: https://softwaredownloads.sap.com/file/0010000001909232018
+      download: false
+
+    - name: "UIBAS001 700: Add-On Installation"
+      archive: K-700AGINUIBAS001.SAR
+      url: https://softwaredownloads.sap.com/file/0010000000754362021
+      download: false
+
+    - name: "UIS4HOP1 700: Add-On Installation"
+      archive: K-700AGINUIS4HOP1.SAR
+      url: https://softwaredownloads.sap.com/file/0010000000914232021
+      download: false
+
+    - name: "ST-PI 740: SP 0016"
+      archive: K-74016INSTPI.SAR
+      url: https://softwaredownloads.sap.com/file/0010000001454472021
+      download: false
+
+    - name: "ST-PI 740: SP 0017"
+      archive: K-74017INSTPI.SAR
+      url: https://softwaredownloads.sap.com/file/0010000000096822022
+      download: false
+
+    - name: "SAP_UI 756: SP 0001"
+      archive: K-75601INSAPUI.SAR
+      url: https://softwaredownloads.sap.com/file/0010000001404512021
+      download: false
+
+    - name: "UIAPFI70 900: Add-On Installation"
+      archive: K-900AGINUIAPFI70.SAR
+      url: https://softwaredownloads.sap.com/file/0010000000914092021
+      download: false
+
+    - name: "SPAM/SAINT Update - Version 756/0081"
+      archive: KD75681.SAR
+      url: https://softwaredownloads.sap.com/file/0010000000247182022
+      download: false
+
+    - name: "Attribute Change Package 35 for SAP_HR 608"
+      archive: SAP_HR608.SAR
+      url: https://softwaredownloads.sap.com/file/0010000000249512014
+      download: false
+
+    - name: "Attribute Change Package 45 for ST-PI 740"
+      archive: ST-PI740.SAR
+      url: https://softwaredownloads.sap.com/file/0010000000297212015
+      download: false
+
+    - name: "Attribute Change Package 01 for UIAPFI70 900"
+      archive: UIAPFI70900.SAR
+      url: https://softwaredownloads.sap.com/file/0010000000382232022
+      download: false
+
+    - name: "Attribute Change Package 01 for UIBAS001 700"
+      archive: UIBAS001700.SAR
+      url: https://softwaredownloads.sap.com/file/0010000001617952021
+      download: false
+
+    - name: "Attribute Change Package 30 for UIHR002 100"
+      archive: UIHR002100.SAR
+      url: https://softwaredownloads.sap.com/file/0010000020208092017
+      download: false
+
+    - name: "Attribute Change Package 13 for UIMDG001 200"
+      archive: UIMDG001200.SAR
+      url: https://softwaredownloads.sap.com/file/0010000014247222017
+      download: false
+
+    - name: "Attribute Change Package 01 for UIS4HOP1 700"
+      archive: UIS4HOP1700.SAR
+      url: https://softwaredownloads.sap.com/file/0010000000382242022
+      download: false
+
+    - name: "Attribute Change Package 13 for UITRV001 300"
+      archive: UITRV001300.SAR
+      url: https://softwaredownloads.sap.com/file/0010000000561182019
+      download: false
 
 ...

--- a/deploy/ansible/BOM-catalog/S42021SPS00_v0001ms/S42021SPS00_v0001ms.yaml
+++ b/deploy/ansible/BOM-catalog/S42021SPS00_v0001ms/S42021SPS00_v0001ms.yaml
@@ -1,0 +1,256 @@
+---
+# 3015539 - SAP S/4HANA 2021: Release Information Note
+name:                                  "SAP_S4HANA_2021"
+target:                                "ABAP PLATFORM 2021"
+version:                               1
+platform:                              'HANA'
+defaults:
+  target_location:                     "{{ target_media_location }}/download_basket"
+
+product_ids:
+  scs:
+  scs_ha:
+  dbl:
+  pas:
+  pas_ha:
+  app:
+  app_ha:
+  web:
+  ers:
+  ers_ha:
+
+materials:
+  dependencies:
+  #  - name:                            "HANA_2_00_059_v0001ms"
+    - name:                            "SWPM20SP11_latest"
+
+  media:
+
+    # kernel components
+
+    - name:                            "SP12 Patch6 for UMML4HANA 1"
+      archive:                         HANAUMML12_6-70001054.ZIP
+      url:                             https://softwaredownloads.sap.com/file/0020000000356792022
+      path:                            download_basket
+
+    - name:                            "SAP HANA CLIENT Version 2.12"
+      archive:                         IMDB_CLIENT20_012_20-80002082.SAR
+      url:                             https://softwaredownloads.sap.com/file/0020000000378322022
+      path:                            download_basket
+
+    - name:                            "Revision 2.00.061.0 (SPS06) for HANA DB 2.0"
+      archive:                         IMDB_SERVER20_061_0-80002031.SAR
+      url:                             https://softwaredownloads.sap.com/file/0020000000198352022
+      path:                            download_basket
+
+    - name:                            "Kernel Part II (785)"
+      archive:                         SAPEXEDB_100-80005373.SAR
+      url:                             https://softwaredownloads.sap.com/file/0020000000250002022
+      path:                            download_basket
+
+    - name:                            "Kernel Part I (785)"
+      archive:                         SAPEXE_100-80005374.SAR
+      url:                             https://softwaredownloads.sap.com/file/0020000000249732022
+      path:                            download_basket
+
+    - name:                            "SAP HOST AGENT 7.22 SP55"
+      archive:                         SAPHOSTAGENT55_55-80004822.SAR
+      url:                             https://softwaredownloads.sap.com/file/0020000000239812022
+      path:                            download_basket
+
+    - name:                            "Predi. Analy. APL 2008 for SAP HANA 2.0 SPS03 and beyond"
+      archive:                         SAPPAAPL4_2008_0-80004547.ZIP
+      url:                             https://softwaredownloads.sap.com/file/0020000000410162020
+      path:                            download_basket
+
+    - name:                            "Patch 2 for SOFTWARE UPDATE MANAGER 2.0 SP13"
+      archive:                         SUM20SP13_2-80002456.SAR
+      url:                             https://softwaredownloads.sap.com/file/0020000000363352022
+      path:                            download_basket
+
+    - name:                            "Installation for SAP IGS integrated in SAP Kernel"
+      archive:                         igsexe_1-70005417.sar
+      url:                             https://softwaredownloads.sap.com/file/0020000000535042021
+      path:                            download_basket
+
+    - name:                            "SAP IGS Fonts and Textures"
+      archive:                         igshelper_17-10010245.sar
+      url:                             https://softwaredownloads.sap.com/file/0020000000703122018
+      path:                            download_basket
+
+    # db export components
+
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_1.zip"
+      archive:                         S4CORE106_INST_EXPORT_1.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440322021
+      path:                            download_basket
+
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_2.zip"
+      archive:                         S4CORE106_INST_EXPORT_2.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440482021
+      path:                            download_basket
+
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_3.zip"
+      archive:                         S4CORE106_INST_EXPORT_3.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440602021
+      path:                            download_basket
+
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_4.zip"
+      archive:                         S4CORE106_INST_EXPORT_4.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440612021
+      path:                            download_basket
+
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_5.zip"
+      archive:                         S4CORE106_INST_EXPORT_5.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440622021
+      path:                            download_basket
+
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_6.zip"
+      archive:                         S4CORE106_INST_EXPORT_6.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440632021
+      path:                            download_basket
+
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_7.zip"
+      archive:                         S4CORE106_INST_EXPORT_7.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440642021
+      path:                            download_basket
+
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_8.zip"
+      archive:                         S4CORE106_INST_EXPORT_8.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440662021
+      path:                            download_basket
+
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_9.zip"
+      archive:                         S4CORE106_INST_EXPORT_9.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440672021
+      path:                            download_basket
+
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_10.zip"
+      archive:                         S4CORE106_INST_EXPORT_10.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440332021
+      path:                            download_basket
+
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_11.zip"
+      archive:                         S4CORE106_INST_EXPORT_11.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440352021
+      path:                            download_basket
+
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_12.zip"
+      archive:                         S4CORE106_INST_EXPORT_12.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440382021
+      path:                            download_basket
+
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_13.zip"
+      archive:                         S4CORE106_INST_EXPORT_13.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440392021
+      path:                            download_basket
+
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_14.zip"
+      archive:                         S4CORE106_INST_EXPORT_14.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440402021
+      path:                            download_basket
+
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_15.zip"
+      archive:                         S4CORE106_INST_EXPORT_15.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440412021
+      path:                            download_basket
+
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_16.zip"
+      archive:                         S4CORE106_INST_EXPORT_16.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440422021
+      path:                            download_basket
+
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_17.zip"
+      archive:                         S4CORE106_INST_EXPORT_17.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440442021
+      path:                            download_basket
+
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_18.zip"
+      archive:                         S4CORE106_INST_EXPORT_18.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440452021
+      path:                            download_basket
+
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_19.zip"
+      archive:                         S4CORE106_INST_EXPORT_19.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440472021
+      path:                            download_basket
+
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_20.zip"
+      archive:                         S4CORE106_INST_EXPORT_20.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440492021
+      path:                            download_basket
+
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_21.zip"
+      archive:                         S4CORE106_INST_EXPORT_21.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440502021
+      path:                            download_basket
+
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_22.zip"
+      archive:                         S4CORE106_INST_EXPORT_22.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440512021
+      path:                            download_basket
+
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_23.zip"
+      archive:                         S4CORE106_INST_EXPORT_23.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440532021
+      path:                            download_basket
+
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_24.zip"
+      archive:                         S4CORE106_INST_EXPORT_24.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440542021
+      path:                            download_basket
+
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_25.zip"
+      archive:                         S4CORE106_INST_EXPORT_25.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440562021
+      path:                            download_basket
+
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_26.zip"
+      archive:                         S4CORE106_INST_EXPORT_26.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440572021
+      path:                            download_basket
+
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_27.zip"
+      archive:                         S4CORE106_INST_EXPORT_27.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440582021
+      path:                            download_basket
+
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_28.zip"
+      archive:                         S4CORE106_INST_EXPORT_28.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440592021
+      path:                            download_basket
+    
+    # LANGUAGE PACKS: Includes only English, German and Japanese language packs.
+    - name:                            "File on DVD - S4HANAOP106_ERP_LANG_DE.SAR"
+      archive:                         S4HANAOP106_ERP_LANG_DE.SAR
+      url:                             https://softwaredownloads.sap.com/file/0030000001437352021
+      path:                            download_basket
+
+    - name:                            "File on DVD - S4HANAOP106_ERP_LANG_EN.SAR"
+      archive:                         S4HANAOP106_ERP_LANG_EN.SAR
+      url:                             https://softwaredownloads.sap.com/file/0030000001437362021
+      path:                            download_basket
+
+    - name:                            "File on DVD - S4HANAOP106_ERP_LANG_JA.SAR"
+      archive:                         S4HANAOP106_ERP_LANG_JA.SAR
+      url:                             https://softwaredownloads.sap.com/file/0030000001437732021
+      path:                            download_basket
+
+    # other components
+
+    - name:                            "ST-PI 740: SP 0016"
+      archive:                         K-74016INSTPI.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000001454472021
+      download:                        false
+
+    - name:                            "ST-PI 740: SP 0017"
+      archive:                         K-74017INSTPI.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000000096822022
+      download:                        false
+
+    - name:                            "SPAM/SAINT Update - Version 756/0081"
+      archive:                         KD75681.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000000247182022
+      download:                        false
+
+...

--- a/deploy/ansible/BOM-catalog/S4HANA_2021_ISS_v0001ms/S4HANA_2021_ISS_v0001ms.yaml
+++ b/deploy/ansible/BOM-catalog/S4HANA_2021_ISS_v0001ms/S4HANA_2021_ISS_v0001ms.yaml
@@ -23,289 +23,275 @@ materials:
   dependencies:
   #  - name:                            "HANA_2_00_059_v0001ms"
     - name:                            "SWPM20SP11_latest"
-
+    - name:                            "SUM20SP13_latest"
   media:
 
     # kernel components
 
-        # kernel components
+    - name:                            "SP12 Patch6 for UMML4HANA 1"
+      archive:                         HANAUMML12_6-70001054.ZIP
+      url:                             https://softwaredownloads.sap.com/file/0020000000356792022
+      path:                            download_basket
 
-    - name:          "SP12 Patch6 for UMML4HANA 1"
-      archive:       HANAUMML12_6-70001054.ZIP
-      url:           https://softwaredownloads.sap.com/file/0020000000356792022
-      path:          download_basket
+    - name:                            "SAP HANA CLIENT Version 2.12"
+      archive:                         IMDB_CLIENT20_012_20-80002082.SAR
+      url:                             https://softwaredownloads.sap.com/file/0020000000378322022
+      path:                            download_basket
 
-    - name:    "SAP HANA CLIENT Version 2.12"
-      archive: IMDB_CLIENT20_012_20-80002082.SAR
-      url:     https://softwaredownloads.sap.com/file/0020000000378322022
-      path:    download_basket
+    - name:                            "Revision 2.00.061.0 (SPS06) for HANA DB 2.0"
+      archive:                         IMDB_SERVER20_061_0-80002031.SAR
+      url:                             https://softwaredownloads.sap.com/file/0020000000198352022
+      path:                            download_basket
 
-    - name: "Revision 2.00.061.0 (SPS06) for HANA DB 2.0"
-      archive: IMDB_SERVER20_061_0-80002031.SAR
-      url: https://softwaredownloads.sap.com/file/0020000000198352022
-      path: download_basket
+    - name:                            "Kernel Part II (785)"
+      archive:                         SAPEXEDB_100-80005373.SAR
+      url:                             https://softwaredownloads.sap.com/file/0020000000250002022
+      path:                            download_basket
 
-    - name: "Kernel Part II (785)"
-      archive: SAPEXEDB_100-80005373.SAR
-      url: https://softwaredownloads.sap.com/file/0020000000250002022
-      path: download_basket
+    - name:                            "Kernel Part I (785)"
+      archive:                         SAPEXE_100-80005374.SAR
+      url:                             https://softwaredownloads.sap.com/file/0020000000249732022
+      path:                            download_basket
 
-    - name: "Kernel Part I (785)"
-      archive: SAPEXE_100-80005374.SAR
-      url: https://softwaredownloads.sap.com/file/0020000000249732022
-      path: download_basket
+    - name:                            "SAP HOST AGENT 7.22 SP55"
+      archive:                         SAPHOSTAGENT55_55-80004822.SAR
+      url:                             https://softwaredownloads.sap.com/file/0020000000239812022
+      path:                            download_basket
 
-    - name: "SAP HOST AGENT 7.22 SP55"
-      archive: SAPHOSTAGENT55_55-80004822.SAR
-      url: https://softwaredownloads.sap.com/file/0020000000239812022
-      path: download_basket
+    - name:                            "Predi. Analy. APL 2008 for SAP HANA 2.0 SPS03 and beyond"
+      archive:                         SAPPAAPL4_2008_0-80004547.ZIP
+      url:                             https://softwaredownloads.sap.com/file/0020000000410162020
+      path:                            download_basket
 
-    - name: "Predi. Analy. APL 2008 for SAP HANA 2.0 SPS03 and beyond"
-      archive: SAPPAAPL4_2008_0-80004547.ZIP
-      url: https://softwaredownloads.sap.com/file/0020000000410162020
-      path: download_basket
+    - name:                            "Installation for SAP IGS integrated in SAP Kernel"
+      archive:                         igsexe_1-70005417.sar
+      url:                             https://softwaredownloads.sap.com/file/0020000000535042021
+      path:                            download_basket
 
-    - name: "Patch 2 for SOFTWARE UPDATE MANAGER 2.0 SP13"
-      archive: SUM20SP13_2-80002456.SAR
-      url: https://softwaredownloads.sap.com/file/0020000000363352022
-      path: download_basket
-
-    - name: "SWPM20SP11"
-      archive: SWPM20SP11_2-80003424.SAR
-      override_target_filename: "SWPM.SAR"
-      extract: true
-      extractDir: SWPM
-      url: https://softwaredownloads.sap.com/file/0020000000369162022
-      path: download_basket
-
-    - name: "Installation for SAP IGS integrated in SAP Kernel"
-      archive: igsexe_1-70005417.sar
-      url: https://softwaredownloads.sap.com/file/0020000000535042021
-      path: download_basket
-
-    - name: "SAP IGS Fonts and Textures"
-      archive: igshelper_17-10010245.sar
-      url: https://softwaredownloads.sap.com/file/0020000000703122018
-      path: download_basket
+    - name:                            "SAP IGS Fonts and Textures"
+      archive:                         igshelper_17-10010245.sar
+      url:                             https://softwaredownloads.sap.com/file/0020000000703122018
+      path:                            download_basket
 
     # db export components
 
-    - name: "File on DVD - S4CORE106_INST_EXPORT_1.zip"
-      archive: S4CORE106_INST_EXPORT_1.zip
-      url: https://softwaredownloads.sap.com/file/0030000001440322021
-      path: download_basket
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_1.zip"
+      archive:                         S4CORE106_INST_EXPORT_1.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440322021
+      path:                            download_basket
 
-    - name: "File on DVD - S4CORE106_INST_EXPORT_10.zip"
-      archive: S4CORE106_INST_EXPORT_10.zip
-      url: https://softwaredownloads.sap.com/file/0030000001440332021
-      path: download_basket
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_2.zip"
+      archive:                         S4CORE106_INST_EXPORT_2.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440482021
+      path:                            download_basket
 
-    - name: "File on DVD - S4CORE106_INST_EXPORT_11.zip"
-      archive: S4CORE106_INST_EXPORT_11.zip
-      url: https://softwaredownloads.sap.com/file/0030000001440352021
-      path: download_basket
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_3.zip"
+      archive:                         S4CORE106_INST_EXPORT_3.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440602021
+      path:                            download_basket
 
-    - name: "File on DVD - S4CORE106_INST_EXPORT_12.zip"
-      archive: S4CORE106_INST_EXPORT_12.zip
-      url: https://softwaredownloads.sap.com/file/0030000001440382021
-      path: download_basket
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_4.zip"
+      archive:                         S4CORE106_INST_EXPORT_4.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440612021
+      path:                            download_basket
 
-    - name: "File on DVD - S4CORE106_INST_EXPORT_13.zip"
-      archive: S4CORE106_INST_EXPORT_13.zip
-      url: https://softwaredownloads.sap.com/file/0030000001440392021
-      path: download_basket
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_5.zip"
+      archive:                         S4CORE106_INST_EXPORT_5.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440622021
+      path:                            download_basket
 
-    - name: "File on DVD - S4CORE106_INST_EXPORT_14.zip"
-      archive: S4CORE106_INST_EXPORT_14.zip
-      url: https://softwaredownloads.sap.com/file/0030000001440402021
-      path: download_basket
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_6.zip"
+      archive:                         S4CORE106_INST_EXPORT_6.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440632021
+      path:                            download_basket
 
-    - name: "File on DVD - S4CORE106_INST_EXPORT_15.zip"
-      archive: S4CORE106_INST_EXPORT_15.zip
-      url: https://softwaredownloads.sap.com/file/0030000001440412021
-      path: download_basket
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_7.zip"
+      archive:                         S4CORE106_INST_EXPORT_7.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440642021
+      path:                            download_basket
 
-    - name: "File on DVD - S4CORE106_INST_EXPORT_16.zip"
-      archive: S4CORE106_INST_EXPORT_16.zip
-      url: https://softwaredownloads.sap.com/file/0030000001440422021
-      path: download_basket
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_8.zip"
+      archive:                         S4CORE106_INST_EXPORT_8.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440662021
+      path:                            download_basket
 
-    - name: "File on DVD - S4CORE106_INST_EXPORT_17.zip"
-      archive: S4CORE106_INST_EXPORT_17.zip
-      url: https://softwaredownloads.sap.com/file/0030000001440442021
-      path: download_basket
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_9.zip"
+      archive:                         S4CORE106_INST_EXPORT_9.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440672021
+      path:                            download_basket
 
-    - name: "File on DVD - S4CORE106_INST_EXPORT_18.zip"
-      archive: S4CORE106_INST_EXPORT_18.zip
-      url: https://softwaredownloads.sap.com/file/0030000001440452021
-      path: download_basket
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_10.zip"
+      archive:                         S4CORE106_INST_EXPORT_10.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440332021
+      path:                            download_basket
 
-    - name: "File on DVD - S4CORE106_INST_EXPORT_19.zip"
-      archive: S4CORE106_INST_EXPORT_19.zip
-      url: https://softwaredownloads.sap.com/file/0030000001440472021
-      path: download_basket
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_11.zip"
+      archive:                         S4CORE106_INST_EXPORT_11.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440352021
+      path:                            download_basket
 
-    - name: "File on DVD - S4CORE106_INST_EXPORT_2.zip"
-      archive: S4CORE106_INST_EXPORT_2.zip
-      url: https://softwaredownloads.sap.com/file/0030000001440482021
-      path: download_basket
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_12.zip"
+      archive:                         S4CORE106_INST_EXPORT_12.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440382021
+      path:                            download_basket
 
-    - name: "File on DVD - S4CORE106_INST_EXPORT_20.zip"
-      archive: S4CORE106_INST_EXPORT_20.zip
-      url: https://softwaredownloads.sap.com/file/0030000001440492021
-      path: download_basket
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_13.zip"
+      archive:                         S4CORE106_INST_EXPORT_13.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440392021
+      path:                            download_basket
 
-    - name: "File on DVD - S4CORE106_INST_EXPORT_21.zip"
-      archive: S4CORE106_INST_EXPORT_21.zip
-      url: https://softwaredownloads.sap.com/file/0030000001440502021
-      path: download_basket
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_14.zip"
+      archive:                         S4CORE106_INST_EXPORT_14.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440402021
+      path:                            download_basket
 
-    - name: "File on DVD - S4CORE106_INST_EXPORT_22.zip"
-      archive: S4CORE106_INST_EXPORT_22.zip
-      url: https://softwaredownloads.sap.com/file/0030000001440512021
-      path: download_basket
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_15.zip"
+      archive:                         S4CORE106_INST_EXPORT_15.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440412021
+      path:                            download_basket
 
-    - name: "File on DVD - S4CORE106_INST_EXPORT_23.zip"
-      archive: S4CORE106_INST_EXPORT_23.zip
-      url: https://softwaredownloads.sap.com/file/0030000001440532021
-      path: download_basket
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_16.zip"
+      archive:                         S4CORE106_INST_EXPORT_16.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440422021
+      path:                            download_basket
 
-    - name: "File on DVD - S4CORE106_INST_EXPORT_24.zip"
-      archive: S4CORE106_INST_EXPORT_24.zip
-      url: https://softwaredownloads.sap.com/file/0030000001440542021
-      path: download_basket
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_17.zip"
+      archive:                         S4CORE106_INST_EXPORT_17.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440442021
+      path:                            download_basket
 
-    - name: "File on DVD - S4CORE106_INST_EXPORT_25.zip"
-      archive: S4CORE106_INST_EXPORT_25.zip
-      url: https://softwaredownloads.sap.com/file/0030000001440562021
-      path: download_basket
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_18.zip"
+      archive:                         S4CORE106_INST_EXPORT_18.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440452021
+      path:                            download_basket
 
-    - name: "File on DVD - S4CORE106_INST_EXPORT_26.zip"
-      archive: S4CORE106_INST_EXPORT_26.zip
-      url: https://softwaredownloads.sap.com/file/0030000001440572021
-      path: download_basket
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_19.zip"
+      archive:                         S4CORE106_INST_EXPORT_19.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440472021
+      path:                            download_basket
 
-    - name: "File on DVD - S4CORE106_INST_EXPORT_27.zip"
-      archive: S4CORE106_INST_EXPORT_27.zip
-      url: https://softwaredownloads.sap.com/file/0030000001440582021
-      path: download_basket
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_20.zip"
+      archive:                         S4CORE106_INST_EXPORT_20.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440492021
+      path:                            download_basket
 
-    - name: "File on DVD - S4CORE106_INST_EXPORT_28.zip"
-      archive: S4CORE106_INST_EXPORT_28.zip
-      url: https://softwaredownloads.sap.com/file/0030000001440592021
-      path: download_basket
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_21.zip"
+      archive:                         S4CORE106_INST_EXPORT_21.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440502021
+      path:                            download_basket
 
-    - name: "File on DVD - S4CORE106_INST_EXPORT_3.zip"
-      archive: S4CORE106_INST_EXPORT_3.zip
-      url: https://softwaredownloads.sap.com/file/0030000001440602021
-      path: download_basket
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_22.zip"
+      archive:                         S4CORE106_INST_EXPORT_22.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440512021
+      path:                            download_basket
 
-    - name: "File on DVD - S4CORE106_INST_EXPORT_4.zip"
-      archive: S4CORE106_INST_EXPORT_4.zip
-      url: https://softwaredownloads.sap.com/file/0030000001440612021
-      path: download_basket
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_23.zip"
+      archive:                         S4CORE106_INST_EXPORT_23.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440532021
+      path:                            download_basket
 
-    - name: "File on DVD - S4CORE106_INST_EXPORT_5.zip"
-      archive: S4CORE106_INST_EXPORT_5.zip
-      url: https://softwaredownloads.sap.com/file/0030000001440622021
-      path: download_basket
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_24.zip"
+      archive:                         S4CORE106_INST_EXPORT_24.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440542021
+      path:                            download_basket
 
-    - name: "File on DVD - S4CORE106_INST_EXPORT_6.zip"
-      archive: S4CORE106_INST_EXPORT_6.zip
-      url: https://softwaredownloads.sap.com/file/0030000001440632021
-      path: download_basket
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_25.zip"
+      archive:                         S4CORE106_INST_EXPORT_25.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440562021
+      path:                            download_basket
 
-    - name: "File on DVD - S4CORE106_INST_EXPORT_7.zip"
-      archive: S4CORE106_INST_EXPORT_7.zip
-      url: https://softwaredownloads.sap.com/file/0030000001440642021
-      path: download_basket
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_26.zip"
+      archive:                         S4CORE106_INST_EXPORT_26.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440572021
+      path:                            download_basket
 
-    - name: "File on DVD - S4CORE106_INST_EXPORT_8.zip"
-      archive: S4CORE106_INST_EXPORT_8.zip
-      url: https://softwaredownloads.sap.com/file/0030000001440662021
-      path: download_basket
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_27.zip"
+      archive:                         S4CORE106_INST_EXPORT_27.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440582021
+      path:                            download_basket
 
-    - name: "File on DVD - S4CORE106_INST_EXPORT_9.zip"
-      archive: S4CORE106_INST_EXPORT_9.zip
-      url: https://softwaredownloads.sap.com/file/0030000001440672021
-      path: download_basket
+    - name:                            "File on DVD - S4CORE106_INST_EXPORT_28.zip"
+      archive:                         S4CORE106_INST_EXPORT_28.zip
+      url:                             https://softwaredownloads.sap.com/file/0030000001440592021
+      path:                            download_basket
 
-    - name: "File on DVD - S4HANAOP106_ERP_LANG_DE.SAR"
-      archive: S4HANAOP106_ERP_LANG_DE.SAR
-      url: https://softwaredownloads.sap.com/file/0030000001437352021
-      path: download_basket
+    # Language packs, only add the mandatory ones i.e. German and English
+    - name:                            "File on DVD - S4HANAOP106_ERP_LANG_DE.SAR"
+      archive:                         S4HANAOP106_ERP_LANG_DE.SAR
+      url:                             https://softwaredownloads.sap.com/file/0030000001437352021
+      path:                            download_basket
 
-    - name: "File on DVD - S4HANAOP106_ERP_LANG_EN.SAR"
-      archive: S4HANAOP106_ERP_LANG_EN.SAR
-      url: https://softwaredownloads.sap.com/file/0030000001437362021
-      path: download_basket
+    - name:                            "File on DVD - S4HANAOP106_ERP_LANG_EN.SAR"
+      archive:                         S4HANAOP106_ERP_LANG_EN.SAR
+      url:                             https://softwaredownloads.sap.com/file/0030000001437362021
+      path:                            download_basket
 
     # other components
 
-    - name: "Attribute Change Package 17 for EA-HR 608"
-      archive: EA-HR608.SAR
-      url: https://softwaredownloads.sap.com/file/0010000000059642016
-      download: false
+    - name:                            "Attribute Change Package 17 for EA-HR 608"
+      archive:                         EA-HR608.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000000059642016
+      download:                        false
 
-    - name: "Attribute Change Package 22 for GBX01HR5 605"
-      archive: GBX01HR5605.SAR
-      url: https://softwaredownloads.sap.com/file/0010000000033172015
-      download: false
+    - name:                            "Attribute Change Package 22 for GBX01HR5 605"
+      archive:                         GBX01HR5605.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000000033172015
+      download:                        false
 
-    - name: "Attribute Change Package 19 for GBX01HR 600"
-      archive: GBX01HR600.SAR
-      url: https://softwaredownloads.sap.com/file/0010000000029982015
-      download: false
+    - name:                            "Attribute Change Package 19 for GBX01HR 600"
+      archive:                         GBX01HR600.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000000029982015
+      download:                        false
 
-    - name: "UIHR002 100: SP 0001"
-      archive: K-10001INUIHR002.SAR
-      url: https://softwaredownloads.sap.com/file/0010000020421312017
-      download: false
+    - name:                            "UIHR002 100: SP 0001"
+      archive:                         K-10001INUIHR002.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000020421312017
+      download:                        false
 
-    - name: "UIHR002 100: SP 0002"
-      archive: K-10002INUIHR002.SAR
-      url: https://softwaredownloads.sap.com/file/0010000000493432018
-      download: false
+    - name:                            "UIHR002 100: SP 0002"
+      archive:                         K-10002INUIHR002.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000000493432018
+      download:                        false
 
-    - name: "UIHR002 100: SP 0003"
-      archive: K-10003INUIHR002.SAR
-      url: https://softwaredownloads.sap.com/file/0010000001141912018
-      download: false
+    - name:                            "UIHR002 100: SP 0003"
+      archive:                         K-10003INUIHR002.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000001141912018
+      download:                        false
 
-    - name: "UIHR002 100: SP 0004"
-      archive: K-10004INUIHR002.SAR
-      url: https://softwaredownloads.sap.com/file/0010000001934802018
-      download: false
+    - name:                            "UIHR002 100: SP 0004"
+      archive:                         K-10004INUIHR002.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000001934802018
+      download:                        false
 
-    - name: "UIHR002 100: SP 0005"
-      archive: K-10005INUIHR002.SAR
-      url: https://softwaredownloads.sap.com/file/0010000000045522019
-      download: false
+    - name:                            "UIHR002 100: SP 0005"
+      archive:                         K-10005INUIHR002.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000000045522019
+      download:                        false
 
-    - name: "UIHR002 100: SP 0006"
-      archive: K-10006INUIHR002.SAR
-      url: https://softwaredownloads.sap.com/file/0010000000464552019
-      download: false
+    - name:                            "UIHR002 100: SP 0006"
+      archive:                         K-10006INUIHR002.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000000464552019
+      download:                        false
 
-    - name: "UIHR002 100: SP 0007"
-      archive: K-10007INUIHR002.SAR
-      url: https://softwaredownloads.sap.com/file/0010000001273902019
-      download: false
+    - name:                            "UIHR002 100: SP 0007"
+      archive:                         K-10007INUIHR002.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000001273902019
+      download:                        false
 
-    - name: "UIHR002 100: SP 0008"
-      archive: K-10008INUIHR002.SAR
-      url: https://softwaredownloads.sap.com/file/0010000001810332019
-      download: false
+    - name:                            "UIHR002 100: SP 0008"
+      archive:                         K-10008INUIHR002.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000001810332019
+      download:                        false
 
-    - name: "UIHR002 100: SP 0009"
-      archive: K-10009INUIHR002.SAR
-      url: https://softwaredownloads.sap.com/file/0010000000341482020
-      download: false
+    - name:                            "UIHR002 100: SP 0009"
+      archive:                         K-10009INUIHR002.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000000341482020
+      download:                        false
 
-    - name: "UIHR002 100: SP 0010"
-      archive: K-10010INUIHR002.SAR
-      url: https://softwaredownloads.sap.com/file/0010000000979992020
-      download: false
+    - name:                            "UIHR002 100: SP 0010"
+      archive:                         K-10010INUIHR002.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000000979992020
+      download:                        false
 
     - name: "UIHR002 100: SP 0011"
       archive: K-10011INUIHR002.SAR

--- a/deploy/ansible/BOM-catalog/S4HANA_2021_ISS_v0001ms/S4HANA_2021_ISS_v0001ms.yaml
+++ b/deploy/ansible/BOM-catalog/S4HANA_2021_ISS_v0001ms/S4HANA_2021_ISS_v0001ms.yaml
@@ -293,194 +293,194 @@ materials:
       url:                             https://softwaredownloads.sap.com/file/0010000000979992020
       download:                        false
 
-    - name: "UIHR002 100: SP 0011"
-      archive: K-10011INUIHR002.SAR
-      url: https://softwaredownloads.sap.com/file/0010000001525832020
-      download: false
+    - name:                            "UIHR002 100: SP 0011"
+      archive:                         K-10011INUIHR002.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000001525832020
+      download:                        false
 
-    - name: "UIHR002 100: SP 0012"
-      archive: K-10012INUIHR002.SAR
-      url: https://softwaredownloads.sap.com/file/0010000002085752020
-      download: false
+    - name:                            "UIHR002 100: SP 0012"
+      archive:                         K-10012INUIHR002.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000002085752020
+      download:                        false
 
-    - name: "UIHR002 100: SP 0013"
-      archive: K-10013INUIHR002.SAR
-      url: https://softwaredownloads.sap.com/file/0010000000335032021
-      download: false
+    - name:                            "UIHR002 100: SP 0013"
+      archive:                         K-10013INUIHR002.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000000335032021
+      download:                        false
 
-    - name: "UIHR002 100: SP 0014"
-      archive: K-10014INUIHR002.SAR
-      url: https://softwaredownloads.sap.com/file/0010000000819382021
-      download: false
+    - name:                            "UIHR002 100: SP 0014"
+      archive:                         K-10014INUIHR002.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000000819382021
+      download:                        false
 
-    - name: "UIHR002 100: Add-On Installation"
-      archive: K-100AGINUIHR002.SAR
-      url: https://softwaredownloads.sap.com/file/0010000019183952017
-      download: false
+    - name:                            "UIHR002 100: Add-On Installation"
+      archive:                         K-100AGINUIHR002.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000019183952017
+      download:                        false
 
-    - name: "UIMDG001 200: Support Package 0001"
-      archive: K-20001INUIMDG001.SAR
-      url: https://softwaredownloads.sap.com/file/0010000001029322016
-      download: false
+    - name:                            "UIMDG001 200: Support Package 0001"
+      archive:                         K-20001INUIMDG001.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000001029322016
+      download:                        false
 
-    - name: "UIMDG001 200: SP 0002"
-      archive: K-20002INUIMDG001.SAR
-      url: https://softwaredownloads.sap.com/file/0010000014298612017
-      download: false
+    - name:                            "UIMDG001 200: SP 0002"
+      archive:                         K-20002INUIMDG001.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000014298612017
+      download:                        false
 
-    - name: "UIMDG001 200: SP 0003"
-      archive: K-20003INUIMDG001.SAR
-      url: https://softwaredownloads.sap.com/file/0010000019125502017
-      download: false
+    - name:                            "UIMDG001 200: SP 0003"
+      archive:                         K-20003INUIMDG001.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000019125502017
+      download:                        false
 
-    - name: "UIMDG001 200: SP 0004"
-      archive: K-20004INUIMDG001.SAR
-      url: https://softwaredownloads.sap.com/file/0010000019849022017
-      download: false
+    - name:                            "UIMDG001 200: SP 0004"
+      archive:                         K-20004INUIMDG001.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000019849022017
+      download:                        false
 
-    - name: "UIMDG001 200: SP 0005"
-      archive: K-20005INUIMDG001.SAR
-      url: https://softwaredownloads.sap.com/file/0010000020421762017
-      download: false
+    - name:                            "UIMDG001 200: SP 0005"
+      archive:                         K-20005INUIMDG001.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000020421762017
+      download:                        false
 
-    - name: "UIMDG001 200: SP 0006"
-      archive: K-20006INUIMDG001.SAR
-      url: https://softwaredownloads.sap.com/file/0010000000493392018
-      download: false
+    - name:                            "UIMDG001 200: SP 0006"
+      archive:                         K-20006INUIMDG001.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000000493392018
+      download:                        false
 
-    - name: "UIMDG001 200: SP 0007"
-      archive: K-20007INUIMDG001.SAR
-      url: https://softwaredownloads.sap.com/file/0010000001935022018
-      download: false
+    - name:                            "UIMDG001 200: SP 0007"
+      archive:                         K-20007INUIMDG001.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000001935022018
+      download:                        false
 
-    - name: "UIMDG001 200: SP 0008"
-      archive: K-20008INUIMDG001.SAR
-      url: https://softwaredownloads.sap.com/file/0010000000464372019
-      download: false
+    - name:                            "UIMDG001 200: SP 0008"
+      archive:                         K-20008INUIMDG001.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000000464372019
+      download:                        false
 
-    - name: "UIMDG001 200: SP 0009"
-      archive: K-20009INUIMDG001.SAR
-      url: https://softwaredownloads.sap.com/file/0010000001525852020
-      download: false
+    - name:                            "UIMDG001 200: SP 0009"
+      archive:                         K-20009INUIMDG001.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000001525852020
+      download:                        false
 
-    - name: "UIMDG001 200: SP 0010"
-      archive: K-20010INUIMDG001.SAR
-      url: https://softwaredownloads.sap.com/file/0010000002085772020
-      download: false
+    - name:                            "UIMDG001 200: SP 0010"
+      archive:                         K-20010INUIMDG001.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000002085772020
+      download:                        false
 
-    - name: "UIMDG001 200: Add-On Installation"
-      archive: K-200AGINUIMDG001.SAR
-      url: https://softwaredownloads.sap.com/file/0010000000696272016
-      download: false
+    - name:                            "UIMDG001 200: Add-On Installation"
+      archive:                         K-200AGINUIMDG001.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000000696272016
+      download:                        false
 
-    - name: "UITRV001 300: SP 0001"
-      archive: K-30001INUITRV001.SAR
-      url: https://softwaredownloads.sap.com/file/0010000000045572019
-      download: false
+    - name:                            "UITRV001 300: SP 0001"
+      archive:                         K-30001INUITRV001.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000000045572019
+      download:                        false
 
-    - name: "UITRV001 300: SP 0002"
-      archive: K-30002INUITRV001.SAR
-      url: https://softwaredownloads.sap.com/file/0010000001273832019
-      download: false
+    - name:                            "UITRV001 300: SP 0002"
+      archive:                         K-30002INUITRV001.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000001273832019
+      download:                        false
 
-    - name: "UITRV001 300: SP 0003"
-      archive: K-30003INUITRV001.SAR
-      url: https://softwaredownloads.sap.com/file/0010000001810452019
-      download: false
+    - name:                            "UITRV001 300: SP 0003"
+      archive:                         K-30003INUITRV001.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000001810452019
+      download:                        false
 
-    - name: "UITRV001 300: SP 0004"
-      archive: K-30004INUITRV001.SAR
-      url: https://softwaredownloads.sap.com/file/0010000000341512020
-      download: false
+    - name:                            "UITRV001 300: SP 0004"
+      archive:                         K-30004INUITRV001.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000000341512020
+      download:                        false
 
-    - name: "UITRV001 300: SP 0005"
-      archive: K-30005INUITRV001.SAR
-      url: https://softwaredownloads.sap.com/file/0010000001616922020
-      download: false
+    - name:                            "UITRV001 300: SP 0005"
+      archive:                         K-30005INUITRV001.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000001616922020
+      download:                        false
 
-    - name: "UITRV001 300: SP 0006"
-      archive: K-30006INUITRV001.SAR
-      url: https://softwaredownloads.sap.com/file/0010000000335052021
-      download: false
+    - name:                            "UITRV001 300: SP 0006"
+      archive:                         K-30006INUITRV001.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000000335052021
+      download:                        false
 
-    - name: "UITRV001 300: Add-On Installation"
-      archive: K-300AGINUITRV001.SAR
-      url: https://softwaredownloads.sap.com/file/0010000001909232018
-      download: false
+    - name:                            "UITRV001 300: Add-On Installation"
+      archive:                         K-300AGINUITRV001.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000001909232018
+      download:                        false
 
-    - name: "UIBAS001 700: Add-On Installation"
-      archive: K-700AGINUIBAS001.SAR
-      url: https://softwaredownloads.sap.com/file/0010000000754362021
-      download: false
+    - name:                            "UIBAS001 700: Add-On Installation"
+      archive:                         K-700AGINUIBAS001.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000000754362021
+      download:                        false
 
-    - name: "UIS4HOP1 700: Add-On Installation"
-      archive: K-700AGINUIS4HOP1.SAR
-      url: https://softwaredownloads.sap.com/file/0010000000914232021
-      download: false
+    - name:                            "UIS4HOP1 700: Add-On Installation"
+      archive:                         K-700AGINUIS4HOP1.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000000914232021
+      download:                        false
 
-    - name: "ST-PI 740: SP 0016"
-      archive: K-74016INSTPI.SAR
-      url: https://softwaredownloads.sap.com/file/0010000001454472021
-      download: false
+    - name:                            "ST-PI 740: SP 0016"
+      archive:                         K-74016INSTPI.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000001454472021
+      download:                        false
 
-    - name: "ST-PI 740: SP 0017"
-      archive: K-74017INSTPI.SAR
-      url: https://softwaredownloads.sap.com/file/0010000000096822022
-      download: false
+    - name:                            "ST-PI 740: SP 0017"
+      archive:                         K-74017INSTPI.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000000096822022
+      download:                        false
 
-    - name: "SAP_UI 756: SP 0001"
-      archive: K-75601INSAPUI.SAR
-      url: https://softwaredownloads.sap.com/file/0010000001404512021
-      download: false
+    - name:                            "SAP_UI 756: SP 0001"
+      archive:                         K-75601INSAPUI.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000001404512021
+      download:                        false
 
-    - name: "UIAPFI70 900: Add-On Installation"
-      archive: K-900AGINUIAPFI70.SAR
-      url: https://softwaredownloads.sap.com/file/0010000000914092021
-      download: false
+    - name:                            "UIAPFI70 900: Add-On Installation"
+      archive:                         K-900AGINUIAPFI70.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000000914092021
+      download:                        false
 
-    - name: "SPAM/SAINT Update - Version 756/0081"
-      archive: KD75681.SAR
-      url: https://softwaredownloads.sap.com/file/0010000000247182022
-      download: false
+    - name:                            "SPAM/SAINT Update - Version 756/0081"
+      archive:                         KD75681.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000000247182022
+      download:                        false
 
-    - name: "Attribute Change Package 35 for SAP_HR 608"
-      archive: SAP_HR608.SAR
-      url: https://softwaredownloads.sap.com/file/0010000000249512014
-      download: false
+    - name:                            "Attribute Change Package 35 for SAP_HR 608"
+      archive:                         SAP_HR608.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000000249512014
+      download:                        false
 
-    - name: "Attribute Change Package 45 for ST-PI 740"
-      archive: ST-PI740.SAR
-      url: https://softwaredownloads.sap.com/file/0010000000297212015
-      download: false
+    - name:                            "Attribute Change Package 45 for ST-PI 740"
+      archive:                         ST-PI740.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000000297212015
+      download:                        false
 
-    - name: "Attribute Change Package 01 for UIAPFI70 900"
-      archive: UIAPFI70900.SAR
-      url: https://softwaredownloads.sap.com/file/0010000000382232022
-      download: false
+    - name:                            "Attribute Change Package 01 for UIAPFI70 900"
+      archive:                         UIAPFI70900.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000000382232022
+      download:                        false
 
-    - name: "Attribute Change Package 01 for UIBAS001 700"
-      archive: UIBAS001700.SAR
-      url: https://softwaredownloads.sap.com/file/0010000001617952021
-      download: false
+    - name:                            "Attribute Change Package 01 for UIBAS001 700"
+      archive:                         UIBAS001700.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000001617952021
+      download:                        false
 
-    - name: "Attribute Change Package 30 for UIHR002 100"
-      archive: UIHR002100.SAR
-      url: https://softwaredownloads.sap.com/file/0010000020208092017
-      download: false
+    - name:                            "Attribute Change Package 30 for UIHR002 100"
+      archive:                         UIHR002100.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000020208092017
+      download:                        false
 
-    - name: "Attribute Change Package 13 for UIMDG001 200"
-      archive: UIMDG001200.SAR
-      url: https://softwaredownloads.sap.com/file/0010000014247222017
-      download: false
+    - name:                            "Attribute Change Package 13 for UIMDG001 200"
+      archive:                         UIMDG001200.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000014247222017
+      download:                        false
 
-    - name: "Attribute Change Package 01 for UIS4HOP1 700"
-      archive: UIS4HOP1700.SAR
-      url: https://softwaredownloads.sap.com/file/0010000000382242022
-      download: false
+    - name:                            "Attribute Change Package 01 for UIS4HOP1 700"
+      archive:                         UIS4HOP1700.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000000382242022
+      download:                        false
 
-    - name: "Attribute Change Package 13 for UITRV001 300"
-      archive: UITRV001300.SAR
-      url: https://softwaredownloads.sap.com/file/0010000000561182019
-      download: false
+    - name:                            "Attribute Change Package 13 for UITRV001 300"
+      archive:                         UITRV001300.SAR
+      url:                             https://softwaredownloads.sap.com/file/0010000000561182019
+      download:                        false
 
 ...

--- a/deploy/ansible/BOM-catalog/S4HANA_2021_ISS_v0001ms/S4HANA_2021_ISS_v0001ms.yaml
+++ b/deploy/ansible/BOM-catalog/S4HANA_2021_ISS_v0001ms/S4HANA_2021_ISS_v0001ms.yaml
@@ -1,7 +1,7 @@
 ---
 # 3015539 - SAP S/4HANA 2021: Release Information Note
-name:                                  "SAP_S4HANA_2021"
-target:                                "ABAP PLATFORM 2021"
+name:                                  "S4HANA_2021_ISS_v0001ms"
+target:                                "S/4 HANA 2021 ISS 00"
 version:                               1
 platform:                              'HANA'
 defaults:

--- a/deploy/ansible/BOM-catalog/SWPM20SP11_latest/SWPM20SP11_latest.yaml
+++ b/deploy/ansible/BOM-catalog/SWPM20SP11_latest/SWPM20SP11_latest.yaml
@@ -7,7 +7,7 @@ materials:
 
   media:
     # SWPM
-    - name:         "SWPM20SP11; OS: Linux on x86_64 64bit"
+    - name:         "Patch 2 for SOFTWARE UPDATE MANAGER 2.0 SP13 ; OS: Linux on x86_64 64b"
       archive:      SWPM20SP11_2-80003424.SAR
       checksum:     24822fe947831f2ee5695417fa65e660d13062f53f14a8beb5cbd077085b7423
       extract:      true

--- a/deploy/ansible/BOM-catalog/SWPM20SP11_latest/SWPM20SP11_latest.yaml
+++ b/deploy/ansible/BOM-catalog/SWPM20SP11_latest/SWPM20SP11_latest.yaml
@@ -7,7 +7,7 @@ materials:
 
   media:
     # SWPM
-    - name:         "Patch 2 for SOFTWARE UPDATE MANAGER 2.0 SP13 ; OS: Linux on x86_64 64b"
+    - name:         "Patch 2 for SWPM 2.0 SP11 ; OS: Linux on x86_64 64bit"
       archive:      SWPM20SP11_2-80003424.SAR
       checksum:     24822fe947831f2ee5695417fa65e660d13062f53f14a8beb5cbd077085b7423
       extract:      true


### PR DESCRIPTION
## Problem
We do not have a S/4HANA 2021 Bill of materials

## Solution
Create BOM based on [BOM prep process](https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/automation-bom-get-files)

## Tests


## Notes
This is the initial version and will be modified as we move through the testing process