### PR TITLE
Kernel parameter kptr_restrict should be set to 1

### DIFF
--- a/deploy/ansible/roles-os/1.9-kernelparameters/vars/parameters.yaml
+++ b/deploy/ansible/roles-os/1.9-kernelparameters/vars/parameters.yaml
@@ -26,7 +26,7 @@ parameters:
     - { tier: 'os', name: 'kernel.core_uses_pid',                          value: '1',                        state: 'present' }
     - { tier: 'os', name: 'kernel.ctrl-alt-del',                           value: '0',                        state: 'present' }
     - { tier: 'os', name: 'kernel.dmesg_restrict',                         value: '1',                        state: 'present' }
-    - { tier: 'os', name: 'kernel.kptr_restrict',                          value: '2',                        state: 'present' }
+    - { tier: 'os', name: 'kernel.kptr_restrict',                          value: '1',                        state: 'present' }
     - { tier: 'os', name: 'kernel.perf_event_paranoid',                    value: '3',                        state: 'present' }
     - { tier: 'os', name: 'kernel.randomize_va_space',                     value: '2',                        state: 'present' }
     - { tier: 'os', name: 'kernel.sysrq',                                  value: '0',                        state: 'present' }


### PR DESCRIPTION
## Problem
The kernel parameter kptr_restrict is currently set by the code to the value of 2 which is marked as unsafe. I can't find a SAP note that requires this value to be set to 2 so I want to change the value to 1.

## Solution
Set the kernel.kptr_restrict parameter to 1

## Tests

## Notes
https://sysctl-explorer.net/kernel/kptr_restrict/
https://www.stigviewer.com/stig/red_hat_enterprise_linux_8/2021-12-03/finding/V-230547