### PR TITLE
optionally retrieve STATE_SUBSCRIPTION

### DIFF
--- a/deploy/scripts/set_secrets.sh
+++ b/deploy/scripts/set_secrets.sh
@@ -143,7 +143,9 @@ fi
 
 if [ "$workload" != 1 ]; then
     load_config_vars "${environment_config_information}" "STATE_SUBSCRIPTION"
-    subscription=${STATE_SUBSCRIPTION}
+    if [ "$STATE_SUBSCRIPTION" ]; then
+        subscription=${STATE_SUBSCRIPTION}
+    fi
 fi
 
 if [ -z "$keyvault" ]; then


### PR DESCRIPTION


## Problem
Previously, STATE_SUBSCRIPTION would always override subscription.  If STATE_SUBSCRIPTION was not set, it would still override subscription, even if it was on the command line.

## Solution
Make the set surrounded by a if [-z STATE_SUBSCRIPTION]

## Tests
This worked in my subscription

## Notes
<Additional comments for the PR>