### PR TITLE
Install flags in the progress directory don't need root privileges

### DIFF
--- a/deploy/ansible/playbook_01_os_base_config.yaml
+++ b/deploy/ansible/playbook_01_os_base_config.yaml
@@ -170,6 +170,7 @@
 
     - name:                            "OS configuration playbook: - Create os-configuration-done flag"
       delegate_to:                     localhost
+      become:                          false
       ansible.builtin.file:
         path:                          "{{ _workspace_directory }}/.progress/os-configuration-done"
         state:                         touch

--- a/deploy/ansible/playbook_02_os_sap_specific_config.yaml
+++ b/deploy/ansible/playbook_02_os_sap_specific_config.yaml
@@ -157,6 +157,7 @@
 
     - name:                            "SAP OS configuration playbook: - Create sap-os-install-done flag"
       delegate_to:                     localhost
+      become:                          false
       ansible.builtin.file:
         path:                          "{{ _workspace_directory }}/.progress/sap-os-configuration-done"
         state:                         touch

--- a/deploy/ansible/playbook_03_bom_processing.yaml
+++ b/deploy/ansible/playbook_03_bom_processing.yaml
@@ -80,6 +80,7 @@
 
             - name:                    Create bom-processing flag
               delegate_to:             localhost
+              become:                  false
               ansible.builtin.file:
                 path:                  "{{ _workspace_directory }}/.progress/bom-processing"
                 state:                 touch

--- a/deploy/ansible/playbook_04_00_00_db_install.yaml
+++ b/deploy/ansible/playbook_04_00_00_db_install.yaml
@@ -106,6 +106,7 @@
 
             - name:                    "Database Installation Playbook: - Create db-install-done flag"
               delegate_to:             localhost
+              become:                  false
               ansible.builtin.file:
                 path:                  "{{ _workspace_directory }}/.progress/db/db-install-done{{ ansible_hostname }}"
                 state:                 touch
@@ -206,6 +207,7 @@
 
         - name:                        "Database Installation Playbook: - Create pacemaker-install-done flag"
           delegate_to:                 localhost
+          become:                      false
           ansible.builtin.file:
             path:                      "{{ _workspace_directory }}/.progress/pacemaker-install-done"
             state:                     touch
@@ -305,9 +307,8 @@
             tier:                      'oracle'
 
         - name:                        "Database Installation Playbook: - Create db-install-done flag"
-          become_user:                 "root"
-          become:                      true
           delegate_to:                 localhost
+          become:                      false
           ansible.builtin.file:
             path:                      "{{ _workspace_directory }}/.progress/db/db-install-done{{ ansible_hostname }}"
             state:                     touch
@@ -342,8 +343,7 @@
 
         - name:                        "Database Installation Playbook: - Create db-install-done flag"
           delegate_to:                 localhost
-          become:                      true
-          become_user:                 root
+          become:                      false
           ansible.builtin.file:
             path:                      "{{ _workspace_directory }}/.progress/db-install-done"
             state:                     touch
@@ -382,11 +382,11 @@
         patterns:                      "*"
       register:                        find_progress_files
       delegate_to:                     localhost
+      become:                          false
 
     - name:                            "DB Playbook - Post Install: - Create db-install-done flag"
       delegate_to:                     localhost
-      become_user:                     "root"
-      become:                          true
+      become:                          false
       ansible.builtin.file:
         path:                          "{{ _workspace_directory }}/.progress/db-install-done"
         state:                         touch

--- a/deploy/ansible/playbook_05_00_00_sap_scs_install.yaml
+++ b/deploy/ansible/playbook_05_00_00_sap_scs_install.yaml
@@ -163,6 +163,7 @@
 
             - name:                    "SCS Installation Playbook: - Ensure scs-install-done flag exists"
               delegate_to:             localhost
+              become:                  false
               ansible.builtin.file:
                 path:                  "{{ _workspace_directory }}/.progress/scs-install-done"
                 state:                 touch
@@ -316,6 +317,7 @@
 
             - name:                    "SCS Installation Playbook: - Ensure scs-install-done flag exists"
               delegate_to:             localhost
+              become:                  false
               ansible.builtin.file:
                 path:                  "{{ _workspace_directory }}/.progress/scs-install-done"
                 state:                 touch
@@ -325,6 +327,7 @@
 
             - name:                    "ERS Installation Playbook: - Ensure ers-install-done flag exists"
               delegate_to:             localhost
+              become:                  false
               ansible.builtin.file:
                 path:                  "{{ _workspace_directory }}/.progress/ers-install-done"
                 state:                 touch

--- a/deploy/ansible/playbook_05_01_sap_dbload.yaml
+++ b/deploy/ansible/playbook_05_01_sap_dbload.yaml
@@ -99,6 +99,7 @@
 
             - name:                    "DBLoad Playbook: - Create db-load-done flag"
               delegate_to:             localhost
+              become:                  false
               ansible.builtin.file:
                 path:                  "{{ _workspace_directory }}/.progress/db-load-done"
                 state:                 touch
@@ -179,6 +180,7 @@
 
             - name:                    "DBLoad Playbook: - Create db-load-done flag"
               delegate_to:             localhost
+              become:                  false
               ansible.builtin.file:
                 path:                  "{{ _workspace_directory }}/.progress/db-load-done"
                 state:                 touch

--- a/deploy/ansible/playbook_05_02_sap_pas_install.yaml
+++ b/deploy/ansible/playbook_05_02_sap_pas_install.yaml
@@ -173,6 +173,7 @@
 
             - name:                    "PAS Installation Playbook: - Create pas-install-done flag"
               delegate_to:             localhost
+              become:                  false
               ansible.builtin.file:
                 path:                  "{{ _workspace_directory }}/.progress/pas-install-done"
                 state:                 touch

--- a/deploy/ansible/playbook_05_03_sap_app_install.yaml
+++ b/deploy/ansible/playbook_05_03_sap_app_install.yaml
@@ -143,6 +143,7 @@
 
         - name:                        "APP Playbook - Install: - Create app-install-done flag"
           delegate_to:                 localhost
+          become:                      false
           ansible.builtin.file:
             path:                      "{{ _workspace_directory }}/.progress/app/app-install-done{{ ansible_hostname }}"
             state:                     touch
@@ -206,9 +207,11 @@
         patterns:                      "*"
       register:                        find_progress_files
       delegate_to:                     localhost
+      become:                          false
 
     - name:                            "APP Playbook - Post Install: - Create app-install-done flag"
       delegate_to:                     localhost
+      become:                          false
       ansible.builtin.file:
         path:                          "{{ _workspace_directory }}/.progress/app-install-done"
         state:                         touch

--- a/deploy/ansible/playbook_05_04_sap_web_install.yaml
+++ b/deploy/ansible/playbook_05_04_sap_web_install.yaml
@@ -109,6 +109,7 @@
 
     - name:                            "WEB Installation Playbook: - Create web-install-done flag"
       delegate_to:                     localhost
+      become:                          false
       ansible.builtin.file:
         path:                          "{{ _workspace_directory }}/.progress/web-install-done"
         state:                         touch


### PR DESCRIPTION
## Problem
The install flags in the workspace progress directory don't need root privileges. The progress directory in the workspace directory is from the user (azureadm by default on the deployer) running the Ansible command.

## Solution
Add become false to delegated_to localhost tasks.

## Tests

## Notes