### PR TITLE
Fixes to generate sas token at runtime using account key while downloading SAP bits/validating if the bits are already downloaded.

### DIFF
--- a/deploy/ansible/roles-sap/0.1-bom-validator/tasks/bom_download.yaml
+++ b/deploy/ansible/roles-sap/0.1-bom-validator/tasks/bom_download.yaml
@@ -135,7 +135,7 @@
       ansible.builtin.command: >-
                                        az storage blob upload
                                          --account-name {{ account }}
-                                         --account-key {{ sapbits_access_key }}
+                                         --sas-token {{ sapbits_sas_token }}
                                          --container-name {{ container }}
                                          --name {{ item.archive }}
                                          --file {{ result.dest }}

--- a/deploy/ansible/roles-sap/0.1-bom-validator/tasks/bom_validator.yaml
+++ b/deploy/ansible/roles-sap/0.1-bom-validator/tasks/bom_validator.yaml
@@ -71,6 +71,31 @@
 #   02) Validate media from SAP
 #   Loop through BOM media URLs
 
+- name:                                "BoM Validator: - Extract SAP Binaries Storage Account SAS secret"
+  block:
+
+    - name:                            "BoM Validator: - Set Expiry"
+      ansible.builtin.command:         "date +'%Y-%m-%d' -d '+3 days'"
+      register: expiry
+
+    - name:                            "BoM Validator: - Create SAP Binaries Storage Account SAS"
+      ansible.builtin.shell: >-
+                                       az storage account generate-sas \
+                                         --services b \
+                                         --resource-types sco \
+                                         --permissions cdlrw \
+                                         --account-name {{ sapbits_location_base_path.rpartition('//')[2].split('.')[0] }} \
+                                         --account-key {{ sapbits_access_key }} \
+                                         --expiry {{ expiry.stdout }} \
+                                         | tr -d \"
+      changed_when:                    false
+      register:                        az_sapbits_sas_token
+
+    - name:                            "BoM Validator: - Extract SAP Binaries Storage Account SAS (temp)"
+      ansible.builtin.set_fact:
+        sapbits_sas_token: >-
+                                       {{ az_sapbits_sas_token.stdout }}
+
 - name:                                "0.1 BoM Validator: - BOM: {{ bom_name }} Check and Download Files"
   ansible.builtin.include_tasks:       bom_download.yaml
 
@@ -85,7 +110,7 @@
   ansible.builtin.command: >-
                                        az storage blob delete-batch
                                          --account-name {{ sapbits_location_base_path.rpartition('//')[2].split('.')[0] }}
-                                         --account-key {{ sapbits_access_key }}
+                                         --sas-token {{ sapbits_sas_token }}
                                          --source {{ sapbits_location_base_path.rpartition('//')[2].split('/')[1] }}
                                          --pattern "{{ sapbits_bom_files }}/boms/{{ bom_base_name }}/templates/*"
   delegate_to:                         localhost

--- a/deploy/ansible/roles-sap/0.1-bom-validator/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/0.1-bom-validator/tasks/main.yaml
@@ -67,7 +67,7 @@
   ansible.builtin.command: >-
                                        az storage blob upload
                                          --account-name {{ sapbits_location_base_path.rpartition('//')[2].split('.')[0] }}
-                                         --account-key {{ sapbits_access_key }}
+                                         --sas-token {{ sapbits_sas_token }}
                                          --container-name {{ sapbits_location_base_path.rpartition('//')[2].split('/')[1] }}/{{ sapbits_bom_files }}/archives
                                          --name readme.md
                                          --file {{ readme_file.dest }}
@@ -158,7 +158,7 @@
   ansible.builtin.command: >-
                                        az storage blob delete
                                          --account-name {{ sapbits_location_base_path.rpartition('//')[2].split('.')[0] }}
-                                         --account-key {{ sapbits_access_key }}
+                                         --sas-token {{ sapbits_sas_token }}
                                          --container-name {{ sapbits_location_base_path.rpartition('//')[2].split('/')[1] }}/{{ sapbits_bom_files }}/boms/{{ bom_base_name }}
                                          --name {{ bom_base_name }}.yaml
   delegate_to:                         localhost
@@ -174,7 +174,7 @@
   ansible.builtin.command: >-
                                        az storage blob upload
                                          --account-name {{ sapbits_location_base_path.rpartition('//')[2].split('.')[0] }}
-                                         --account-key {{ sapbits_access_key }}
+                                         --sas-token {{ sapbits_sas_token }}
                                          --container-name {{ sapbits_location_base_path.rpartition('//')[2].split('/')[1] }}/{{ sapbits_bom_files }}/boms/{{ bom_base_name }}
                                          --name {{ bom_base_name }}.yaml
                                          --file {{ download_directory }}/bom/{{ bom_base_name }}.yaml


### PR DESCRIPTION
downloading SAP bits/validating if the bits are already downloaded.

## Problem
While updating the SAP bits, the bom downloader script intends to validate if storage account already has the sap archive present. For this, it was using sas token. However, if sas token is not required as account key is taken as input already from whih sas token can be generated at runtime. 

## Solution
Generated sas token as part of bom validator and registered it in sapbits_sas_token. This is used for all further az storage operations.

## Tests
Run the bom downloader without passing sas token as argument. If files are aready downoaded, redownload should get skipped.

## Notes
<Additional comments for the PR>