### PR TITLE
Set default network rule action based on configuration

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_deployer/key_vault.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/key_vault.tf
@@ -22,7 +22,7 @@ resource "azurerm_key_vault" "kv_user" {
 
   network_acls {
     bypass         = "AzureServices"
-    default_action = "Allow"
+    default_action = var.use_private_endpoint || local.management_subnet_exists ? "Deny" : "Allow"
     ip_rules = var.use_private_endpoint ? (
       [
         local.enable_deployer_public_ip ? azurerm_public_ip.deployer[0].ip_address : ""

--- a/deploy/terraform/terraform-units/modules/sap_library/storage_accounts.tf
+++ b/deploy/terraform/terraform-units/modules/sap_library/storage_accounts.tf
@@ -3,6 +3,11 @@
   Set up storage accounts for sap library 
 */
 
+locals {
+  deployer_public_ip_address_used = length(local.deployer_public_ip_address) > 0
+  deployer_tfstate_subnet_used    = length(try(var.deployer_tfstate.subnet_mgmt_id, "")) > 0
+}
+
 // Creates storage account for storing tfstate
 resource "azurerm_storage_account" "storage_tfstate" {
   provider = azurerm.main
@@ -26,12 +31,16 @@ resource "azurerm_storage_account" "storage_tfstate" {
   }
 
   network_rules {
-    default_action = "Allow"
-    ip_rules = var.use_private_endpoint && length(local.deployer_public_ip_address) > 0 ? (
+    default_action = var.use_private_endpoint || local.deployer_public_ip_address_used || local.deployer_tfstate_subnet_used ? "Deny" : "Allow"
+    ip_rules = var.use_private_endpoint && local.deployer_public_ip_address_used ? (
       [local.deployer_public_ip_address]) : (
       []
     )
+<<<<<<< Updated upstream
     virtual_network_subnet_ids = var.use_private_endpoint && length(try(var.deployer_tfstate.subnet_mgmt_id, "")) > 0 ? (
+=======
+    virtual_network_subnet_ids = !var.use_private_endpoint && local.deployer_tfstate_subnet_used ? (
+>>>>>>> Stashed changes
       [var.deployer_tfstate.subnet_mgmt_id]) : (
       []
     )
@@ -126,12 +135,16 @@ resource "azurerm_storage_account" "storage_sapbits" {
   enable_https_traffic_only = true
 
   network_rules {
-    default_action = "Allow"
-    ip_rules = var.use_private_endpoint && length(local.deployer_public_ip_address) > 0 ? (
+    default_action = var.use_private_endpoint || local.deployer_public_ip_address_used || local.deployer_tfstate_subnet_used ? "Deny" : "Allow"
+    ip_rules = var.use_private_endpoint && local.deployer_public_ip_address_used ? (
       [local.deployer_public_ip_address]) : (
       []
     )
+<<<<<<< Updated upstream
     virtual_network_subnet_ids = var.use_private_endpoint && length(try(var.deployer_tfstate.subnet_mgmt_id, "")) > 0 ? (
+=======
+    virtual_network_subnet_ids = !var.use_private_endpoint && local.deployer_tfstate_subnet_used ? (
+>>>>>>> Stashed changes
       [var.deployer_tfstate.subnet_mgmt_id]) : (
       []
     )


### PR DESCRIPTION
## Problem
When you assign a private endpoint, IP or a subnet the default_action should be set to deny, otherwise, they will still be reachable from public networks. 

This is explained in the documentation
![image](https://user-images.githubusercontent.com/33801297/173293401-e1e249e7-1aa9-42b3-8ed8-ede3a26e1c4e.png)

## Solution
Made it conditional based on the already existing variables

## Tests
Run the 02 pipeline

## Notes
<Additional comments for the PR>