### PR TITLE
Fix hacluster

### DIFF
--- a/deploy/ansible/roles-sap-os/2.10-sap-notes/tasks/2.10.1.yaml
+++ b/deploy/ansible/roles-sap-os/2.10-sap-notes/tasks/2.10.1.yaml
@@ -29,7 +29,7 @@
     grub_config_file:                  "{{ grub_config_path | default('/etc/default/grub') }}"
 
 - name:                                "2.10.1 sap-notes: - Add GRUB arguments to the config if RHEL 8.4"
-  ansible.builtin.include_tasks:       2.10.1.1.yaml
+  ansible.builtin.include_tasks:       roles-sap-os/2.10-sap-notes/tasks/2.10.1.1.yaml
   with_dict:
     - tsx:                             'on'
     - transparent_hugepage:            'never'

--- a/deploy/ansible/roles-sap/5.0.0-scs-install/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.0.0-scs-install/tasks/main.yaml
@@ -52,7 +52,13 @@
   ansible.builtin.file:
     path:                              "{{ dir_params }}"
     state:                             directory
-    mode:                              '0755'
+    mode:                              0755
+
+- name:                                "SCS Install: Create temp directory for sid"
+  ansible.builtin.file:
+    path:                              "{{ tmp_directory }}/{{ sid_to_be_deployed.sid | upper }}"
+    state:                             directory
+    mode:                              0755
 
 - name:                                "SCS Install: Include 3.3.1-bom-utility role"
   ansible.builtin.include_role:

--- a/deploy/ansible/roles-sap/5.1-dbload/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.1-dbload/tasks/main.yaml
@@ -52,7 +52,13 @@
   ansible.builtin.file:
     path:                              "{{ dir_params }}"
     state:                             directory
-    mode:                              '0755'
+    mode:                              0755
+
+- name:                                "DBLoad: Create temp directory for sid"
+  ansible.builtin.file:
+    path:                              "{{ tmp_directory }}/{{ sid_to_be_deployed.sid | upper }}"
+    state:                             directory
+    mode:                              0755
 
 - name:                                "DBLoad: - Include 3.3.1-bom-utility role"
   ansible.builtin.include_role:

--- a/deploy/ansible/roles-sap/5.1-dbload/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.1-dbload/tasks/main.yaml
@@ -147,20 +147,10 @@
       async:                           7200
       poll:                            60
 
-    - name:                            "DBLoad Install -Wait for asynchronous job to end"
-      ansible.builtin.async_status:
-        jid:                           '{{ dbload_results.ansible_job_id }}'
-      register:                        job_result
-      until:                           job_result.finished
-      retries:                         90
-      delay:                           120
-      when:                            dbload_results.ansible_job_id is defined
-
     - name:                            "DBLoad: Installation results"
       ansible.builtin.debug:
         msg:
           - "DBLoad : {{ dbload_results }}"
-          - "Job    : {{ job_result }}"
 
 
     - name:                            "DBLoad: Installation results"

--- a/deploy/ansible/roles-sap/5.1-dbload/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.1-dbload/tasks/main.yaml
@@ -145,13 +145,22 @@
       tags:
         - skip_ansible_lint
       async:                           7200
-      poll:                            60
+      poll:                            0
+
+    - name:                            "DBLoad Install -Wait for asynchronous job to end"
+      ansible.builtin.async_status:
+        jid:                           "{{ dbload_results.ansible_job_id }}"
+      register:                        job_result
+      until:                           job_result.finished
+      retries:                         120
+      delay:                           60
+      when:                            dbload_results.ansible_job_id is defined
 
     - name:                            "DBLoad: Installation results"
       ansible.builtin.debug:
         msg:
           - "DBLoad : {{ dbload_results }}"
-
+          - "Job result: {{ job_result }}"
 
     - name:                            "DBLoad: Installation results"
       ansible.builtin.debug:

--- a/deploy/ansible/roles-sap/5.2-pas-install/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.2-pas-install/tasks/main.yaml
@@ -22,11 +22,15 @@
 #   0x) Create hidden directory for parameter files
 - name:                                "PAS Install: Create hidden directory"
   ansible.builtin.file:
-    path:                              "{{ item.path }}"
+    path:                              "{{ dir_params }}"
     state:                             directory
-    mode:                              '{{ item.mode }}'
-  loop:
-    - { state: 'directory', mode: '0755', path: '{{ dir_params }}' }
+    mode:                              0755
+
+- name:                                "PAS Install: Create temp directory for sid"
+  ansible.builtin.file:
+    path:                              "{{ tmp_directory }}/{{ sid_to_be_deployed.sid | upper }}"
+    state:                             directory
+    mode:                              0755
 
 - name:                                "PAS Install: reset"
   ansible.builtin.file:

--- a/deploy/ansible/roles-sap/5.3-app-install/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.3-app-install/tasks/main.yaml
@@ -16,11 +16,15 @@
 #   0x) Create hidden directory for parameter files
 - name:                                "APP Install: Create hidden directory"
   ansible.builtin.file:
-    path:                              "{{ item.path }}"
+    path:                              "{{ dir_params }}"
     state:                             directory
-    mode:                              '{{ item.mode }}'
-  loop:
-    - { state: 'directory', mode: '0755', path: '{{ dir_params }}' }
+    mode:                              0755
+
+- name:                                "APP Install: Create temp directory for sid"
+  ansible.builtin.file:
+    path:                              "{{ tmp_directory }}/{{ sid_to_be_deployed.sid | upper }}"
+    state:                             directory
+    mode:                              0755
 
 - name:                                "APP Install: Create run flag directory"
   ansible.builtin.file:

--- a/deploy/ansible/roles-sap/5.3-app-install/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.3-app-install/tasks/main.yaml
@@ -94,7 +94,7 @@
     sap_scs_hostname:                  "{{ scs_server }}"
     sap_db_hostname:                   "{{ db_virtual_host }}"
     sap_ciVirtualHostname:             "{{ query('inventory_hostnames', '{{ sap_sid | upper }}_APP') | first }}"
-    sap_appVirtualHostname:            "{{ inventory_hostname }}"
+    sap_appVirtualHostname:            "{{ virtual_host }}"
     param_directory:                   "{{ dir_params }}"
     sap_sid:                           "{{ sid_to_be_deployed.sid }}"
     sidadm_uid:                        "{{ sid_to_be_deployed.sidadm_uid }}"

--- a/deploy/ansible/roles-sap/5.6-scsers-pacemaker/tasks/5.6.4-provision.yml
+++ b/deploy/ansible/roles-sap/5.6-scsers-pacemaker/tasks/5.6.4-provision.yml
@@ -34,12 +34,11 @@
   block:
     - name:                            "Post SCS HA Install: check if installed"
       become:                          true
-      delegate_to:                     "{{ primary_instance_ip }}"
       ansible.builtin.stat:
         path:                          "/etc/sap_deployment_automation/{{ sap_sid | upper }}/sap_deployment_scs.txt"
       register:                        post_scs_install
       failed_when:                     not post_scs_install.stat.exists
-      when:                            ansible_hostname == secondary_instance_name
+      when:                            ansible_hostname == primary_instance_name
 
     - name:                            "Post ERS Install: check if installed"
       become:                          true

--- a/deploy/ansible/roles-sap/5.6-scsers-pacemaker/tasks/5.6.4.0-cluster-RedHat.yml
+++ b/deploy/ansible/roles-sap/5.6-scsers-pacemaker/tasks/5.6.4.0-cluster-RedHat.yml
@@ -19,10 +19,14 @@
     - name:                            "5.6 SCSERS - RHEL - Put Secondary host on standby"
       ansible.builtin.command:         pcs node standby {{ secondary_instance_name }}
 
+    - name:                            "5.6 SCSERS - RHEL - Set fact for ASCS Filesystem"
+      ansible.builtin.set_fact:
+        ascs_filesystem_device:        "{{ sap_mnt }}/usrsap{{ sap_sid }}ascs{{ scs_instance_number }}"
+
     - name:                            "5.6 SCSERS - RHEL - SCS - Configure File system resources"
       ansible.builtin.command: >
                                        pcs resource create fs_{{ sap_sid }}_ASCS Filesystem \
-                                       device='{{ sap_mnt }}/usrsap{{ sap_sid }}ascs{{ scs_instance_number }}' \
+                                       device='{{ ascs_filesystem_device }}' \
                                        directory='/usr/sap/{{ sap_sid | upper }}/ASCS{{ scs_instance_number }}' fstype='nfs' force_unmount=safe options='sec=sys,vers=4.1' \
                                        op start interval=0 timeout=60 \
                                        op stop interval=0 timeout=120 \
@@ -63,6 +67,7 @@
         path:                          "{{ item.path }}"
         owner:                         "{{ sap_sid | lower }}adm"
         group:                         sapsys
+        state:                         directory
       loop:
         - { path: '/sapmnt/{{ sap_sid | upper }}' }
         - { path: '/usr/sap/{{ sap_sid | upper }}/SYS' }
@@ -87,10 +92,14 @@
     - name:                            "5.6 SCSERS - RHEL - Put Primary host on standby"
       ansible.builtin.command:         pcs node standby {{ primary_instance_name }}
 
+    - name:                            "5.6 SCSERS - RHEL - Set fact for ERS Filesystem"
+      ansible.builtin.set_fact:
+        ers_filesystem_device:        "{{ sap_mnt }}/usrsap{{ sap_sid }}ers{{ ers_instance_number }}"
+
     - name:                            "5.6 SCSERS - RHEL - ERS - Configure File system resources"
       ansible.builtin.command: >
                                        pcs resource create fs_{{ sap_sid }}_ERS Filesystem \
-                                       device='{{ sap_mnt }}/usrsap{{ sap_sid }}ers{{ ers_instance_number }}' \
+                                       device='{{ ers_filesystem_device }}' \
                                        directory='/usr/sap/{{ sap_sid | upper }}/ERS{{ ers_instance_number }}' fstype='nfs' force_unmount=safe options='sec=sys,vers=4.1' \
                                        op start interval=0 timeout=60 \
                                        op stop interval=0 timeout=120 \
@@ -137,7 +146,7 @@
       loop:
         - { path: '/sapmnt/{{ sap_sid | upper }}' }
         - { path: '/usr/sap/{{ sap_sid | upper }}/SYS' }
-        - { path: '/usr/sap/{{ sap_sid }}/ERS{{ ers_instance_number }}' }
+        - { path: '/usr/sap/{{ sap_sid | upper }}/ERS{{ ers_instance_number }}' }
       when: inventory_hostname == secondary_instance_name
       tags:
         - skip_ansible_lint

--- a/deploy/terraform/terraform-units/modules/sap_landscape/key_vault_sap_landscape.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/key_vault_sap_landscape.tf
@@ -34,9 +34,7 @@ resource "azurerm_key_vault" "kv_user" {
         local.deployer_subnet_management_id
       ]
     )
-
   }
-
 
   lifecycle {
     ignore_changes = [


### PR DESCRIPTION
## Problem
- The variables 'primary_instance_ip_db' and 'secondary_instance_ip_db' are undefined in 4.0.1.3
- Task file '2.10.1.1.yaml' could not be found in task '2.10.1.yaml'
- The directory '{{ tmp_directory }}/{{ sid | upper }}' does not exist, resulting in installation using the wrong temp dir
- The wait for async task wails due to the job not existing anymore
- The app install uses the wrong virtual hostname during install
- Post SCS HA install fails due to delegation from ERS vm
- Pacemaker resource fails due to filesystem device not being available
- When not using a deployer the creation of the keyvault fails due to there not being a deployer subnet

## Solution
- Create the variable in playbook_04_00_01_hana_hsr.yaml
- Provide path for task file '2.10.1.1.yaml'
- Create a task to ensure the temp directory is created
- Removed the wait task. It's not needed due to the poll being present
- Update variable to use the correct hostname
- Remove the delegation and run the task directly from the Ansible controller to the SCS vm
- Make the device name, used for creating the resource, variable
- Use the Terraform compact function to ensure the list is empty and not used during creation
