### PR TITLE
Remove spaces from sudoers template

### DIFF
--- a/deploy/ansible/roles-os/1.11-accounts/templates/sudoers_hanaadmin_no_password.j2
+++ b/deploy/ansible/roles-os/1.11-accounts/templates/sudoers_hanaadmin_no_password.j2
@@ -7,4 +7,4 @@ Cmnd_Alias SITEB_SFAIL = /usr/sbin/crm_attribute -n hana_{{ db_sid | lower }}_si
 
 {{ db_sid | lower }}adm ALL=(ALL) NOPASSWD: SITEA_SOK, SITEA_SFAIL, SITEB_SOK, SITEB_SFAIL
 
-Defaults!SITEA_SOK, SITEA_SFAIL, SITEB_SOK, SITEB_SFAIL !requiretty
+Defaults!SITEA_SOK,SITEA_SFAIL,SITEB_SOK,SITEB_SFAIL !requiretty


### PR DESCRIPTION
## Problem
A syntax error occurs in parsing the sudoers file

## Solution
Removed spaces from the template
