### PR TITLE
Kernel parameter perf_event_paranoid should be set to 2

### DIFF
--- a/deploy/ansible/roles-os/1.9-kernelparameters/vars/parameters.yaml
+++ b/deploy/ansible/roles-os/1.9-kernelparameters/vars/parameters.yaml
@@ -27,7 +27,7 @@ parameters:
     - { tier: 'os', name: 'kernel.ctrl-alt-del',                           value: '0',                        state: 'present' }
     - { tier: 'os', name: 'kernel.dmesg_restrict',                         value: '1',                        state: 'present' }
     - { tier: 'os', name: 'kernel.kptr_restrict',                          value: '2',                        state: 'present' }
-    - { tier: 'os', name: 'kernel.perf_event_paranoid',                    value: '3',                        state: 'present' }
+    - { tier: 'os', name: 'kernel.perf_event_paranoid',                    value: '2',                        state: 'present' }
     - { tier: 'os', name: 'kernel.randomize_va_space',                     value: '2',                        state: 'present' }
     - { tier: 'os', name: 'kernel.sysrq',                                  value: '0',                        state: 'present' }
     - { tier: 'os', name: 'net.ipv4.conf.all.accept_redirects',            value: '0',                        state: 'present' }


### PR DESCRIPTION
## Problem
The kernel parameter perf_event_paranoid is currently set by the code to the value of 3 which is invalid.

The kernel.perf_event_paranoid sysctl key defines how paranoid the kernel should be related to performance monitoring.

* perf event paranoia level (from kernel/perf_event.c)
-1 - not paranoid at all
0 - disallow raw tracepoint access for unprivileged users
1 - disallow CPU events for unprivileged users
2 - disallow kernel profiling for unprivileged users

## Solution
Set the perf_event_paranoid parameter to 2 (default value)

## Tests

## Notes
https://sysctl-explorer.net/kernel/perf_event_paranoid/
https://www.kernel.org/doc/Documentation/sysctl/kernel.txt