### PR TITLE
Use HANA vmname instead of secondary dnsname for single nic deployments

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/outputs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/outputs.tf
@@ -23,23 +23,36 @@ output "hdb_sid" {
 // Output for DNS
 output "dns_info_vms" {
   value = local.enable_deployment ? (
-    zipmap(
-      concat(
-        (
-          var.hana_dual_nics ? slice(var.naming.virtualmachine_names.HANA_VMNAME, 0, var.database_server_count) : [""]
+    var.hana_dual_nics ? (
+      zipmap(
+        compact(
+          concat(
+            slice(var.naming.virtualmachine_names.HANA_VMNAME, 0, var.database_server_count),
+            slice(var.naming.virtualmachine_names.HANA_SECONDARY_DNSNAME, 0, var.database_server_count)
+          )
         ),
-        (
-          slice(var.naming.virtualmachine_names.HANA_SECONDARY_DNSNAME, 0, var.database_server_count)
+        compact(
+          concat(
+            slice(azurerm_network_interface.nics_dbnodes_admin[*].private_ip_address, 0, var.database_server_count),
+            slice(azurerm_network_interface.nics_dbnodes_db[*].private_ip_address, 0, var.database_server_count)
+          )
         )
-      ),
-      concat(
-        (
-          var.hana_dual_nics ? slice(azurerm_network_interface.nics_dbnodes_admin[*].private_ip_address, 0, var.database_server_count) : [""]
+      )
+    ) : (
+      zipmap(
+        compact(
+          concat(
+            slice(var.naming.virtualmachine_names.HANA_VMNAME, 0, var.database_server_count)
+          )
         ),
-        (
-          slice(azurerm_network_interface.nics_dbnodes_db[*].private_ip_address, 0, var.database_server_count)
+        compact(
+          concat(
+            slice(azurerm_network_interface.nics_dbnodes_db[*].private_ip_address, 0, var.database_server_count)
+          )
         )
-    ))) : (
+      )
+    )
+  ) : (
     null
   )
 }


### PR DESCRIPTION
## Problem
When deploying single NIC HANA VM's the HANA_SECONDARY_DNSNAME is used in the DNS ouput.

## Solution
Use the HANA_VMNAME for single nic deployments in DNS output as this is the same for the Application VM's.

## Tests

## Notes