### PR TITLE
Change S4 hana 2020 name to SAP S/4HANA 2020 SPS 03

### DIFF
--- a/deploy/ansible/BOM-catalog/S42020SPS03_v0002ms/S42020SPS03_v0002ms.yaml
+++ b/deploy/ansible/BOM-catalog/S42020SPS03_v0002ms/S42020SPS03_v0002ms.yaml
@@ -1,6 +1,7 @@
 ---
 
-name:      "SAP S/4HANA 2020 SPS 02"
+name:      "SAP S/4HANA 2020 SPS 03"
+filename:  "S42020SPS03_v0002ms"
 target:    'S/4 HANA 2020 SPS 01'
 version:   1
 platform:  HANA


### PR DESCRIPTION
## Problem
Patch version was wrong.
## Solution
Change patch version from SPS 02 to SPS 03

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>