### PR TITLE
Commenting out the boot_time_command to solve bug

### DIFF
--- a/deploy/ansible/roles-sap-os/2.10-sap-notes/handlers/main.yaml
+++ b/deploy/ansible/roles-sap-os/2.10-sap-notes/handlers/main.yaml
@@ -2,7 +2,7 @@
 
 - name: "2.10-sap-notes: Reboot after the selinux is configured"
   ansible.builtin.reboot:
-    reboot_timeout: 3600
-    boot_time_command: "cat /proc/uptime"
+#    reboot_timeout: 3600
+#    boot_time_command: "cat /proc/uptime"
 
 # ...


### PR DESCRIPTION
    Commenting out the following lines to resolve an error
    reboot_timeout: 3600
    boot_time_command: "cat /proc/uptime"

## Problem
Error:  The ansible task 'roles-sap-os/2.10-sap-notes : 2.10-sap-notes: Reboot after the selinux is configured' has failed on host s02dbzavm, s02dbzbvm.

## Solution
'boot_time_command' was removed from the experimental branch to resolve this issue , but remains in Main branch

## Tests
Successful Install workflow execution 

## Notes
<Additional comments for the PR>