### PR TITLE
create empty array instead of empty string

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_deployer/key_vault.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/key_vault.tf
@@ -23,13 +23,13 @@ resource "azurerm_key_vault" "kv_user" {
   network_acls {
     bypass         = "AzureServices"
     default_action = "Allow"
-    ip_rules = var.use_private_endpoint ? (
+    ip_rules = var.use_private_endpoint && local.enable_deployer_public_ip ? (
       [
-        local.enable_deployer_public_ip ? azurerm_public_ip.deployer[0].ip_address : ""
+        azurerm_public_ip.deployer[0].ip_address
       ]
       ) : (
       [
-        
+
       ]
     )
     virtual_network_subnet_ids = [


### PR DESCRIPTION
## Problem
When enabling the private endpoint the following error occurs

```
╷ 
│ Error: "network_acls.0.ip_rules.0" is not a valid IPv4 address: "" 
│ 
│ with module.sap_deployer.azurerm_key_vault.kv_user[0], 
│ on ../../terraform-units/modules/sap_deployer/key_vault.tf line 26, in resource "azurerm_key_vault" "kv_user": 
│ 26: ip_rules = var.use_private_endpoint ? ( 
│ 27: [ 
│ 28: local.enable_deployer_public_ip ? azurerm_public_ip.deployer[0].ip_address : "" 
│ 29: ] 
│ 30: ) : ( 
│ 31: [ 
│ 32: 
│ 33: ] 
│ 34: ) 
│ 
╵ 
╷ 
│ Error: network_acls.0.ip_rules.0 must start with IPV4 address and/or slash, number of bits (0-32) as prefix. Example: 127.0.0.1/8. Got "". 
│ 
│ with module.sap_deployer.azurerm_key_vault.kv_user[0], 
│ on ../../terraform-units/modules/sap_deployer/key_vault.tf line 26, in resource "azurerm_key_vault" "kv_user": 
│ 26: ip_rules = var.use_private_endpoint ? ( 
│ 27: [ 
│ 28: local.enable_deployer_public_ip ? azurerm_public_ip.deployer[0].ip_address : "" 
│ 29: ] 
│ 30: ) : ( 
│ 31: [ 
│ 32: 
│ 33: ] 
│ 34: ) 
│ 

```
This is due to creating an array with an empty IP address in it.

## Solution
Changing the condition to create an empty array instead of an array with an empty IP address

## Tests
Run the deployer pipeline

## Notes
