### PR TITLE
Fix DBLoad result task

### DIFF
--- a/deploy/ansible/roles-sap/0.1-bom-validator/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/0.1-bom-validator/tasks/main.yaml
@@ -162,9 +162,12 @@
                                          --container-name {{ sapbits_location_base_path.rpartition('//')[2].split('/')[1] }}/{{ sapbits_bom_files }}/boms/{{ bom_base_name }}
                                          --name {{ bom_base_name }}.yaml
   delegate_to:                         localhost
+  register:                            azresult
   ignore_errors:                       true
   changed_when:                        false
-
+  failed_when:
+    - azresult.rc != 0
+    - azresult.stderr is defined
 
 - name:                                "0.1 BoM Validator: - Upload combined BoM"
   ansible.builtin.command: >-
@@ -179,7 +182,6 @@
                                          --no-progress
   delegate_to:                         localhost
   register:                            azresult
-  failed_when:                         false
   changed_when:                        false
   failed_when:
     - azresult.rc != 0

--- a/deploy/ansible/roles-sap/5.1-dbload/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.1-dbload/tasks/main.yaml
@@ -166,8 +166,8 @@
       ansible.builtin.debug:
         var:                           dbload_results
       when:
-        - job_result is defined
-        - job_result.rc > 0
+        - dbload_results is defined
+        - dbload_results.rc > 0
 
     - name:                            "DBLoad Install: Cleanup ini file {{ ansible_hostname }}"
       ansible.builtin.file:


### PR DESCRIPTION
## Problem
The "DBLoad: Installation results" task fails due to a variable in the when statement not existing. But on inspection the wrong variable is checked in the when clause

## Solution
Replace the variable for the correct one
