### PR TITLE
Add idle timeout to lbs rules

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/infrastructure.tf
@@ -189,6 +189,7 @@ resource "azurerm_lb_rule" "scs" {
   probe_id                 = azurerm_lb_probe.scs[0].id
   enable_floating_ip       = true
   enable_tcp_reset         = true
+  idle_timeout_in_minutes  = var.idle_timeout_scs_ers
 }
 
 # Create the ERS Load balancer rules only in High Availability configurations
@@ -215,6 +216,7 @@ resource "azurerm_lb_rule" "ers" {
   probe_id                 = azurerm_lb_probe.scs[1].id
   enable_floating_ip       = true
   enable_tcp_reset         = true
+  idle_timeout_in_minutes  = var.idle_timeout_scs_ers
 }
 
 resource "azurerm_lb_rule" "clst" {

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_global.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_global.tf
@@ -79,12 +79,16 @@ variable "cloudinit_growpart_config" {
 variable "license_type" {
   description = "Specifies the license type for the OS"
   default     = ""
-
 }
 
 variable "use_loadbalancers_for_standalone_deployments" {
   description = "Defines if load balancers are used even for standalone deployments"
   default     = true
+}
+
+variable "idle_timeout_scs_ers" {
+  description = "Sets the idle timeout setting for the SCS and ERS loadbalancer"
+  default     = 4
 }
 
 variable "network_location" {


### PR DESCRIPTION
## Problem
The SCS and ERS loadbalancer rules have an idle timeout setting of 4 minutes.
This is due to not specifying the timeout

## Solution
Added a variable to set the idle timeout of the SCS and ERS loadbalancer rules

## Notes
https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/high-availability-guide-rhel
https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/high-availability-guide-rhel-nfs-azure-files
https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/high-availability-guide-rhel-netapp-files