### PR TITLE
Add hdbadm_uid and sapsys_gid to HANA installation templates

### DIFF
--- a/deploy/ansible/BOM-catalog/HANA_2_00_061_v0001ms/templates/HANA_2_00_055_v1_install.rsp.j2
+++ b/deploy/ansible/BOM-catalog/HANA_2_00_061_v0001ms/templates/HANA_2_00_055_v1_install.rsp.j2
@@ -132,10 +132,10 @@ home=/usr/sap/${sid}/home
 shell=/bin/sh
 
 # System Administrator User ID
-userid=
+userid={{ hdbadm_uid }}
 
 # ID of User Group (sapsys)
-groupid=
+groupid={{ sapsys_gid }}
 
 # Database User (SYSTEM) Password
 system_user_password=

--- a/deploy/ansible/BOM-catalog/NW750SPS20_v0004ms/templates/HANA_2_00_055_v1_install.rsp.j2
+++ b/deploy/ansible/BOM-catalog/NW750SPS20_v0004ms/templates/HANA_2_00_055_v1_install.rsp.j2
@@ -132,10 +132,10 @@ home=/usr/sap/${sid}/home
 shell=/bin/sh
 
 # System Administrator User ID
-userid=
+userid={{ hdbadm_uid }}
 
 # ID of User Group (sapsys)
-groupid=
+groupid={{ sapsys_gid }}
 
 # Database User (SYSTEM) Password
 system_user_password={{ main_password }}

--- a/deploy/ansible/BOM-catalog/S41909SPS03_v0011ms/templates/HANA_2_00_055_v1_install.rsp.j2
+++ b/deploy/ansible/BOM-catalog/S41909SPS03_v0011ms/templates/HANA_2_00_055_v1_install.rsp.j2
@@ -132,10 +132,10 @@ home=/usr/sap/${sid}/home
 shell=/bin/sh
 
 # System Administrator User ID
-userid=
+userid={{ hdbadm_uid }}
 
 # ID of User Group (sapsys)
-groupid=
+groupid={{ sapsys_gid }}
 
 # Database User (SYSTEM) Password
 system_user_password=

--- a/deploy/ansible/BOM-catalog/S42020SPS03_v0002ms/templates/HANA_2_00_055_v1_install.rsp.j2
+++ b/deploy/ansible/BOM-catalog/S42020SPS03_v0002ms/templates/HANA_2_00_055_v1_install.rsp.j2
@@ -132,10 +132,10 @@ home=/usr/sap/${sid}/home
 shell=/bin/sh
 
 # System Administrator User ID
-userid=
+userid={{ hdbadm_uid }}
 
 # ID of User Group (sapsys)
-groupid=
+groupid={{ sapsys_gid }}
 
 # Database User (SYSTEM) Password
 system_user_password={{ main_password }}

--- a/deploy/ansible/BOM-catalog/S4HANA_2021_ISS_v0001ms/templates/HANA_2_00_055_v1_install.rsp.j2
+++ b/deploy/ansible/BOM-catalog/S4HANA_2021_ISS_v0001ms/templates/HANA_2_00_055_v1_install.rsp.j2
@@ -132,10 +132,10 @@ home=/usr/sap/${sid}/home
 shell=/bin/sh
 
 # System Administrator User ID
-userid=
+userid={{ hdbadm_uid }}
 
 # ID of User Group (sapsys)
-groupid=
+groupid={{ sapsys_gid }}
 
 # Database User (SYSTEM) Password
 system_user_password=

--- a/deploy/ansible/BOM-catalog/archives/S41909SPS03_v0010ms/templates/HANA_2_00_055_v1_install.rsp.j2
+++ b/deploy/ansible/BOM-catalog/archives/S41909SPS03_v0010ms/templates/HANA_2_00_055_v1_install.rsp.j2
@@ -132,10 +132,10 @@ home=/usr/sap/${sid}/home
 shell=/bin/sh
 
 # System Administrator User ID
-userid=
+userid={{ hdbadm_uid }}
 
 # ID of User Group (sapsys)
-groupid=
+groupid={{ sapsys_gid }}
 
 # Database User (SYSTEM) Password
 system_user_password=

--- a/deploy/ansible/BOM-catalog/archives/S42020SPS03_v0001ms/templates/HANA_2_00_055_v1_install.rsp.j2
+++ b/deploy/ansible/BOM-catalog/archives/S42020SPS03_v0001ms/templates/HANA_2_00_055_v1_install.rsp.j2
@@ -132,10 +132,10 @@ home=/usr/sap/${sid}/home
 shell=/bin/sh
 
 # System Administrator User ID
-userid=
+userid={{ hdbadm_uid }}
 
 # ID of User Group (sapsys)
-groupid=
+groupid={{ sapsys_gid }}
 
 # Database User (SYSTEM) Password
 system_user_password={{ main_password }}

--- a/deploy/ansible/roles-db/4.0.0-hdb-install/tasks/main.yaml
+++ b/deploy/ansible/roles-db/4.0.0-hdb-install/tasks/main.yaml
@@ -50,7 +50,6 @@
       ansible.builtin.set_fact:
         sap_inifile:                   "hdbserver_{{ ansible_hostname }}_{{ sap_sid }}_install.rsp"
         sap_inifile_template:          "HANA_2_00_055_v1_install.rsp.j2"
-        db_pwd:                        "{{ main_password }}"
 
     - name:                            "SAP HANA: remove install response file"
       ansible.builtin.file:
@@ -73,7 +72,6 @@
         _rsp_sid:                      "{{ db_sid|upper }}"
         _rsp_number:                   "{{ hdb_instance_number }}"
         _rsp_system_usage:             "custom"
-        main_password:                 "{{ db_pwd }}"
 
     - name:                            "SAP HANA: Execute hdblcm on {{ ansible_hostname }}"
       ansible.builtin.command:         ./hdblcm --batch --action=install  --configfile='{{ target_media_location }}/downloads/{{ sap_inifile }}'

--- a/deploy/ansible/roles-db/4.0.0-hdb-install/templates/HANA_2_00_055_v1_install.rsp.j2
+++ b/deploy/ansible/roles-db/4.0.0-hdb-install/templates/HANA_2_00_055_v1_install.rsp.j2
@@ -132,10 +132,10 @@ home=/usr/sap/${sid}/home
 shell=/bin/sh
 
 # System Administrator User ID
-userid=
+userid={{ hdbadm_uid }}
 
 # ID of User Group (sapsys)
-groupid=
+groupid={{ sapsys_gid }}
 
 # Database User (SYSTEM) Password
 system_user_password={{ main_password }}


### PR DESCRIPTION
## Problem
The HANA installation isn't using the hdbadm_uid and sapsys_gid variables from the ansible-input-api.yaml file.
The db_pwd variable is obsolete. The main_password variable can be used directly in the HANA installation template.

## Solution
Use the hdbadm_uid and sapsys_gid variables in the HANA installation templates.
Remove db_pwd variable from hdb-install main task.

## Tests


## Notes
