### PR TITLE
enable purge_soft_delete on destroy based on configuration

### DIFF
--- a/deploy/terraform/run/sap_landscape/providers.tf
+++ b/deploy/terraform/run/sap_landscape/providers.tf
@@ -17,6 +17,9 @@ provider "azurerm" {
     resource_group {
       prevent_deletion_if_contains_resources = true
     }
+    key_vault {
+      purge_soft_delete_on_destroy = !var.enable_purge_control_for_keyvaults
+    }
   }
   subscription_id = local.spn.subscription_id
   client_id       = var.use_spn ? local.spn.client_id : null


### PR DESCRIPTION
## Problem
When using the pipeline 10 to destroy a workload zone. It will fail if you have the purge keyvaults enabled.

```
Error: purging of Secret "DEV-WEEU-SAP01-sid-sshkey-pub" (Key Vault "https://XXX.vault.azure.net/") : keyvault.BaseClient#PurgeDeletedSecret: Failure responding to request: StatusCode=403 -- Original Error: autorest/azure: Service returned an error. Status=403 Code="Forbidden" Message="Operation \"purge\" is not allowed because purge protection is enabled for this vault. Key Vault service will automatically purge it after the retention period has passed.\r\nVault: XXX;location=westeurope" 
Error: purging of Secret "DEV-WEEU-SAP01-sid-password" (Key Vault "https://XXX.vault.azure.net/") : keyvault.BaseClient#PurgeDeletedSecret: Failure responding to request: StatusCode=403 -- Original Error: autorest/azure: Service returned an error. Status=403 Code="Forbidden" Message="Operation \"purge\" is not allowed because purge protection is enabled for this vault. Key Vault service will automatically purge it after the retention period has passed.\r\nVault: XXX;location=westeurope" 
Error: purging of Secret "DEV-WEEU-SAP01-sid-username" (Key Vault "https://XXX.vault.azure.net/") : keyvault.BaseClient#PurgeDeletedSecret: Failure responding to request: StatusCode=403 -- Original Error: autorest/azure: Service returned an error. Status=403 Code="Forbidden" Message="Operation \"purge\" is not allowed because purge protection is enabled for this vault. Key Vault service will automatically purge it after the retention period has passed.\r\nVault: XXX;location=westeurope" 
Error: purging of Secret "DEV-WEEU-SAP01-sid-sshkey" (Key Vault "https://XXX.vault.azure.net/") : keyvault.BaseClient#PurgeDeletedSecret: Failure responding to request: StatusCode=403 -- Original Error: autorest/azure: Service returned an error. Status=403 Code="Forbidden" Message="Operation \"purge\" is not allowed because purge protection is enabled for this vault. Key Vault service will automatically purge it after the retention period has passed.\r\nVault: XXX;location=westeurope" 
Error: purging of Secret "deployer-kv-name" (Key Vault "https://XXX.vault.azure.net/") : keyvault.BaseClient#PurgeDeletedSecret: Failure responding to request: StatusCode=403 -- Original Error: autorest/azure: Service returned an error. Status=403 Code="Forbidden" Message="Operation \"purge\" is not allowed because purge protection is enabled for this vault. Key Vault service will automatically purge it after the retention period has passed.\r\nVault: XXX;location=westeurope" 
Error: purging of Secret "DEV-WEEU-SAP01-witness-accesskey" (Key Vault "https://XXX.vault.azure.net/") : keyvault.BaseClient#PurgeDeletedSecret: Failure responding to request: StatusCode=403 -- Original Error: autorest/azure: Service returned an error. Status=403 Code="Forbidden" Message="Operation \"purge\" is not allowed because purge protection is enabled for this vault. Key Vault service will automatically purge it after the retention period has passed.\r\nVault: XXX;location=westeurope" 
Error: purging of Secret "DEV-WEEU-SAP01-witness-name" (Key Vault "https://XXX.vault.azure.net/") : keyvault.BaseClient#PurgeDeletedSecret: Failure responding to request: StatusCode=403 -- Original Error: autorest/azure: Service returned an error. Status=403 Code="Forbidden" Message="Operation \"purge\" is not allowed because purge protection is enabled for this vault. Key Vault service will automatically purge it after the retention period has passed.\r\nVault: XXX;location=westeurope" 
```

## Solution
To cope with this behaviour on with purge enabled you can enable the "purge_soft_delete_on_destroy" feature option on the provider. However this needs to be configurable cause not everybody runs the softdelete enabled configuration, so respect the setting in the tfvars

## Tests
1. Deploy a workload_zone with "enable_purge_control_for_keyvaults=true"
1. Remove the workloadzone using the pipeline 10

## Notes
none