### PR TITLE
SAP parameters are already specified as extra-vars

### DIFF
--- a/deploy/ansible/playbook_05_01_sap_dbload.yaml
+++ b/deploy/ansible/playbook_05_01_sap_dbload.yaml
@@ -69,9 +69,6 @@
 # Build the list of tasks to be executed in order here.
 #
 # -------------------------------------+---------------------------------------8
-    - name:                            "DBLoad Playbook: - Load the SAP parameters"
-      ansible.builtin.include_vars:    "{{ _workspace_directory }}/sap-parameters.yaml"
-
     - name:                            "DBLoad Playbook: - Perform DB Load on HANA"
       block:
         - name:                        "DBLoad Playbook: - Setting the dbload facts"


### PR DESCRIPTION
## Problem
The SAP parameters are already specified as extra-vars at the execution of the Ansible playbook. It is not necessary to load them again.

## Solution
Remove the include_vars from the sap_dbload playbook.

## Tests

## Notes
