### PR TITLE
Add SAP Permissions task to OS SAP Specific config playbook

### DIFF
--- a/deploy/ansible/playbook_02_os_sap_specific_config.yaml
+++ b/deploy/ansible/playbook_02_os_sap_specific_config.yaml
@@ -121,6 +121,13 @@
         - 2.5-sap-users
 
     - block:
+        - name:                        "SAP OS configuration playbook: - directory permissions"
+          ansible.builtin.include_role:
+            name:                      roles-sap-os/2.2-sapPermissions
+      tags:
+        - 2.2-sapPermissions
+
+    - block:
         - name:                        "SAP OS configuration playbook: - configure exports"
           ansible.builtin.include_role:
             name:                      roles-sap-os/2.3-sap-exports

--- a/deploy/ansible/roles-sap-os/2.2-sapPermissions/tasks/main.yaml
+++ b/deploy/ansible/roles-sap-os/2.2-sapPermissions/tasks/main.yaml
@@ -1,16 +1,16 @@
 ---
 
-- name:                                "2.5 SAP Permissions: - File Permissions"
-  file:
-    path:   "{{ item.path }}"
-    owner:  "{{ item.owner }}"
-    group:  "{{ item.group }}"
-    mode:   "{{ item.mode }}"
-    state:  "{{ item.state }}"
+- name: "2.2 SAP Permissions: - Directory Permissions"
+  ansible.builtin.file:
+    path:  "{{ item.path }}"
+    owner: "{{ item.owner }}"
+    group: "{{ item.group }}"
+    mode:  "{{ item.mode }}"
+    state: "{{ item.state }}"
   loop:
-    - { node_tier: 'hana',   path: '/hana',                mode: '0755', owner: 'root', group: 'root',   state: 'directory' }
-    - { node_tier: 'pas',    path: '/sapmnt',              mode: '0755', owner: 'root', group: 'sapsys', state: 'directory' }
-    - { node_tier: 'app',    path: '/sapmnt',              mode: '0755', owner: 'root', group: 'sapsys', state: 'directory' }
-  when:     item.tier == "all" or
-            item.tier == node_tier
+    - { node_tier: 'hana', path: '/hana', mode: '0755', owner: 'root', group: 'root',   state: 'directory' }
+    - { node_tier: 'pas', path: '/sapmnt', mode: '0755', owner: 'root', group: 'sapsys', state: 'directory' }
+    - { node_tier: 'app', path: '/sapmnt', mode: '0755', owner: 'root', group: 'sapsys', state: 'directory' }
+  when: item.node_tier == "all" or item.node_tier == node_tier
+
 ...

--- a/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/main.yaml
+++ b/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/main.yaml
@@ -149,7 +149,7 @@
         - { type: 'nfs4',  src: '{{ nfs_server }}:/sapmnt/{{ sap_sid|upper }}',  path: '/sapmnt/{{ sap_sid|upper }}' }
       when:
         - tier == 'sapos'
-        - node_tier in ['pas', 'app', 'ers', 'oracle']]
+        - node_tier in ['pas', 'app', 'ers', 'oracle']
         - sap_mnt is undefined
         - MULTI_SIDS is undefined
         - nfs_server !=  ansible_hostname


### PR DESCRIPTION
## Problem
- The /hana directory isn't created with the right permissions by Ansible with a strict default umask setting
- Syntax error in 2.6-sap-mounts task

## Solution
- Add the SAP Permissions task to the OS SAP Specific Config playbook. 
- Fix syntax

## Tests

## Notes