### PR TITLE
use agent and remove unused pool variable

### DIFF
--- a/deploy/pipelines/01-deploy-control-plane.yaml
+++ b/deploy/pipelines/01-deploy-control-plane.yaml
@@ -228,6 +228,7 @@ stages:
               ARM_TENANT_ID:           $(ARM_TENANT_ID)
               TF_VAR_agent_pat:        $(PAT)
               TF_VAR_agent_ado_url:    $(System.CollectionUri)
+              TF_VAR_agent_pool:       $(POOL)
             failOnStderr:              false
 
 ...

--- a/deploy/pipelines/01-deploy-control-plane.yaml
+++ b/deploy/pipelines/01-deploy-control-plane.yaml
@@ -25,7 +25,7 @@ parameters:
 trigger:                               none
 
 pool:
-  vmImage:                             ubuntu-latest
+  name:                                $(Agent)
 
 variables:
   - group:                             "SDAF-General"
@@ -228,7 +228,6 @@ stages:
               ARM_TENANT_ID:           $(ARM_TENANT_ID)
               TF_VAR_agent_pat:        $(PAT)
               TF_VAR_agent_ado_url:    $(System.CollectionUri)
-              TF_VAR_agent_pool:       $(POOL)
             failOnStderr:              false
 
 ...


### PR DESCRIPTION
## Problem
The documentation describes the use of a POOL variable in the library to use your hosted agent. This POOL variable is actually never used and the vmimage is set hard for the pipeline.

![image](https://user-images.githubusercontent.com/33801297/172590920-a60e99b8-dc92-4f39-9263-5d806b05ffce.png)


## Solution
Replaced the hard reference with the $(Agent) that is being used by other parts of the code and is defined in your second library

## Tests
Run the 02 pipeline

## Notes
Should also be removed from the documentation cause it is doing nothing [documentaion](https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/automation-configure-devops#common-variables)