### PR TITLE
Removed duplicate hosts file task

### DIFF
--- a/deploy/ansible/roles-sap/5.6-scsers-pacemaker/tasks/5.6.3-prep_steps.yml
+++ b/deploy/ansible/roles-sap/5.6-scsers-pacemaker/tasks/5.6.3-prep_steps.yml
@@ -31,22 +31,6 @@
 
 # @TODO - Update of SAP resource agents - do we need to do anything for SLES 15 ? The documentation is not clear
 
-
-# [A] Setup host name resolution
-# @TODO - if the following does not work we can keep it simple
-
-- name:                               "5.6 SCSERS - Hostname: Setup Virtual host name resolution - SCS & ERS"
-  ansible.builtin.blockinfile:
-    path:                             /etc/hosts
-    mode:                             0644
-    create:                           true
-    state:                            present
-    block: |
-                                      {{ scs_lb_ip }} {{ scs_virtual_hostname }}.{{ sap_fqdn }} {{ scs_virtual_hostname }}
-                                      {{ ers_lb_ip }} {{ ers_virtual_hostname }}.{{ sap_fqdn }} {{ ers_virtual_hostname }}
-    marker:                           "# {mark} ASCS/ERS Entries {{ scs_virtual_hostname }}"
-  register:                           scsersvirhosts
-
 # [A] Add mount entries - RHEL
 
 # [A] Configure SWAP file


### PR DESCRIPTION
## Problem
The /etc/hosts file gets filled with the SCS/ERS loadbalancer items even though role `2.4-hosts-file` is skipped by using tags.
This is due to the task also being present in 5.6.3

## Solution
Removed the duplicate task from 5.6.3 as it is already present at: https://github.com/Azure/sap-automation/blob/experimental/deploy/ansible/roles-sap-os/2.4-hosts-file/tasks/main.yaml#L52