### PR TITLE
use env vars instead of pipeline due to secret not working

### DIFF
--- a/deploy/pipelines/02-sap-workload-zone.yaml
+++ b/deploy/pipelines/02-sap-workload-zone.yaml
@@ -67,7 +67,7 @@ stages:
                   echo "##vso[task.logissue type=error]Variable ARM_CLIENT_ID was not defined."
                   exit 2
                 fi
-                if [ ! -n $(ARM_CLIENT_SECRET) ]; then
+                if [ ! -n $ARM_CLIENT_SECRET ]; then
                   echo "##vso[task.logissue type=error]Variable ARM_CLIENT_SECRET was not defined."
                   exit 2
                 fi
@@ -113,7 +113,7 @@ stages:
                 export DEPLOYMENT_REPO_PATH=$(Build.Repository.LocalPath)
 
               echo -e "$green--- az login ---$reset"
-                az login --service-principal --username $(ARM_CLIENT_ID) --password $(ARM_CLIENT_SECRET) --tenant $(ARM_TENANT_ID)
+                az login --service-principal --username $(ARM_CLIENT_ID) --password $ARM_CLIENT_SECRET --tenant $(ARM_TENANT_ID)
                 return_code=$?
                 if [ 0 != $return_code ]; then
                   echo -e "$boldred--- Login failed ---$reset"
@@ -166,7 +166,7 @@ stages:
                 cd $HOME/LANDSCAPE/$(workload_zone_folder)
                 $DEPLOYMENT_REPO_PATH/deploy/scripts/install_workloadzone.sh --parameterfile $(workload_zone_configuration_file)      \
                   --deployer_environment $(deployer_environment) --subscription $(ARM_SUBSCRIPTION_ID)                                \
-                  --spn_id $(ARM_CLIENT_ID) --spn_secret $(ARM_CLIENT_SECRET) --tenant_id $(ARM_TENANT_ID)                            \
+                  --spn_id $(ARM_CLIENT_ID) --spn_secret $ARM_CLIENT_SECRET --tenant_id $(ARM_TENANT_ID)                            \
                   --deployer_tfstate_key "${deployer_tfstate_key}" --keyvault "${keyvault}" --storageaccountname "${REMOTE_STATE_SA}" \
                   --state_subscription "${STATE_SUBSCRIPTION}" --auto-approve --ado
                 return_code=$?


### PR DESCRIPTION
## Problem
When running the pipeline following the described documentation (creating the library SDAF-DEV with ARM_CLIENT_SECRET) the shell scripts will fail with the following:
```
--- Validations --- 
/home/vsts/work/_temp/797b59ab-def3-4170-837f-c38fd8a80ba5.sh: line 15: syntax error near unexpected token `)' 
/home/vsts/work/_temp/797b59ab-def3-4170-837f-c38fd8a80ba5.sh: line 15: ` if [ ! -n *** ]; then' 
##[error]Bash exited with code '2'. 

```

## Solution
Using the environment variables for shell scripts is advised by the documentations and resolves the issue we have for the  ARM_CLIENT_SECRET to prevent the value of the secret impacting the script

## Tests
Run the02-sap-workload-zone.yaml pipeline

## Notes
It only is a problem when inside the scripting
same as PR #171 