### PR TITLE
SSH access between nodes isn't required for pacemaker on RHEL

### DIFF
--- a/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.0-set_runtime_facts.yml
+++ b/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.0-set_runtime_facts.yml
@@ -63,26 +63,27 @@
       - "SUBNET PREFIX  : {{ subnet_prefix }}"
     verbosity:                         2
 
-# Configure SSH Keys for inter-node communication as root
-- name:                                "1.17 Generic Pacemaker - Ensure there are SSH keys for the root user to communicate between nodes"
-  ansible.builtin.command:             ssh-keygen -b 4096 -t rsa -f /root/.ssh/id_rsa -q -N ""
-  args:
-    creates:                           /root/.ssh/id_rsa
+# Configure SSH Keys for inter-node communication as root for SUSE
+- block:
+    - name:                                "1.17 Generic Pacemaker - Ensure there are SSH keys for the root user to communicate between nodes"
+      ansible.builtin.command:             ssh-keygen -b 4096 -t rsa -f /root/.ssh/id_rsa -q -N ""
+      args:
+        creates:                           /root/.ssh/id_rsa
 
-- name:                                "1.17 Generic Pacemaker - Ensure there is a public key for the root user SSH key"
-  ansible.builtin.shell:               ssh-keygen -f /root/.ssh/id_rsa -y > /root/.ssh/id_rsa.pub
-  args:
-    creates:                           /root/.ssh/id_rsa.pub
+    - name:                                "1.17 Generic Pacemaker - Ensure there is a public key for the root user SSH key"
+      ansible.builtin.shell:               ssh-keygen -f /root/.ssh/id_rsa -y > /root/.ssh/id_rsa.pub
+      args:
+        creates:                           /root/.ssh/id_rsa.pub
 
-- name:                                "1.17 Generic Pacemaker - Ensure the Public SSH keys are available for exchanging SSH key trust between nodes"
-  ansible.builtin.command:             cat /root/.ssh/id_rsa.pub
-  register:                            cluster_public_ssh_key
-  changed_when:                        false
+    - name:                                "1.17 Generic Pacemaker - Ensure the Public SSH keys are available for exchanging SSH key trust between nodes"
+      ansible.builtin.command:             cat /root/.ssh/id_rsa.pub
+      register:                            cluster_public_ssh_key
+      changed_when:                        false
 
-- name:                                "1.17 Generic Pacemaker - Set SSH fact"
-  ansible.builtin.set_fact:
-    cluster_public_ssh_key:            "{{ cluster_public_ssh_key.stdout }}"
-
+    - name:                                "1.17 Generic Pacemaker - Set SSH fact"
+      ansible.builtin.set_fact:
+        cluster_public_ssh_key:            "{{ cluster_public_ssh_key.stdout }}"
+  when: ansible_os_family|upper == "SUSE"
 # /*---------------------------------------------------------------------------8
 # |                                   END                                     |
 # +------------------------------------4--------------------------------------*/

--- a/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.2-provision.yml
+++ b/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.2-provision.yml
@@ -10,47 +10,48 @@
   ansible.builtin.systemd:
     daemon_reload:                     true
 
-# Change the configuration file for the network interface to prevent the cloud
-# network plugin from removing the virtual IP address (Pacemaker must control
-# the VIP assignment)
-# Refer to: https://www.suse.com/support/kb/doc/?id=7023633 for more information
-- name:                                "1.17 Generic Pacemaker - Ensure that network interface is not managed by cloud network plugin"
-  become:                              true
-  ansible.builtin.lineinfile:
-    path:                              /etc/sysconfig/network/ifcfg-eth0
-    backup:                            true
-    regexp:                            '^CLOUD_NETCONFIG_MANAGE='
-    line:                              CLOUD_NETCONFIG_MANAGE='no'
-  when:                                ansible_os_family|upper == "SUSE"
-  tags:
-    - cloudnetmanage
+# SSH access between nodes is only required on SUSE for crm_clustering
+- block:
+    # Change the configuration file for the network interface to prevent the cloud
+    # network plugin from removing the virtual IP address (Pacemaker must control
+    # the VIP assignment)
+    # Refer to: https://www.suse.com/support/kb/doc/?id=7023633 for more information
+    - name:                                "1.17 Generic Pacemaker - Ensure that network interface is not managed by cloud network plugin"
+      become:                              true
+      ansible.builtin.lineinfile:
+        path:                              /etc/sysconfig/network/ifcfg-eth0
+        backup:                            true
+        regexp:                            '^CLOUD_NETCONFIG_MANAGE='
+        line:                              CLOUD_NETCONFIG_MANAGE='no'
+      tags:
+        - cloudnetmanage
 
-- name:                                "1.17 Generic Pacemaker - Ensure the Primary Node public key is authorized on all nodes, required for crm_clustering"
-  ansible.builtin.authorized_key:
-    user:                              root
-    key:                               "{{ hostvars[primary_instance_name].cluster_public_ssh_key }}"
-  when:                                ansible_hostname != primary_instance_name
+    - name:                                "1.17 Generic Pacemaker - Ensure the Primary Node public key is authorized on all nodes, required for crm_clustering"
+      ansible.builtin.authorized_key:
+        user:                              root
+        key:                               "{{ hostvars[primary_instance_name].cluster_public_ssh_key }}"
+      when:                                ansible_hostname != primary_instance_name
 
-- name:                                "1.17 Generic Pacemaker - Ensure the Secondary Node public key is authorized on all nodes, required for crm_clustering"
-  ansible.builtin.authorized_key:
-    user:                              root
-    key:                               "{{ hostvars[secondary_instance_name].cluster_public_ssh_key }}"
-  when:                                ansible_hostname != secondary_instance_name
+    - name:                                "1.17 Generic Pacemaker - Ensure the Secondary Node public key is authorized on all nodes, required for crm_clustering"
+      ansible.builtin.authorized_key:
+        user:                              root
+        key:                               "{{ hostvars[secondary_instance_name].cluster_public_ssh_key }}"
+      when:                                ansible_hostname != secondary_instance_name
 
-- name:                                1.17 Generic Pacemaker - Ensure trust relationship is working from primary to secondary
-  ansible.builtin.command:             ssh -oStrictHostKeyChecking=no {{ secondary_instance_name }} "hostname -s"
-  register:                            primary_to_secondary_ssh_result
-  changed_when:                        false
-  failed_when:                         primary_to_secondary_ssh_result.stdout_lines[0] != secondary_instance_name
-  when:                                ansible_hostname == primary_instance_name
+    - name:                                1.17 Generic Pacemaker - Ensure trust relationship is working from primary to secondary
+      ansible.builtin.command:             ssh -oStrictHostKeyChecking=no {{ secondary_instance_name }} "hostname -s"
+      register:                            primary_to_secondary_ssh_result
+      changed_when:                        false
+      failed_when:                         primary_to_secondary_ssh_result.stdout_lines[0] != secondary_instance_name
+      when:                                ansible_hostname == primary_instance_name
 
-- name:                                1.17 Generic Pacemaker - Ensure trust relationship is working from secondary to primary"
-  ansible.builtin.command:             ssh -oStrictHostKeyChecking=no {{ primary_instance_name }} "hostname -s"
-  register:                            secondary_to_primary_ssh_result
-  changed_when:                        false
-  failed_when:                         secondary_to_primary_ssh_result.stdout_lines[0] != primary_instance_name
-  when:                                ansible_hostname == secondary_instance_name
-
+    - name:                                1.17 Generic Pacemaker - Ensure trust relationship is working from secondary to primary"
+      ansible.builtin.command:             ssh -oStrictHostKeyChecking=no {{ primary_instance_name }} "hostname -s"
+      register:                            secondary_to_primary_ssh_result
+      changed_when:                        false
+      failed_when:                         secondary_to_primary_ssh_result.stdout_lines[0] != primary_instance_name
+      when:                                ansible_hostname == secondary_instance_name
+  when: ansible_os_family|upper == "SUSE"
 
 # Clustering commands are based on the Host OS
 - name:                                "1.17 Generic Pacemaker - Cluster based on {{ ansible_os_family }} on VM {{ ansible_hostname }}"


### PR DESCRIPTION
## Problem
SSH root access between nodes in Enterprise environments usually isn't permitted. According to the docs this is however a requirement for crm_clustering on SUSE but it isn't for RHEL.

## Solution
Only generate and distribute SSH private/public keys for SUSE systems and not RHEL.

## Tests

## Notes
https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/high-availability-guide-suse-pacemaker
https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/high-availability-guide-rhel-pacemaker