### PR TITLE
Bug/invalid arrays

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_library/storage_accounts.tf
+++ b/deploy/terraform/terraform-units/modules/sap_library/storage_accounts.tf
@@ -27,11 +27,14 @@ resource "azurerm_storage_account" "storage_tfstate" {
 
   network_rules {
     default_action = "Allow"
-    ip_rules = var.use_private_endpoint ? (
-      [length(local.deployer_public_ip_address) > 0 ? local.deployer_public_ip_address : null]) : (
+    ip_rules = var.use_private_endpoint && length(local.deployer_public_ip_address) > 0  ? (
+      [ local.deployer_public_ip_address ]) : (
       []
     )
-    virtual_network_subnet_ids = var.use_private_endpoint ? [try(var.deployer_tfstate.subnet_management_id, null)] : []
+    virtual_network_subnet_ids = var.use_private_endpoint && length(local.deployer_tfstate.subnet_management_id) > 0  ? (
+      [ local.deployer_tfstate.subnet_management_id ]) : (
+      []
+    )
   }
 
   min_tls_version                 = "TLS1_2"
@@ -124,12 +127,15 @@ resource "azurerm_storage_account" "storage_sapbits" {
 
   network_rules {
     default_action = "Allow"
-    ip_rules = var.use_private_endpoint ? (
-      [length(local.deployer_public_ip_address) > 0 ? local.deployer_public_ip_address : null]) : (
+    ip_rules = var.use_private_endpoint && length(local.deployer_public_ip_address) > 0  ? (
+      [ local.deployer_public_ip_address ]) : (
+      []
+    )
+    virtual_network_subnet_ids = var.use_private_endpoint && length(local.deployer_tfstate.subnet_management_id) > 0  ? (
+      [ local.deployer_tfstate.subnet_management_id ]) : (
       []
     )
 
-    virtual_network_subnet_ids = var.use_private_endpoint ? [try(var.deployer_tfstate.subnet_management_id, null)] : []
   }
   min_tls_version                 = "TLS1_2"
   allow_nested_items_to_be_public = false

--- a/deploy/terraform/terraform-units/modules/sap_library/storage_accounts.tf
+++ b/deploy/terraform/terraform-units/modules/sap_library/storage_accounts.tf
@@ -31,8 +31,8 @@ resource "azurerm_storage_account" "storage_tfstate" {
       [local.deployer_public_ip_address]) : (
       []
     )
-    virtual_network_subnet_ids = var.use_private_endpoint && length(try(local.deployer_tfstate.subnet_management_id, "")) > 0 ? (
-      [local.deployer_tfstate.subnet_management_id]) : (
+    virtual_network_subnet_ids = var.use_private_endpoint && length(try(var.deployer_tfstate.subnet_mgmt_id, "")) > 0 ? (
+      [var.deployer_tfstate.subnet_mgmt_id]) : (
       []
     )
   }
@@ -88,7 +88,7 @@ resource "azurerm_private_endpoint" "storage_tfstate" {
     data.azurerm_resource_group.library[0].location) : (
     azurerm_resource_group.library[0].location
   )
-  subnet_id = var.deployer_tfstate.subnet_management_id
+  subnet_id = var.deployer_tfstate.subnet_mgmt_id
 
   private_service_connection {
     name = format("%s%s%s", var.naming.resource_prefixes.storage_private_svc_tf,
@@ -131,8 +131,8 @@ resource "azurerm_storage_account" "storage_sapbits" {
       [local.deployer_public_ip_address]) : (
       []
     )
-    virtual_network_subnet_ids = var.use_private_endpoint && length(try(local.deployer_tfstate.subnet_management_id, "")) > 0 ? (
-      [local.deployer_tfstate.subnet_management_id]) : (
+    virtual_network_subnet_ids = var.use_private_endpoint && length(try(var.deployer_tfstate.subnet_mgmt_id, "")) > 0 ? (
+      [var.deployer_tfstate.subnet_mgmt_id]) : (
       []
     )
 
@@ -165,7 +165,7 @@ resource "azurerm_private_endpoint" "storage_sapbits" {
     data.azurerm_resource_group.library[0].location) : (
     azurerm_resource_group.library[0].location
   )
-  subnet_id = var.deployer_tfstate.subnet_management_id
+  subnet_id = var.deployer_tfstate.subnet_mgmt_id
 
   private_service_connection {
     name = format("%s%s%s",

--- a/deploy/terraform/terraform-units/modules/sap_library/storage_accounts.tf
+++ b/deploy/terraform/terraform-units/modules/sap_library/storage_accounts.tf
@@ -27,12 +27,12 @@ resource "azurerm_storage_account" "storage_tfstate" {
 
   network_rules {
     default_action = "Allow"
-    ip_rules = var.use_private_endpoint && length(local.deployer_public_ip_address) > 0  ? (
-      [ local.deployer_public_ip_address ]) : (
+    ip_rules = var.use_private_endpoint && length(local.deployer_public_ip_address) > 0 ? (
+      [local.deployer_public_ip_address]) : (
       []
     )
-    virtual_network_subnet_ids = var.use_private_endpoint && length(local.deployer_tfstate.subnet_management_id) > 0  ? (
-      [ local.deployer_tfstate.subnet_management_id ]) : (
+    virtual_network_subnet_ids = var.use_private_endpoint && length(try(local.deployer_tfstate.subnet_management_id, "")) > 0 ? (
+      [local.deployer_tfstate.subnet_management_id]) : (
       []
     )
   }
@@ -127,12 +127,12 @@ resource "azurerm_storage_account" "storage_sapbits" {
 
   network_rules {
     default_action = "Allow"
-    ip_rules = var.use_private_endpoint && length(local.deployer_public_ip_address) > 0  ? (
-      [ local.deployer_public_ip_address ]) : (
+    ip_rules = var.use_private_endpoint && length(local.deployer_public_ip_address) > 0 ? (
+      [local.deployer_public_ip_address]) : (
       []
     )
-    virtual_network_subnet_ids = var.use_private_endpoint && length(local.deployer_tfstate.subnet_management_id) > 0  ? (
-      [ local.deployer_tfstate.subnet_management_id ]) : (
+    virtual_network_subnet_ids = var.use_private_endpoint && length(try(local.deployer_tfstate.subnet_management_id, "")) > 0 ? (
+      [local.deployer_tfstate.subnet_management_id]) : (
       []
     )
 


### PR DESCRIPTION
## Problem
Various errors in the storage_account.tf file. 

- Wrong initialization of arrays with null values
- referencing a local variable while this should be a global var
- statefile that will be loaded had a name refactor subnet_management_id => subnet_mgmt_id that was not changed in this file

## Solution
Solved the various issues so it will pass the planning phase
- test and initialize an empty array instead of an array with a null value
- replaced local.deploy_tfstate => var.deploy_tfstate (as been already done for the landscape)
- replaced subnet_management_id => subnet_mgmt_id as exists in the deployer state

## Tests
Run the ado pipeline

## Notes
<Additional comments for the PR>