### PR TITLE
Improve security level for SAPHanaSR hook sudo file

### DIFF
--- a/deploy/ansible/roles-os/1.11-accounts/templates/sudoers_hanaadmin_no_password.j2
+++ b/deploy/ansible/roles-os/1.11-accounts/templates/sudoers_hanaadmin_no_password.j2
@@ -1,3 +1,10 @@
 # User rules for {{ hanasudoers_file }} with role {{ hanasudoers_role }}
-{{ db_sid | lower }}adm ALL=(ALL) NOPASSWD:ALL
-{{ db_sid | lower }}adm ALL=(ALL) NOPASSWD: /usr/sbin/crm_attribute -n hana_{{ db_sid | lower }}_site_srHook_*
+
+Cmnd_Alias SITEA_SOK   = /usr/sbin/crm_attribute -n hana_{{ db_sid | lower }}_site_srHook_SITEA -v SOK -t crm_config -s SAPHanaSR
+Cmnd_Alias SITEA_SFAIL = /usr/sbin/crm_attribute -n hana_{{ db_sid | lower }}_site_srHook_SITEA -v SFAIL -t crm_config -s SAPHanaSR
+Cmnd_Alias SITEB_SOK   = /usr/sbin/crm_attribute -n hana_{{ db_sid | lower }}_site_srHook_SITEB -v SOK -t crm_config -s SAPHanaSR
+Cmnd_Alias SITEB_SFAIL = /usr/sbin/crm_attribute -n hana_{{ db_sid | lower }}_site_srHook_SITEB -v SFAIL -t crm_config -s SAPHanaSR
+
+{{ db_sid | lower }}adm ALL=(ALL) NOPASSWD: SITEA_SOK, SITEA_SFAIL, SITEB_SOK, SITEB_SFAIL
+
+Defaults!SITEA_SOK, SITEA_SFAIL, SITEB_SOK, SITEB_SFAIL !requiretty


### PR DESCRIPTION
## Problem
The current sudo rules for the <sid>adm user on HANA nodes allows it to become root for all commands. This isn't required and not safe.

## Solution
Use specific sudo rules for the <sid>adm user to limit the elevated permissions for the SAPHanaSR hook cluster attribute update commands.

## Tests

## Notes
https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/sap-hana-high-availability-rhel
https://access.redhat.com/articles/3004101
https://access.redhat.com/solutions/6315931
https://documentation.suse.com/sbp/all/html/SLES4SAP-hana-sr-guide-CostOpt-12/index.html