### PR TITLE
Bug/sa networkrules

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_landscape/storage_accounts.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/storage_accounts.tf
@@ -119,40 +119,35 @@ resource "azurerm_storage_account" "witness_storage" {
     data.azurerm_resource_group.resource_group[0].location) : (
     azurerm_resource_group.resource_group[0].location
   )
+
   account_replication_type        = "LRS"
   account_tier                    = "Standard"
   enable_https_traffic_only       = true
   min_tls_version                 = "TLS1_2"
   allow_nested_items_to_be_public = false
 
-}
-
-resource "azurerm_storage_account_network_rules" "witness_storage" {
-  count              = length(var.witness_storage_account.arm_id) > 0 ? 0 : var.use_private_endpoint ? 1 : 0
-  provider           = azurerm.main
-  storage_account_id = azurerm_storage_account.witness_storage[0].id
-  depends_on = [
-    azurerm_subnet.app,
-    azurerm_subnet.db
-  ]
-
-  default_action = "Deny"
-  ip_rules       = length(var.Agent_IP) > 0 ? [var.Agent_IP] : [""]
-  virtual_network_subnet_ids = compact(
-    [
-      local.application_subnet_existing ? (
-        local.application_subnet_arm_id) : (
-        azurerm_subnet.app[0].id
-      ),
-      local.database_subnet_existing ? (
-        local.database_subnet_arm_id) : (
-        azurerm_subnet.db[0].id
-      ),
-      local.deployer_subnet_management_id
-    ]
-  )
-  bypass = ["AzureServices", "Logging", "Metrics"]
-
+  network_rules {
+    default_action = "Deny"
+    ip_rules       = length(var.Agent_IP) > 0 ? [var.Agent_IP] : []
+    bypass         = ["AzureServices", "Logging", "Metrics"]
+    virtual_network_subnet_ids = var.use_private_endpoint ? (
+      []
+      ) : (
+      compact(
+        [
+          local.application_subnet_existing ? (
+            local.application_subnet_arm_id) : (
+            azurerm_subnet.app[0].id
+          ),
+          local.database_subnet_existing ? (
+            local.database_subnet_arm_id) : (
+            azurerm_subnet.db[0].id
+          ),
+          local.deployer_subnet_management_id
+        ]
+      )
+    )
+  }
 }
 
 data "azurerm_storage_account" "witness_storage" {

--- a/deploy/terraform/terraform-units/modules/sap_landscape/storage_accounts.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/storage_accounts.tf
@@ -16,51 +16,44 @@ resource "azurerm_storage_account" "storage_bootdiag" {
     data.azurerm_resource_group.resource_group[0].location) : (
     azurerm_resource_group.resource_group[0].location
   )
-  account_replication_type        = "LRS"
-  account_tier                    = "Standard"
-  enable_https_traffic_only       = true
-  min_tls_version                 = "TLS1_2"
-  allow_nested_items_to_be_public = false
-}
-
-resource "azurerm_storage_account_network_rules" "storage_bootdiag" {
-  count = length(var.diagnostics_storage_account.arm_id) > 0 ? (
-    0) : (
-    var.use_private_endpoint ? (
-      1) : (
-      0
-    )
-  )
   depends_on = [
     azurerm_subnet.app,
     azurerm_subnet.db,
     azurerm_subnet.web,
   ]
 
-  provider           = azurerm.main
-  storage_account_id = azurerm_storage_account.storage_bootdiag[0].id
+  account_replication_type        = "LRS"
+  account_tier                    = "Standard"
+  enable_https_traffic_only       = true
+  min_tls_version                 = "TLS1_2"
+  allow_nested_items_to_be_public = false
 
-  default_action = "Deny"
-  ip_rules       = length(var.Agent_IP) > 0 ? [var.Agent_IP] : [""]
-  virtual_network_subnet_ids = compact(
-    [
-      local.application_subnet_existing ? (
-        local.application_subnet_arm_id) : (
-        azurerm_subnet.app[0].id
-      ),
-      local.database_subnet_existing ? (
-        local.database_subnet_arm_id) : (
-        azurerm_subnet.db[0].id
-      ),
-      local.web_subnet_existing ? (
-        local.web_subnet_arm_id) : (
-        azurerm_subnet.web[0].id
-      ),
-      local.deployer_subnet_management_id
-    ]
-  )
-  bypass = ["AzureServices", "Logging", "Metrics"]
-
+  network_rules {
+    default_action = "Deny"
+    ip_rules       = length(var.Agent_IP) > 0 ? [var.Agent_IP] : []
+    bypass         = ["AzureServices", "Logging", "Metrics"]
+    virtual_network_subnet_ids = var.use_private_endpoint ? (
+      []
+      ) : (
+      compact(
+        [
+          local.application_subnet_existing ? (
+            local.application_subnet_arm_id) : (
+            azurerm_subnet.app[0].id
+          ),
+          local.database_subnet_existing ? (
+            local.database_subnet_arm_id) : (
+            azurerm_subnet.db[0].id
+          ),
+          local.web_subnet_existing ? (
+            local.web_subnet_arm_id) : (
+            azurerm_subnet.web[0].id
+          ),
+          local.deployer_subnet_management_id
+        ]
+      )
+    )
+  }
 }
 
 data "azurerm_storage_account" "storage_bootdiag" {
@@ -358,8 +351,8 @@ data "azurerm_private_endpoint_connection" "transport" {
     )) : (
     0
   )
-  name                = split("/",var.transport_private_endpoint_id)[8]
-  resource_group_name = split("/",var.transport_private_endpoint_id)[4]
+  name                = split("/", var.transport_private_endpoint_id)[8]
+  resource_group_name = split("/", var.transport_private_endpoint_id)[4]
 
 }
 
@@ -412,7 +405,7 @@ data "azurerm_storage_account" "install" {
   name                = split("/", var.install_storage_account_id)[8]
   resource_group_name = split("/", var.install_storage_account_id)[4]
 }
- 
+
 data "azurerm_private_endpoint_connection" "install" {
   provider = azurerm.main
   count = var.NFS_provider == "AFS" ? (
@@ -422,8 +415,8 @@ data "azurerm_private_endpoint_connection" "install" {
     )) : (
     0
   )
-  name                = split("/",var.install_private_endpoint_id)[8]
-  resource_group_name = split("/",var.install_private_endpoint_id)[4]
+  name                = split("/", var.install_private_endpoint_id)[8]
+  resource_group_name = split("/", var.install_private_endpoint_id)[4]
 
 }
 

--- a/deploy/terraform/terraform-units/modules/sap_landscape/storage_accounts.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/storage_accounts.tf
@@ -354,6 +354,11 @@ resource "azurerm_storage_account" "install" {
     )) : (
     0
   )
+  depends_on = [
+    azurerm_subnet.app,
+    azurerm_subnet.db,
+    azurerm_subnet.web
+  ]
   name = replace(
     lower(
       format("%s%s",
@@ -376,6 +381,33 @@ resource "azurerm_storage_account" "install" {
   enable_https_traffic_only       = false
   min_tls_version                 = "TLS1_2"
   allow_nested_items_to_be_public = false
+
+  network_rules {
+    default_action = "Deny"
+    ip_rules       = length(var.Agent_IP) > 0 ? [var.Agent_IP] : []
+    bypass         = ["AzureServices", "Logging", "Metrics"]
+    virtual_network_subnet_ids = var.use_private_endpoint ? (
+      []
+      ) : (
+      compact(
+        [
+          local.application_subnet_existing ? (
+            local.application_subnet_arm_id) : (
+            azurerm_subnet.app[0].id
+          ),
+          local.database_subnet_existing ? (
+            local.database_subnet_arm_id) : (
+            azurerm_subnet.db[0].id
+          ),
+          local.web_subnet_existing ? (
+            local.web_subnet_arm_id) : (
+            azurerm_subnet.web[0].id
+          ),
+          local.deployer_subnet_management_id
+        ]
+      )
+    )
+  }
 }
 
 data "azurerm_storage_account" "install" {
@@ -401,44 +433,6 @@ data "azurerm_private_endpoint_connection" "install" {
   )
   name                = split("/", var.install_private_endpoint_id)[8]
   resource_group_name = split("/", var.install_private_endpoint_id)[4]
-
-}
-
-resource "azurerm_storage_account_network_rules" "install" {
-  depends_on = [
-    azurerm_subnet.app,
-    azurerm_subnet.db,
-    azurerm_subnet.web
-  ]
-  count = var.NFS_provider == "AFS" && var.use_private_endpoint ? (
-    length(var.install_storage_account_id) > 0 ? (
-      0) : (
-      0
-    )) : (
-    0
-  )
-
-  storage_account_id = azurerm_storage_account.install[0].id
-
-  default_action = "Deny"
-  ip_rules       = [var.Agent_IP]
-  virtual_network_subnet_ids = compact([
-    local.application_subnet_existing ? (
-      local.application_subnet_arm_id) : (
-      azurerm_subnet.app[0].id
-    ),
-    local.database_subnet_existing ? (
-      local.database_subnet_arm_id) : (
-      azurerm_subnet.db[0].id
-    ),
-    local.web_subnet_existing ? (
-      local.web_subnet_arm_id) : (
-      azurerm_subnet.web[0].id
-    ),
-    local.deployer_subnet_management_id
-    ]
-  )
-  bypass = ["AzureServices", "Logging", "Metrics"]
 
 }
 


### PR DESCRIPTION
## Problem
As described within the Terraform Documentation [here](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account_network_rules)
![image](https://user-images.githubusercontent.com/33801297/174004537-ee9a1d38-33f0-45a4-9ece-b0892e7f7f60.png)
The combined use of a azurerm_storage_account resource with a azurerm_storage_account_network_rules is not supported. With the unmodified .tf this resulted in double creations of the storage account while it already existed. 
```
Error: A resource with the ID "/subscriptions/xxx-xxxx-xxxx-xxxx-xxxxx/resourceGroups/DEV-WEEU-SAP01-INFRASTRUCTURE/providers/Microsoft.Storage/storageAccounts/xxxxxx7c9" already exists - to be managed via Terraform this resource needs to be imported into the State. Please see the resource documentation for "azurerm_storage_account_network_rule" for more information. 
with module.sap_landscape.azurerm_storage_account_network_rules.storage_bootdiag[0], 
on ../../terraform-units/modules/sap_landscape/storage_accounts.tf line 26, in resource "azurerm_storage_account_network_rules" "storage_bootdiag": 
26: resource "azurerm_storage_account_network_rules" "storage_bootdiag" { 
Error: A resource with the ID "/subscriptions/xxxx-xxxx-xxxx-xxxx-xxxx/resourceGroups/DEV-WEEU-SAP01-INFRASTRUCTURE/providers/Microsoft.Storage/storageAccounts/xxxxxx7c9" already exists - to be managed via Terraform this resource needs to be imported into the State. Please see the resource documentation for "azurerm_storage_account_network_rule" for more information. 
with module.sap_landscape.azurerm_storage_account_network_rules.witness_storage[0], 
on ../../terraform-units/modules/sap_landscape/storage_accounts.tf line 137, in resource "azurerm_storage_account_network_rules" "witness_storage": 
137: resource "azurerm_storage_account_network_rules" "witness_storage" { 

```

## Solution
Reworked the storage_accounts.tf in landscape to include the network_rules when creating the storage account including no network exclusions when using a private-endpoint. Made sure I used the same configurations that where already in the network_rule resource

## Tests
Run the 02 pipeline

## Notes
<Additional comments for the PR>