### PR TITLE
Update bom.j2 to add endline character after filename

### DIFF
--- a/deploy/ansible/roles-sap/0.1-bom-validator/templates/bom.j2
+++ b/deploy/ansible/roles-sap/0.1-bom-validator/templates/bom.j2
@@ -1,5 +1,6 @@
 name:      {{ root_bom.name }}
 filename:  {% if root_bom.filename is defined %}{{ root_bom.filename }}{% endif %}
+
 target:    {{ root_bom.target }}
 version:   {{ root_bom.version }}
 platform:  {% if root_bom.platform is defined %}{{ root_bom.platform }}{% endif %}


### PR DESCRIPTION
## Problem
Filename and target are coming in same line.

## Solution
Add a new line character after filename

## Tests
Tested by running the playbook with new change
<img width="361" alt="image" src="https://user-images.githubusercontent.com/22003339/182827665-c5d06de9-ef50-40b7-b225-b70f1fa2682e.png">


## Notes
<Additional comments for the PR>