### PR TITLE
Deploy zone-redundant load balancers by default

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/infrastructure.tf
@@ -35,6 +35,7 @@ resource "azurerm_lb" "anydb" {
       )
     )
     private_ip_address_allocation = var.databases[0].use_DHCP ? "Dynamic" : "Static"
+    zones = ["1", "2", "3"]
   }
 }
 

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/infrastructure.tf
@@ -1,12 +1,12 @@
   // In brownfield scenarios the subnets are often defined in the workload
   // If subnet information is specified in the parameter file use it
-  // As either of the arm_id or the prefix need to be specified to create 
-  // a subnet the lack of both indicate that the subnet is to be created in the 
+  // As either of the arm_id or the prefix need to be specified to create
+  // a subnet the lack of both indicate that the subnet is to be created in the
   // SAP Infrastructure Deployment
 
   ##############################################################################################
   #
-  #  Application subnet - Check if locally provided 
+  #  Application subnet - Check if locally provided
   #
   ##############################################################################################
 
@@ -47,13 +47,13 @@ resource "azurerm_subnet_route_table_association" "app" {
 
   // In brownfield scenarios the subnets are often defined in the workload
   // If subnet information is specified in the parameter file use it
-  // As either of the arm_id or the prefix need to be specified to create 
-  // a subnet the lack of both indicate that the subnet is to be created in the 
+  // As either of the arm_id or the prefix need to be specified to create
+  // a subnet the lack of both indicate that the subnet is to be created in the
   // SAP Infrastructure Deployment
 
   ##############################################################################################
   #
-  #  Web subnet - Check if locally provided 
+  #  Web subnet - Check if locally provided
   #
   ##############################################################################################
 resource "azurerm_subnet" "subnet_sap_web" {
@@ -101,8 +101,8 @@ resource "azurerm_lb" "scs" {
       subnet_id                     = pub.value.subnet_id
       private_ip_address            = pub.value.private_ip_address
       private_ip_address_allocation = pub.value.private_ip_address_allocation
+      zones                         = ["1", "2", "3"]
     }
-
   }
 }
 
@@ -356,6 +356,7 @@ resource "azurerm_lb" "web" {
       )
     )
     private_ip_address_allocation = var.application.use_DHCP ? "Dynamic" : "Static"
+    zones = ["1", "2", "3"]
   }
 
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/infrastructure.tf
@@ -69,6 +69,7 @@ resource "azurerm_lb" "hdb" {
         )
       )
     )
+    zones = ["1", "2", "3"]
   }
 
 }


### PR DESCRIPTION
## Problem
As of AzureRM version 3.0 the frontend_ip_configurations of Azure Load Balancers are deployed without zone redundancy. After creation the zone(s) attribute is returned as a Null field and the Azure portal shows an empty select field.

The zones attribute is optional (and isn’t defaulted by Azure): omitting this field (or specifying a value of null) will deploy this without any Zones.

## Solution
As the default behaviour before let to Zone-Redundant load balancers we can simply set the zones of the frontend_ip_configuration to all Availability Zones.

## Tests

## Notes
Sources:
- https://www.hashicorp.com/blog/terraform-azurerm-3-0-brings-enhanced-azure-function-support
- https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/lb#zones