### PR TITLE
SAP CAL Req: Add 2nd IP to VM OS(RHEL)

### DIFF
--- a/deploy/ansible/playbook_01_os_base_config.yaml
+++ b/deploy/ansible/playbook_01_os_base_config.yaml
@@ -123,9 +123,10 @@
         - name:                        "OS configuration playbook: - Configure networking"
           ansible.builtin.include_role:
             name:                      roles-os/1.10-networking
+          when: ansible_os_family | upper == "REDHAT"
       tags:
         - 1.10-networking
-
+      
     - block:
         - name:                        "OS configuration playbook: - Configure accounts"
           ansible.builtin.include_role:

--- a/deploy/ansible/playbook_01_os_base_config.yaml
+++ b/deploy/ansible/playbook_01_os_base_config.yaml
@@ -118,6 +118,13 @@
             name:                      roles-os/1.9-kernelparameters
       tags:
         - 1.9-kernelparameters
+        
+    - block:
+        - name:                        "OS configuration playbook: - Configure networking"
+          ansible.builtin.include_role:
+            name:                      roles-os/1.10-networking
+      tags:
+        - 1.10-networking
 
     - block:
         - name:                        "OS configuration playbook: - Configure accounts"

--- a/deploy/ansible/roles-os/1.10-networking/tasks/main.yaml
+++ b/deploy/ansible/roles-os/1.10-networking/tasks/main.yaml
@@ -1,30 +1,13 @@
-
 # /*---------------------------------------------------------------------------8
 # |                                                                            |
 # |             Add 2nd IP addresses to a VM operating system in RHEL          |
 # |                                                                            |
 # +------------------------------------4--------------------------------------*/
 
-- hosts:              "{{ sap_sid|upper }}_DB  :
-                       {{ sap_sid|upper }}_SCS :
-                       {{ sap_sid|upper }}_ERS :
-                       {{ sap_sid|upper }}_PAS :
-                       {{ sap_sid|upper }}_ERS :
-                       {{ sap_sid|upper }}_APP :
-                       {{ sap_sid|upper }}_WEB"
-
-  name:              " OS Config - Add 2nd IP addresses to a VM operating system in RHEL"
-  become:             true
-  become_user:        root
-  gather_facts:       true
-  vars_files:
-    - vars/ansible-input-api.yaml                               # API Input template with defaults
-  tasks:
-############## RHEL-2nd IP - #######################################################################################################################################
     - name: "Get the IP information from instance meta data"
       ansible.builtin.command: curl -H Metadata:true --noproxy "*" "http://169.254.169.254/metadata/instance/network/interface/0?api-version=2021-02-01"
       register: azure_metadata
-      #no_log: true
+      no_log: true
       changed_when: false
       args:
         warn: false
@@ -50,7 +33,7 @@
       no_log: true
       when:
         - ipadd is defined
-        - ipadd | length > 0
+        - ipadd | length > 1
 
     - name: "print ip info"
       debug: 
@@ -71,8 +54,8 @@
       debug: 
           msg: "{{ secondary_ip }}"
           verbosity: 2
-          when:
-            - secondary_ip is defined
+      when:
+        - secondary_ip is defined
             
 
     - name: "Create the file with secondary ip"
@@ -94,8 +77,6 @@
 # Restart Network service
     - name: "Restart Network service"
       ansible.builtin.command: ifup eth0
-  when: ansible_os_family | upper == "REDHAT"
-
 ...
 # /*----------------------------------------------------------------------------8
 # |                                    END                                      |

--- a/deploy/ansible/roles-os/1.10-networking/tasks/main.yaml
+++ b/deploy/ansible/roles-os/1.10-networking/tasks/main.yaml
@@ -36,22 +36,22 @@
         - ipadd | length > 1
 
     - name: "print ip info"
-      debug: 
+      ansible.builtin.debug: 
           msg: "{{ json_azure_data }}"
           verbosity: 2
       
     - name: "print ipaddress"
-      debug: 
+      ansible.builtin.debug: 
           msg: "{{ private_ips_info }}"
           verbosity: 2
 
     - name: "Print IPS"
-      debug: 
+      ansible.builtin.debug: 
           msg: "{{ ipadd }}"
           verbosity: 2
 
     - name: "Print Secondary ip"
-      debug: 
+      ansible.builtin.debug: 
           msg: "{{ secondary_ip }}"
           verbosity: 2
       when:

--- a/deploy/ansible/roles-os/1.10-networking/tasks/main.yaml
+++ b/deploy/ansible/roles-os/1.10-networking/tasks/main.yaml
@@ -1,0 +1,102 @@
+
+# /*---------------------------------------------------------------------------8
+# |                                                                            |
+# |             Add 2nd IP addresses to a VM operating system in RHEL          |
+# |                                                                            |
+# +------------------------------------4--------------------------------------*/
+
+- hosts:              "{{ sap_sid|upper }}_DB  :
+                       {{ sap_sid|upper }}_SCS :
+                       {{ sap_sid|upper }}_ERS :
+                       {{ sap_sid|upper }}_PAS :
+                       {{ sap_sid|upper }}_ERS :
+                       {{ sap_sid|upper }}_APP :
+                       {{ sap_sid|upper }}_WEB"
+
+  name:              " OS Config - Add 2nd IP addresses to a VM operating system in RHEL"
+  become:             true
+  become_user:        root
+  gather_facts:       true
+  vars_files:
+    - vars/ansible-input-api.yaml                               # API Input template with defaults
+  tasks:
+############## RHEL-2nd IP - #######################################################################################################################################
+    - name: "Get the IP information from instance meta data"
+      ansible.builtin.command: curl -H Metadata:true --noproxy "*" "http://169.254.169.254/metadata/instance/network/interface/0?api-version=2021-02-01"
+      register: azure_metadata
+      #no_log: true
+      changed_when: false
+      args:
+        warn: false
+
+    - name: "Pass the output of instance meta data to azure meta data function"
+      ansible.builtin.set_fact:
+        json_azure_data: "{{ azure_metadata.stdout | from_json }}"
+      no_log: true
+
+    - name: "Filter out the values for IPAddresses in json format"
+      ansible.builtin.set_fact:
+        private_ips_info: "{{ json_azure_data | json_query('ipv4.ipAddress') }}"
+      no_log: true
+    
+    - name: "Convert ips to list"
+      ansible.builtin.set_fact:
+        ipadd: "{{ private_ips_info | map(attribute='privateIpAddress') | list }}"
+      no_log: true
+
+    - name: "Get the secondary IP"
+      ansible.builtin.set_fact:
+        secondary_ip: "{{ ipadd[1] }}"
+      no_log: true
+      when:
+        - ipadd is defined
+        - ipadd | length > 0
+
+    - name: "print ip info"
+      debug: 
+          msg: "{{ json_azure_data }}"
+          verbosity: 2
+      
+    - name: "print ipaddress"
+      debug: 
+          msg: "{{ private_ips_info }}"
+          verbosity: 2
+
+    - name: "Print IPS"
+      debug: 
+          msg: "{{ ipadd }}"
+          verbosity: 2
+
+    - name: "Print Secondary ip"
+      debug: 
+          msg: "{{ secondary_ip }}"
+          verbosity: 2
+          when:
+            - secondary_ip is defined
+            
+
+    - name: "Create the file with secondary ip"
+      ansible.builtin.blockinfile:
+        create: true
+        path: /etc/sysconfig/network-scripts/ifcfg-eth0:0
+        marker_begin: "-- BEGIN"
+        marker_end: "-- END"
+        block: |
+          DEVICE=eth0:0
+          BOOTPROTO=static
+          ONBOOT=yes
+          IPADDR="{{ secondary_ip }}"
+          NETMASK=255.255.255.0
+          mode: 755
+      when:
+        - secondary_ip is defined
+
+# Restart Network service
+    - name: "Restart Network service"
+      ansible.builtin.command: ifup eth0
+  when: ansible_os_family | upper == "REDHAT"
+
+...
+# /*----------------------------------------------------------------------------8
+# |                                    END                                      |
+# +------------------------------------4--------------------------------------*/

--- a/deploy/ansible/roles-os/1.10-networking/tasks/main.yaml
+++ b/deploy/ansible/roles-os/1.10-networking/tasks/main.yaml
@@ -71,12 +71,15 @@
           IPADDR="{{ secondary_ip }}"
           NETMASK=255.255.255.0
           mode: 755
+      register: definition_made
       when:
         - secondary_ip is defined
 
 # Restart Network service
     - name: "Restart Network service"
       ansible.builtin.command: ifup eth0
+      when:
+        - definition_made.changed
 ...
 # /*----------------------------------------------------------------------------8
 # |                                    END                                      |


### PR DESCRIPTION
## Problem
As part of the contract between SAP and Microsoft ,the ask from SAP came up for adding a 2nd IP address to the NIC of SAP VMs ,for SAP LaMa . 

## Solution

- While the addition of IP address to VMs NIC is done through the arm templates in ‘Create Infra’ phase, the scope of this code update(ansible) is to “Add IP addresses to a VM operating system” for RHEL only. This step (addition of IP addresses to a VM OS) is not needed for SUSE. 

- Reference: https://docs.microsoft.com/en-us/azure/virtual-network/ip-services/virtual-network-multiple-ip-addresses-portal#os-config

 
## Tests
1. Execute the "Create Infra" workflow, from the azure portal(SVI). Ensure the 2nd IP is added to the NIC of the SAP VMs as shown below:
![image](https://user-images.githubusercontent.com/78894223/169505813-e0dc7e30-9d0d-44d4-bf7e-67e3361bb3df.png).
You may add the 2nd IP to the NIC manually as well.
2. Login as root.
3. Check the network-scripts folder for ifcfg. You should see ifcfg-eth0 as one of the files.
   ls ifcfg-* 
![image](https://user-images.githubusercontent.com/78894223/169506181-080d32c0-82e8-437d-8c50-df6ff5dab8c1.png)
4.Execute the "SAP-Install" workflow from the azure portal (SVI).
5. Check /etc/sysconfig/network-scripts directory . You should see new file  " ifcfg-eth0:0 ". This file should have the secondary IP.
<img width="341" alt="image" src="https://user-images.githubusercontent.com/78894223/169507258-b38eb7b8-cc07-4bfa-8ae7-ac3e269ee85a.png">
6.Execute ifcfg command to check if the secondary IP is shown.Screenshot below.
<img width="437" alt="image" src="https://user-images.githubusercontent.com/78894223/169507882-eef4979a-6564-4bf7-bf22-d58e7bcad643.png">

## Notes
Background: LaMa uses virtual host names and virtual IP addresses.One IP address is used for the SAP system components like DB, ASCS, PAS, AAS1 to AAS<n> .The other IP addresses stay with the respective VM. All SAP components reside on shares (NFS/SMB) . For SAP components these are /usr/sap/trans, /home/<sid>adm, /sapmnt/<SID>, /usr/sap/<SID>.For HANA these are /hana/data, /hana/log, /hana/shared, /hana/backup. LaMa has a process pair called Prepare/Unprepare. Prepare attaches the virtual IP address and virtual host name to a VM  in addition it also attaches the shares to the same VM. Unprepare does the exact opposite.This allows SAP rather than OS-patching VMs to create to create new ones and simply relocate an SAP system to a new set of VMs in a matter of minutes.