### PR TITLE
Bugfixes for use of deployment without a deployer

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_landscape/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/variables_local.tf
@@ -1,8 +1,8 @@
 
 ###############################################################################
-#                                                                             # 
-#                            Local Variables                                  # 
-#                                                                             # 
+#                                                                             #
+#                            Local Variables                                  #
+#                                                                             #
 ###############################################################################
 
 locals {
@@ -32,7 +32,7 @@ locals {
 
   deployer_subnet_management_id = try(var.deployer_tfstate.subnet_mgmt_id, null)
 
-  deployer_public_ip_address = try(var.deployer_tfstate.deployer_public_ip_address, null)
+  deployer_public_ip_address = try(var.deployer_tfstate.deployer_public_ip_address, "")
 
 
   // Resource group
@@ -61,7 +61,7 @@ locals {
   )
   vnet_sap_addr = local.vnet_sap_exists ? "" : try(var.infrastructure.vnets.sap.address_space, "")
 
-  // By default, Ansible ssh key for SID uses generated public key. 
+  // By default, Ansible ssh key for SID uses generated public key.
   // Provide sshkey.path_to_public_key and path_to_private_key overides it
 
   sid_public_key = local.sid_key_exist ? (
@@ -76,7 +76,7 @@ locals {
   // Current service principal
   service_principal = try(var.service_principal, {})
 
-  // If the user specifies arm id of key vaults in input, 
+  // If the user specifies arm id of key vaults in input,
   // the key vault will be imported instead of creating new key vaults
 
   user_key_vault_id         = try(var.key_vault.kv_user_id, "")
@@ -86,7 +86,7 @@ locals {
 
   enable_landscape_kv = !local.user_keyvault_exist
 
-  // If the user specifies the secret name of key pair/password in input, 
+  // If the user specifies the secret name of key pair/password in input,
   // the secrets will be imported instead of creating new secrets
   input_sid_public_key_secret_name  = try(var.key_vault.kv_sid_sshkey_pub, "")
   input_sid_private_key_secret_name = try(var.key_vault.kv_sid_sshkey_prvt, "")
@@ -176,13 +176,13 @@ locals {
 
   // In brownfield scenarios the subnets are often defined in the workload
   // If subnet information is specified in the parameter file use it
-  // As either of the arm_id or the prefix need to be specified to create 
-  // a subnet the lack of both indicate that the subnet is to be created in the 
+  // As either of the arm_id or the prefix need to be specified to create
+  // a subnet the lack of both indicate that the subnet is to be created in the
   // SAP Infrastructure Deployment
 
   ##############################################################################################
   #
-  #  Admin subnet - Check if locally provided 
+  #  Admin subnet - Check if locally provided
   #
   ##############################################################################################
 
@@ -217,7 +217,7 @@ locals {
 
   ##############################################################################################
   #
-  #  Admin subnet NSG - Check if locally provided 
+  #  Admin subnet NSG - Check if locally provided
   #
   ##############################################################################################
 
@@ -244,7 +244,7 @@ locals {
 
   ##############################################################################################
   #
-  #  Database subnet - Check if locally provided 
+  #  Database subnet - Check if locally provided
   #
   ##############################################################################################
 
@@ -280,7 +280,7 @@ locals {
 
   ##############################################################################################
   #
-  #  Database subnet NSG - Check if locally provided 
+  #  Database subnet NSG - Check if locally provided
   #
   ##############################################################################################
 
@@ -308,7 +308,7 @@ locals {
 
   ##############################################################################################
   #
-  #  Application subnet - Check if locally provided 
+  #  Application subnet - Check if locally provided
   #
   ##############################################################################################
 
@@ -344,7 +344,7 @@ locals {
 
   ##############################################################################################
   #
-  #  Application subnet NSG - Check if locally provided 
+  #  Application subnet NSG - Check if locally provided
   #
   ##############################################################################################
 
@@ -371,7 +371,7 @@ locals {
 
   ##############################################################################################
   #
-  #  Web subnet - Check if locally provided 
+  #  Web subnet - Check if locally provided
   #
   ##############################################################################################
 
@@ -406,7 +406,7 @@ locals {
 
   ##############################################################################################
   #
-  #  Web subnet NSG - Check if locally provided 
+  #  Web subnet NSG - Check if locally provided
   #
   ##############################################################################################
 
@@ -434,7 +434,7 @@ locals {
 
   ##############################################################################################
   #
-  #  ANF subnet - Check if locally provided 
+  #  ANF subnet - Check if locally provided
   #
   ##############################################################################################
 
@@ -503,7 +503,7 @@ locals {
   )
   iscsi_nic_ips = local.sub_iscsi_exists ? try(var.infrastructure.iscsi.iscsi_nic_ips, []) : []
 
-  // By default, ssh key for iSCSI uses generated public key. 
+  // By default, ssh key for iSCSI uses generated public key.
   // Provide sshkey.path_to_public_key and path_to_private_key overides it
   enable_iscsi_auth_key = local.enable_iscsi && local.iscsi_auth_type == "key"
   iscsi_public_key = local.enable_iscsi_auth_key ? (

--- a/deploy/terraform/terraform-units/modules/sap_library/variables_global.tf
+++ b/deploy/terraform/terraform-units/modules/sap_library/variables_global.tf
@@ -91,12 +91,6 @@ variable "naming" {
 variable "deployer_tfstate" {
   description = "terraform.tfstate of deployer"
   default     = {}
-  validation {
-    condition = (
-      length(var.deployer_tfstate) > 0
-    )
-    error_message = "The state file is empty."
-  }
 }
 variable "service_principal" {
   description = "Current service principal used to authenticate to Azure"


### PR DESCRIPTION
## Problem
- When a deployment is performed without a deployer VM there is no deployer_tfstate so the variable is empty.
- The var.deployer_tfstate.deployer_public_ip_address can't be null

## Solution
- It's currently not possible to add an extra conditional to validate for example together with the use_deployer variable. So I removed the validation for the deployer_tfstate variable.
- Default the var.deployer_tfstate.deployer_public_ip_address to an empty string

## Tests

## Notes