### PR TITLE
Secrets in scripting require quotes

### DIFF
--- a/deploy/pipelines/01-deploy-control-plane.yaml
+++ b/deploy/pipelines/01-deploy-control-plane.yaml
@@ -98,7 +98,7 @@ stages:
                   echo "##vso[task.logissue type=error]Variable ARM_CLIENT_ID was not defined."
                   exit 2
                 fi
-                if [ ! -n $(ARM_CLIENT_SECRET) ]; then
+                if [ ! -n "$(ARM_CLIENT_SECRET)" ]; then
                   echo "##vso[task.logissue type=error]Variable ARM_CLIENT_SECRET was not defined."
                   exit 2
                 fi
@@ -108,7 +108,7 @@ stages:
                 fi
 
               echo -e "$green--- az login ---$reset"
-                az login --service-principal --username $(ARM_CLIENT_ID) --password $(ARM_CLIENT_SECRET) --tenant $(ARM_TENANT_ID)
+                az login --service-principal --username $(ARM_CLIENT_ID) --password "$(ARM_CLIENT_SECRET)" --tenant $(ARM_TENANT_ID)
                 return_code=$?
                 if [ 0 != $return_code ]; then
                   echo -e "$boldred--- Login failed ---$reset"
@@ -148,7 +148,7 @@ stages:
 
               echo -e "$green--- Deploy the Control Plane ---$reset"
 
-                $DEPLOYMENT_REPO_PATH/deploy/scripts/prepare_region.sh --deployer_parameter_file DEPLOYER/$(deployerfolder)/$(deployerconfig) --library_parameter_file LIBRARY/$(libraryfolder)/$(libraryconfig)  --subscription $(ARM_SUBSCRIPTION_ID)  --spn_id $(ARM_CLIENT_ID) --spn_secret $(ARM_CLIENT_SECRET) --tenant_id $(ARM_TENANT_ID)  --auto-approve --ado
+                $DEPLOYMENT_REPO_PATH/deploy/scripts/prepare_region.sh --deployer_parameter_file DEPLOYER/$(deployerfolder)/$(deployerconfig) --library_parameter_file LIBRARY/$(libraryfolder)/$(libraryconfig)  --subscription $(ARM_SUBSCRIPTION_ID)  --spn_id $(ARM_CLIENT_ID) --spn_secret "$(ARM_CLIENT_SECRET)" --tenant_id $(ARM_TENANT_ID)  --auto-approve --ado
                 return_code=$?
                 if [ 0 != $return_code ]; then
                   echo "##vso[task.logissue type=error]Return code from prepare_region $return_code."


### PR DESCRIPTION
## Problem
When running the pipeline following the described documentation (creating the library SDAF-MGMT with ARM_CLIENT_SECRET) the shell scripts will fail with the following:
```
/home/vsts/work/_temp/547efcbd-8b04-4720-a04d-61af9a172d22.sh: line 44: syntax error near unexpected token `)' 
/home/vsts/work/_temp/547efcbd-8b04-4720-a04d-61af9a172d22.sh: line 44: ` if [ ! -n *** ]; then' 
```

## Solution
Adding quotes to surround the ARM_CLIENT_SECRET to prevent the value of the secret impacting the script

## Tests
Run the 01-deploy-control-plane.yaml pipeline

## Notes
It only is a problem when inside the scripting