### PR TITLE
Added checksums for S4Hana2020 Bom.

### DIFF
--- a/deploy/ansible/BOM-catalog/HANA_2_00_064_v0001ms/HANA_2_00_064_v0001ms.yaml
+++ b/deploy/ansible/BOM-catalog/HANA_2_00_064_v0001ms/HANA_2_00_064_v0001ms.yaml
@@ -1,5 +1,5 @@
 ---
-name:               'HANA_2_00_063_v0001ms'
+name:               'HANA_2_00_064_v0001ms'
 target:             'HANA 2.0'
 version:            1
 platform:           'HANA'

--- a/deploy/ansible/BOM-catalog/S42020SPS03_v0003ms/S42020SPS03_v0003ms.yaml
+++ b/deploy/ansible/BOM-catalog/S42020SPS03_v0003ms/S42020SPS03_v0003ms.yaml
@@ -40,26 +40,31 @@
         # kernel components
         - name: "Kernel Part I (785)"
           archive: SAPEXE_100-80005374.SAR
+          checksum: 31002d86645b5ed2f03a5ee5508083939b0e219116e2a7a126c3930beb642888
           url: https://softwaredownloads.sap.com/file/0020000000249732022
           path: download_basket
     
         - name: "Kernel Part II (785)"
           archive: SAPEXEDB_100-80005373.SAR
+          checksum: 05a16e9ba5c6c882972fc37ee09c675ca5c06e02d56ea3cd36e39aa0bb809b37
           url: https://softwaredownloads.sap.com/file/0020000000250002022
           path: download_basket
     
         - name: "SAP HOST AGENT 7.22 SP57"
           archive: SAPHOSTAGENT57_57-80004822.SAR
+          checksum: cb016253932342c0dde6c2a89edfcf5a7c38af0ed3f72b841eb5249a88467648
           url: https://softwaredownloads.sap.com/file/0020000000983272022
           path: download_basket
     
         - name: "Installation for SAP IGS integrated in SAP Kernel"
           archive: igsexe_1-70005417.sar
+          checksum: 31e299129fa931c05fb93fcc53f89b568629cb199bca027ac3ee9b7986025629
           url: https://softwaredownloads.sap.com/file/0020000000535042021
           path: download_basket
     
         - name: "SAP IGS Fonts and Textures"
           archive: igshelper_17-10010245.sar
+          checksum: bc405afc4f8221aa1a10a8bc448f8afd9e4e00111100c5544097240c57c99732
           url: https://softwaredownloads.sap.com/file/0020000000703122018
           path: download_basket
     
@@ -67,131 +72,158 @@
     
         - name: "File on DVD - S4CORE105_INST_EXPORT_1.zip"
           archive: S4CORE105_INST_EXPORT_1.zip
+          checksum: bf8ea8d901a9be19b008b20025d9120360c53277e8bc08b31ca7ff837718eadc
           url: https://softwaredownloads.sap.com/file/0030000001666752020
           path: download_basket
     
         - name: "File on DVD - S4CORE105_INST_EXPORT_2.zip"
           archive: S4CORE105_INST_EXPORT_2.zip
+          checksum: 8443085add99ad782c6d1be039ceeac1865a6a78fe448835f8af5ff06c62f116
           url: https://softwaredownloads.sap.com/file/0030000001666922020
           path: download_basket
     
         - name: "File on DVD - S4CORE105_INST_EXPORT_3.zip"
           archive: S4CORE105_INST_EXPORT_3.zip
+          checksum: b3291c94a1981097f6a24936d99a1c5002a319acffcb0be806e54a4359075274
           url: https://softwaredownloads.sap.com/file/0030000001667002020
           path: download_basket
     
         - name: "File on DVD - S4CORE105_INST_EXPORT_4.zip"
           archive: S4CORE105_INST_EXPORT_4.zip
+          checksum: 56412f68d17920c8cffb6d1af0d39a60c73b8d47a2b572bed38eafd3e31956b1
           url: https://softwaredownloads.sap.com/file/0030000001667012020
           path: download_basket
     
         - name: "File on DVD - S4CORE105_INST_EXPORT_5.zip"
           archive: S4CORE105_INST_EXPORT_5.zip
+          checksum: 1ec1bbac65617081ab4ca20976d99d4824a2e9cd8371743059adc4add01d4180
           url: https://softwaredownloads.sap.com/file/0030000001667022020
           path: download_basket
     
         - name: "File on DVD - S4CORE105_INST_EXPORT_6.zip"
           archive: S4CORE105_INST_EXPORT_6.zip
+          checksum: 2186941d7584d21e718fe2ab2e9df92221d4322751d317dabc9131f37c7c2a2f
           url: https://softwaredownloads.sap.com/file/0030000001667032020
           path: download_basket
     
         - name: "File on DVD - S4CORE105_INST_EXPORT_7.zip"
           archive: S4CORE105_INST_EXPORT_7.zip
+          checksum: a569ca20838ad888ec881024840c4a31db5c76ae2dbb4ba31f6e2f1ac9cd18a8
           url: https://softwaredownloads.sap.com/file/0030000001667052020
           path: download_basket
     
         - name: "File on DVD - S4CORE105_INST_EXPORT_8.zip"
           archive: S4CORE105_INST_EXPORT_8.zip
+          checksum: b94fab3ede5a111b1709af65352c835d531407fb09e12a146fdc97a61786b592
           url: https://softwaredownloads.sap.com/file/0030000001667062020
           path: download_basket
     
         - name: "File on DVD - S4CORE105_INST_EXPORT_9.zip"
           archive: S4CORE105_INST_EXPORT_9.zip
+          checksum: 14c2982a43f9f61cd2446fff6474e0368bcc27799883c6a06768783d06698322
           url: https://softwaredownloads.sap.com/file/0030000001667072020
           path: download_basket
+
         - name: "File on DVD - S4CORE105_INST_EXPORT_10.zip"
           archive: S4CORE105_INST_EXPORT_10.zip
+          checksum: 53223fe52caae836b0a63a673e9d8f5e9a3b767d1139c9380a56030a652a13fa
           url: https://softwaredownloads.sap.com/file/0030000001666762020
           path: download_basket
     
         - name: "File on DVD - S4CORE105_INST_EXPORT_11.zip"
           archive: S4CORE105_INST_EXPORT_11.zip
+          checksum: 41a07b3a213ddf3a2ce2ebcdf971e325ee2c9c725495c0908bd5772f43efd5d9
           url: https://softwaredownloads.sap.com/file/0030000001666772020
           path: download_basket
     
         - name: "File on DVD - S4CORE105_INST_EXPORT_12.zip"
           archive: S4CORE105_INST_EXPORT_12.zip
+          checksum: c8dc600b858ffa32d99e4e1aa18b632674c55e2cf1d2d38e88ac968b78ead2ab
           url: https://softwaredownloads.sap.com/file/0030000001666782020
           path: download_basket
     
         - name: "File on DVD - S4CORE105_INST_EXPORT_13.zip"
           archive: S4CORE105_INST_EXPORT_13.zip
+          checksum: 005012e0736bd8ee7f5862c23d5be3d9172d7a7efac6c50553561806ecc8442b
           url: https://softwaredownloads.sap.com/file/0030000001666802020
           path: download_basket
     
         - name: "File on DVD - S4CORE105_INST_EXPORT_14.zip"
           archive: S4CORE105_INST_EXPORT_14.zip
+          checksum: d1b012b1694c55aee5b1e158d11d9d7831742affda319749bbd71ebc5db16c04
           url: https://softwaredownloads.sap.com/file/0030000001666842020
           path: download_basket
     
         - name: "File on DVD - S4CORE105_INST_EXPORT_15.zip"
           archive: S4CORE105_INST_EXPORT_15.zip
+          checksum: a9925856644cec2404956e17218dc0d7555cbcb8c402d007faa7c0beac1b0f8a
           url: https://softwaredownloads.sap.com/file/0030000001666862020
           path: download_basket
     
         - name: "File on DVD - S4CORE105_INST_EXPORT_16.zip"
           archive: S4CORE105_INST_EXPORT_16.zip
+          checksum: 473282155d7e5a9d86312d4f95b1df350d952b32ffd4494b29b1228746484d02
           url: https://softwaredownloads.sap.com/file/0030000001666872020
           path: download_basket
     
         - name: "File on DVD - S4CORE105_INST_EXPORT_17.zip"
           archive: S4CORE105_INST_EXPORT_17.zip
+          checksum: b00799a132ae3b6f0798791c0a8389090ee6fe64895898b2f9bf37a7881e1836
           url: https://softwaredownloads.sap.com/file/0030000001666882020
           path: download_basket
     
         - name: "File on DVD - S4CORE105_INST_EXPORT_18.zip"
           archive: S4CORE105_INST_EXPORT_18.zip
+          checksum: 23552a7bf21e0b92765e9778b6f081e11680a58c4d7d63c8598ee95d5879a9d1
           url: https://softwaredownloads.sap.com/file/0030000001666892020
           path: download_basket
     
         - name: "File on DVD - S4CORE105_INST_EXPORT_19.zip"
           archive: S4CORE105_INST_EXPORT_19.zip
+          checksum: 9d60e53217e0566b05fe06dc7dfde016d2f8f259c73fef6064b5a4f1772a24f8
           url: https://softwaredownloads.sap.com/file/0030000001666912020
           path: download_basket
     
         - name: "File on DVD - S4CORE105_INST_EXPORT_20.zip"
           archive: S4CORE105_INST_EXPORT_20.zip
+          checksum: fc6eae3d201d3b839deab2f7196976b40408bd24bf5ea85183235790e483e8cc
           url: https://softwaredownloads.sap.com/file/0030000001666932020
           path: download_basket
     
         - name: "File on DVD - S4CORE105_INST_EXPORT_21.zip"
           archive: S4CORE105_INST_EXPORT_21.zip
+          checksum: f76a740da5218d8445ef028b501fff8486b4eb315367f70dba93940f4bfdf6e5
           url: https://softwaredownloads.sap.com/file/0030000001666942020
           path: download_basket
     
         - name: "File on DVD - S4CORE105_INST_EXPORT_22.zip"
           archive: S4CORE105_INST_EXPORT_22.zip
+          checksum: f5b2af2bca509a8cfa1738e23490ef646a657abffd7c94863abd445057f60ad8
           url: https://softwaredownloads.sap.com/file/0030000001666952020
           path: download_basket
     
         - name: "File on DVD - S4CORE105_INST_EXPORT_23.zip"
           archive: S4CORE105_INST_EXPORT_23.zip
+          checksum: db4f4b1e52665fbf9b8a98ee36c3f702e3aaec3cd9278f5ad6b7d777693a7810
           url: https://softwaredownloads.sap.com/file/0030000001666982020
           path: download_basket
     
         - name: "File on DVD - S4CORE105_INST_EXPORT_24.zip"
           archive: S4CORE105_INST_EXPORT_24.zip
+          checksum: 7d78b729a8c5ff021e943a2decfb4c8c047458b1848939e50edf37c6915fc46b
           url: https://softwaredownloads.sap.com/file/0030000001666992020
           path: download_basket
     
         # Language packs, only add the mandatory ones i.e. German and English
         - name: "File on DVD - S4HANAOP105_ERP_LANG_DE.SAR"
           archive: S4HANAOP105_ERP_LANG_DE.SAR
+          checksum: 4955bd2b211c68f5f6c6de5d9e36b3a2b24c47b4a5aff8912d75fb9339b60b39
           url: https://softwaredownloads.sap.com/file/0030000001665632020
           path: download_basket
     
         - name: "File on DVD - S4HANAOP105_ERP_LANG_EN.SAR"
           archive: S4HANAOP105_ERP_LANG_EN.SAR
+          checksum: 5465d21fca61b06d32371103e12ba4216210ccc1727e95fba9eb9aef6aa0f29b
           url: https://softwaredownloads.sap.com/file/0030000001665642020
           path: download_basket
     
@@ -199,651 +231,775 @@
     
         - name: "Attribute Change Package 17 for EA-HR 608"
           archive: EA-HR608.SAR
+          checksum: 2a772c2fb7466b6de3b5c54354ae4b08d5e2daf5e916ce244aa2d4586ec32ad1
           url: https://softwaredownloads.sap.com/file/0010000000059642016
           download: false
     
         - name: "Attribute Change Package 26 for GBX01HR5 605"
           archive: GBX01HR5605.SAR
+          checksum: 2e0fb0fa90bca1c152edf6669f7d7118886acffb782506aa45c5a63b6a04fd34
           url: https://softwaredownloads.sap.com/file/0010000000033172015
           download: false
     
         - name: "Attribute Change Package 19 for GBX01HR 600"
           archive: GBX01HR600.SAR
+          checksum: 92e966f40681b11bad6c7bcd068387fdcf196974592aca6e0fae01267ff8a75e
           url: https://softwaredownloads.sap.com/file/0010000000029982015
           download: false
     
         - name: "S4CEXT 105: SP 0001"
           archive: K-10501INS4CEXT.SAR
+          checksum: b472792d9b2fb2b53749ce0822b0d3a59fde36821b7910dc74bd17cd22e72c01
           url: https://softwaredownloads.sap.com/file/0010000000025122021
           download: false
     
         - name: "S4CORE 105: SP 0001"
           archive: K-10501INS4CORE.SAR
+          checksum: 55d1915b8d3a33cd9d65fe2a766c28ef3a8c8479b8a3ffcd470ac9389628cc77
           url: https://softwaredownloads.sap.com/file/0010000000077602021
           download: false
     
         - name: "S4COREOP 105: SP 0001"
           archive: K-10501INS4COREOP.SAR
+          checksum: 03aaf041215edfab2459364fdd21ec32be3cd5c727ed5010eda8fd8be0eb33f0
           url: https://softwaredownloads.sap.com/file/0010000000025142021
           download: false
     
         - name: "S4DEPREC 105: SP 0001"
           archive: K-10501INS4DEPREC.SAR
+          checksum: f3ae490937bdef9e3acc66840a3516483f48287a9e95bd545acbee70090c5a55
           url: https://softwaredownloads.sap.com/file/0010000000595472021
           download: false
     
         - name: "S4FND 105: SP 0001"
           archive: K-10501INS4FND.SAR
+          checksum: dec006c44317bb236ebefabdae72dc062c48cc26bf2bf7afe7afed6cbc404674
           url: https://softwaredownloads.sap.com/file/0010000000025152021
           download: false
     
         - name: "S4CEXT 105: SP 0002"
           archive: K-10502INS4CEXT.SAR
+          checksum: 6e5fa3979ddc125c1c03ccbf65c5f93012ce1265ff855d4d895872b888614e70
           url: https://softwaredownloads.sap.com/file/0010000000595482021
           download: false
     
         - name: "S4CORE 105: SP 0002"
           archive: K-10502INS4CORE.SAR
+          checksum: f3156dde62101ded74f2457feafff2e25202c9c9d3d23740cfd163224a8fcdce
           url: https://softwaredownloads.sap.com/file/0010000000596032021
           download: false
     
         - name: "S4COREOP 105: SP 0002"
           archive: K-10502INS4COREOP.SAR
+          checksum: 0c6a1697c05d1d61d002ddaaeaae4e1352a0cbb37bb0a1b882d0faf9a439a2cb
           url: https://softwaredownloads.sap.com/file/0010000000595492021
           download: false
     
         - name: "S4DEPREC 105: SP 0002"
           archive: K-10502INS4DEPREC.SAR
+          checksum: c1649f0fd111c4e0bde0375943f3fb8b5f64af1722f474b1a0cd87de67aba2e1
           url: https://softwaredownloads.sap.com/file/0010000001433082021
           download: false
     
         - name: "S4FND 105: SP 0002"
           archive: K-10502INS4FND.SAR
+          checksum: bb3a888bd142ec9981d2432adf26f97f4912ba9d2d7485b6b3598027cf623ae5
           url: https://softwaredownloads.sap.com/file/0010000000595502021
           download: false
     
         - name: "S4CEXT 105: SP 0003"
           archive: K-10503INS4CEXT.SAR
+          checksum: a9a2e74f45b87f211bcbb7a579a0cee4209bd95b6afb515c3a85b1c9a365c1f5
           url: https://softwaredownloads.sap.com/file/0010000001433092021
           download: false
     
         - name: "S4CORE 105: SP 0003"
           archive: K-10503INS4CORE.SAR
+          checksum: 43d5b2aea853e5fd1da1e8298b9d97a28085b12b5cf3722d90ea6de2e0045286
           url: https://softwaredownloads.sap.com/file/0010000001431422021
           download: false
     
         - name: "S4COREOP 105: SP 0003"
           archive: K-10503INS4COREOP.SAR
+          checksum: e6b0947d1486e959cbd5af90a338809276b7f226c486db1e80453785168c56d8
           url: https://softwaredownloads.sap.com/file/0010000001433102021
           download: false
     
         - name: "S4FND 105: SP 0003"
           archive: K-10503INS4FND.SAR
+          checksum: c2f15200929f18af1e28a3c1577107f6efa4f322da78a3621f2387fa2a33729c
           url: https://softwaredownloads.sap.com/file/0010000001433122021
           download: false
     
         - name: "S4CRM 205: SP 0001"
           archive: K-20501INS4CRM.SAR
+          checksum: b136ca4b7cc626f162f772f2866ae0cd7d6953190feb5aa64bc5ba6514a00b0a
           url: https://softwaredownloads.sap.com/file/0010000000025162021
           download: false
     
         - name: "S4CRM 205: SP 0002"
           archive: K-20502INS4CRM.SAR
+          checksum: 88f62010f2608a49091df90bc96e134cd9d1a27093992dce98b44be4ff4c632b
           url: https://softwaredownloads.sap.com/file/0010000000595512021
           download: false
     
         - name: "S4CRM 205: SP 0003"
           archive: K-20503INS4CRM.SAR
+          checksum: 7fbbd062ae6574d3447ecd137e22723f725fde0b5fa82ad29ce997e80d4442e6
           url: https://softwaredownloads.sap.com/file/0010000001433142021
           download: false
     
         - name: "UIBAS001 600: SP 0001"
           archive: K-60001INUIBAS001.SAR
+          checksum: a1ecf5288e6bbe5a7b00dbd096ca42fac45d49da0f391a9f6f391132b11997b2
           url: https://softwaredownloads.sap.com/file/0010000000013032021
           download: false
     
         - name: "UIS4HOP1 600: SP 0001"
           archive: K-60001INUIS4HOP1.SAR
+          checksum: 20cc69af6e82b25bd55a73d972a90fd291cac39172d293db9a41aca3ecfea74a
           url: https://softwaredownloads.sap.com/file/0010000000003012021
           download: false
     
         - name: "UIS4HOP1 600: SP 0002"
           archive: K-60002INUIS4HOP1.SAR
+          checksum: 73a4e2e04864b08b643f1068250c4b43995a38f6a169fb8899d66c0c2200e455
           url: https://softwaredownloads.sap.com/file/0010000000578272021
           download: false
     
         - name: "UIS4HOP1 600: SP 0003"
           archive: K-60003INUIS4HOP1.SAR
+          checksum: 3aea929578e27d009ff491379c120c4a2319511c408a3f7b2bb0487967b15c95
           url: https://softwaredownloads.sap.com/file/0010000001550222021
           download: false
     
         - name: "GBX01HR 600: SP 0018"
           archive: K-60018INGBX01HR.SAR
+          checksum: 35d8da893b4b6c29a0f4fadc26a0aeceddf223ab5c94e63eda47d462215d56fd
           url: https://softwaredownloads.sap.com/file/0010000001530032020
           download: false
     
         - name: "GBX01HR 600: SP 0019"
           archive: K-60019INGBX01HR.SAR
+          checksum: d8200111bbb645c3d465ab19a8b13806c5f96b13ba851d1a601e11d0b2615d66
           url: https://softwaredownloads.sap.com/file/0010000002051952020
           download: false
     
         - name: "UIBAS001 600: Add-On Installation"
           archive: K-600AGINUIBAS001.SAR
+          checksum: b7441f9f3916861edee5fce48ea0d62f73220e2c457dddedc75385c3d837f501
           url: https://softwaredownloads.sap.com/file/0010000000638612020
           download: false
     
         - name: "UIS4HOP1 600: Add-On Installation"
           archive: K-600AGINUIS4HOP1.SAR
+          checksum: afe62f81d8ff9f0d760a8ea35ab709d9bbec121bd8949125880df8ce9b199964
           url: https://softwaredownloads.sap.com/file/0010000001013212020
           download: false
     
         - name: "GBX01HR5 605: SP 0015"
           archive: K-60515INGBX01HR5.SAR
+          checksum: 3cc9d632d4bb92adecf617482b92f742ed944a742484bd3ce90fece2edd44a64
           url: https://softwaredownloads.sap.com/file/0010000001521702020
           download: false
     
         - name: "GBX01HR5 605: SP 0016"
           archive: K-60516INGBX01HR5.SAR
+          checksum: 955ef4c5cad3ffc43403761aa9e7e70c5fa1c8bcab53742972baddb0f236645e
           url: https://softwaredownloads.sap.com/file/0010000002052532020
           download: false
     
         - name: "GBX01HR5 605: SP 0017"
           archive: K-60517INGBX01HR5.SAR
+          checksum: 69f58a9703011124caa0d6e7a780ada13851d1586aece99a153d3d49aead5287
           url: https://softwaredownloads.sap.com/file/0010000000258892021
           download: false
     
         - name: "GBX01HR5 605: SP 0018"
           archive: K-60518INGBX01HR5.SAR
+          checksum: 47b38841123edb3445a634753ff5df2d0b6a668545b47e3bf82b4c01390394b5
           url: https://softwaredownloads.sap.com/file/0010000000770752021
           download: false
     
         - name: "GBX01HR5 605: SP 0019"
           archive: K-60519INGBX01HR5.SAR
+          checksum: 94a68bbc8fb6d6bc220788757e411603741447e02bb2a420ab24c40cc8315e30
           url: https://softwaredownloads.sap.com/file/0010000001243172021
           download: false
     
         - name: "EA-HR 608: SP 0083"
           archive: K-60883INEAHR.SAR
+          checksum: 2e0fb0fa90bca1c152edf6669f7d7118886acffb782506aa45c5a63b6a04fd34
           url: https://softwaredownloads.sap.com/file/0010000001324782020
           download: false
     
         - name: "EA-HR 608: SP 0084"
           archive: K-60884INEAHR.SAR
+          checksum: 76561e41400cb15c2e0a11aab41b4e15be0362e78bf322a327947caa166bedb0
           url: https://softwaredownloads.sap.com/file/0010000001507772020
           download: false
     
         - name: "EA-HR 608: SP 0085"
           archive: K-60885INEAHR.SAR
+          checksum: 545705bb821b427722984c79491ef7906c88e949630f7c6fcb480bf57edde23d
           url: https://softwaredownloads.sap.com/file/0010000001676532020
           download: false
     
         - name: "EA-HR 608: SP 0086"
           archive: K-60886INEAHR.SAR
+          checksum: ec6c3e0b1b1a8e022b6d65f03f903193b062a0d2e0b2c2186143c9fb10497f1a
           url: https://softwaredownloads.sap.com/file/0010000001888832020
           download: false
     
         - name: "EA-HR 608: SP 0087"
           archive: K-60887INEAHR.SAR
+          checksum: d14b3f2c6a70ad1a9441def5c88b70d8c743ae3dc7e272fe15d8aea3afa97380
           url: https://softwaredownloads.sap.com/file/0010000002067062020
           download: false
     
         - name: "EA-HR 608: SP 0088"
           archive: K-60888INEAHR.SAR
+          checksum: ec3fed017ee73aaa178e0717be3603556853ca5ac5e15ea96ad506bad1e0aa69
           url: https://softwaredownloads.sap.com/file/0010000002135512020
           download: false
     
         - name: "EA-HR 608: SP 0089"
           archive: K-60889INEAHR.SAR
+          checksum: 9099059568d9b1f0622485b48b35f5110192b780a866cfff1f966ab8ca2ae93b
           url: https://softwaredownloads.sap.com/file/0010000000065512021
           download: false
     
         - name: "EA-HR 608: SP 0090"
           archive: K-60890INEAHR.SAR
+          checksum: a554c981928baad912c3289acd2cf3aeea1a5d641a8519f985eef251dcbb2e88
           url: https://softwaredownloads.sap.com/file/0010000000184582021
           download: false
     
         - name: "EA-HR 608: SP 0091"
           archive: K-60891INEAHR.SAR
+          checksum: f331cc3e80820059c4468550c22480ac0b3905c043b5b8ed8d673d38143b56b0
           url: https://softwaredownloads.sap.com/file/0010000000340882021
           download: false
     
         - name: "EA-HR 608: SP 0092"
           archive: K-60892INEAHR.SAR
+          checksum: 11961732aaed242e474da05d6ae2efb7350e2437cc660f90674dc9f2dc985d67
           url: https://softwaredownloads.sap.com/file/0010000000545472021
           download: false
     
         - name: "EA-HR 608: SP 0093"
           archive: K-60893INEAHR.SAR
+          checksum: f6d219a99c407c7ca209a985a2780f53f6d50f7638798f0771174be29e291f02
           url: https://softwaredownloads.sap.com/file/0010000000683052021
           download: false
     
         - name: "EA-HR 608: SP 0094"
           archive: K-60894INEAHR.SAR
+          checksum: 763c0352594f7d3682a02ad8704d3d846d4a955f1831205b25d2042619991a71
           url: https://softwaredownloads.sap.com/file/0010000000817232021
           download: false
     
         - name: "EA-HR 608: SP 0095"
           archive: K-60895INEAHR.SAR
+          checksum: 78a36f5ea8843d2209240f808e386c70efbd1fd26007e86f7c6d86e11d8b7daa
           url: https://softwaredownloads.sap.com/file/0010000000999642021
           download: false
     
         - name: "EA-HR 608: SP 0096"
           archive: K-60896INEAHR.SAR
+          checksum: 696c04b9b76c0abf33891e7346a095072b5d9a3a17b96b9e829331c3d5d65c12
           url: https://softwaredownloads.sap.com/file/0010000001143012021
           download: false
     
         - name: "EA-HR 608: SP 0097"
           archive: K-60897INEAHR.SAR
+          checksum: 2f1c568001a54b360c1fcd4b8192cc7085740cb1207d8981e78bbbcdd4934c0b
           url: https://softwaredownloads.sap.com/file/0010000001272012021
           download: false
     
         - name: "ST-PI 740: SP 0014"
           archive: K-74014INSTPI.SAR
+          checksum: f1a9058c623360d576469c51a74e5e649b7055bcac200c5b0f8165801a189048
           url: https://softwaredownloads.sap.com/file/0010000001984822020
           download: false
     
         - name: "ST-PI 740: SP 0015"
           archive: K-74015INSTPI.SAR
+          checksum: d877446c5d3c41af8d10dda15b11a61d9ac36b795fe6ace9b7f99654576278af
           url: https://softwaredownloads.sap.com/file/0010000000853222021
           download: false
     
         - name: "ST-PI 740: SP 0016"
           archive: K-74016INSTPI.SAR
+          checksum: 0d5a3c74f813dad48345023c7acd146dc9ef84c121c6d854292cb534006c40a5
           url: https://softwaredownloads.sap.com/file/0010000001454472021
           download: false
     
         - name: "ST-PI 740: SP 0017"
           archive: K-74017INSTPI.SAR
+          checksum: 31b7567ef9510cb1c7dc1434fd55a27531342e4ed8b9b90bc9ca8bd5393b5a64
           url: https://softwaredownloads.sap.com/file/0010000000096822022
           download: false
     
         - name: "ST-PI 740: SP 0018"
           archive: K-74018INSTPI.SAR
+          checksum: 335237b94424f625f65fb599c4c48771daa64d37e773fa8b1111131e73ad0112
           url: https://softwaredownloads.sap.com/file/0010000000509342022
           download: false
     
         - name: "ST-PI 740: SP 0019"
           archive: K-74019INSTPI.SAR
+          checksum: 4f46e84736c31cea16c2095b6337347a7e9707982ed969a434ba44350842abd2
           url: https://softwaredownloads.sap.com/file/0010000000788312022
           download: false
     
         - name: "SAP_BASIS 755: SP 0001"
           archive: K-75501INSAPBASIS.SAR
+          checksum: 50604b03747cf8bd6051ed7b45f7f874b5a17771645322215d3aeee7b26cc5a8
           url: https://softwaredownloads.sap.com/file/0010000000042962021
           download: false
     
         - name: "SAP_BW 755: SP 0001"
           archive: K-75501INSAPBW.SAR
+          checksum: 3f97975cd9934d3f3769efc06aa4a197b421750cf830a586c25a6d87ea73c2f5
           url: https://softwaredownloads.sap.com/file/0010000002112932020
           download: false
     
         - name: "SAP_GWFND 755: SP 0001"
           archive: K-75501INSAPGWFND.SAR
+          checksum: 1cb98c5b3085d0ed6593a0f78d5e3b1970a4c6e741aa2ce6448538f9e846b58c
           url: https://softwaredownloads.sap.com/file/0010000002112942020
           download: false
     
         - name: "SAP_UI 755: SP 0001"
           archive: K-75501INSAPUI.SAR
+          checksum: 738bc98319eea3dc1a4abb10d76526aeb7349ca6d9765a04f020d365ce9a7ad8
           url: https://softwaredownloads.sap.com/file/0010000001645292020
           download: false
     
         - name: "SAP_BASIS 755: SP 0002"
           archive: K-75502INSAPBASIS.SAR
+          checksum: a419099e2b4c8469cbceeaf9f756595a1d8aedb21ac5a02500caa4c6f25fdcf4
           url: https://softwaredownloads.sap.com/file/0010000000566632021
           download: false
     
         - name: "SAP_BW 755: SP 0002"
           archive: K-75502INSAPBW.SAR
+          checksum: 03d7f4a4f4509844e57954a485ac1b9da72caf2329e7e99d5142e5d9685a7575
           url: https://softwaredownloads.sap.com/file/0010000000578322021
           download: false
     
         - name: "SAP_GWFND 755: SP 0002"
           archive: K-75502INSAPGWFND.SAR
+          checksum: 794d6f89a675f9c491593d38b2e800d27076f27fd09765c599eead6cb6eedd14
           url: https://softwaredownloads.sap.com/file/0010000000462562021
           download: false
     
         - name: "SAP_UI 755: SP 0002"
           archive: K-75502INSAPUI.SAR
+          checksum: a07a5cc7d959e7b99adc1ae698c4c259f1f8604d4cb9afa602fd3fe6bceaab77
           url: https://softwaredownloads.sap.com/file/0010000002112912020
           download: false
     
         - name: "SAP_BASIS 755: SP 0003"
           archive: K-75503INSAPBASIS.SAR
+          checksum: ba7c233309e9e5392af4266dfbcd60ebc859d675eb6ae76b3b90868fb3e0b41b
           url: https://softwaredownloads.sap.com/file/0010000001314422021
           download: false
     
         - name: "SAP_BW 755: SP 0003"
           archive: K-75503INSAPBW.SAR
+          checksum: cf6687bd8462e82462c399a377070b105892649e93f73d91a91b9dfa60ba7098
           url: https://softwaredownloads.sap.com/file/0010000001314452021
           download: false
     
         - name: "SAP_GWFND 755: SP 0003"
           archive: K-75503INSAPGWFND.SAR
+          checksum: 91e6d88a5b3b6fe493fe889000d0aa025631ac874b265b6d99aabdd5901ae2bc
           url: https://softwaredownloads.sap.com/file/0010000001314462021
           download: false
     
         - name: "SAP_UI 755: SP 0003"
           archive: K-75503INSAPUI.SAR
+          checksum: d2a3f0cba87f1ae7abd0bcb77ae34e88b9d05669e1f906e47f156ef7332298c3
           url: https://softwaredownloads.sap.com/file/0010000000462572021
           download: false
     
         - name: "SAP_GWFND 755: SP 0004"
           archive: K-75504INSAPGWFND.SAR
+          checksum: 33b4b5afb25840f54de8384b36f86a299b05e646fde71157f81553d5a22d71e7
           url: https://softwaredownloads.sap.com/file/0010000000324402022
           download: false
     
         - name: "SAP_UI 755: SP 0004"
           archive: K-75504INSAPUI.SAR
+          checksum: ea086c862966c65d0f6f4a9c60ee6a426ef3981fbb391a74ca235fdef18ff5fb
           url: https://softwaredownloads.sap.com/file/0010000000869082021
           download: false
     
         - name: "SAP_UI 755: SP 0005"
           archive: K-75505INSAPUI.SAR
+          checksum: b7b93b2fd624c31bb764af4eab2f6fa6013373ea3b4057aeebe19cc8614aff6f
           url: https://softwaredownloads.sap.com/file/0010000001314472021
           download: false
     
         - name: "SAP_ABA 75F: SP 0001"
           archive: K-75F01INSAPABA.SAR
+          checksum: a0f75746d053e0bfa0283a90d59397667d7df05e06ae3e628752828765e2a45f
           url: https://softwaredownloads.sap.com/file/0010000002112962020
           download: false
     
         - name: "SAP_ABA 75F: SP 0002"
           archive: K-75F02INSAPABA.SAR
+          checksum: 6ec2f6b9d2c8649320fdff2a109e6e10e6981893dd7092ce31fb0a4f7dba16e1
           url: https://softwaredownloads.sap.com/file/0010000000462582021
           download: false
     
         - name: "SAP_ABA 75F: SP 0003"
           archive: K-75F03INSAPABA.SAR
+          checksum: 7083f45070f6fad52552cfd149f3daaaabcbe67d8e304f0ec68d6a2f2b71f6ce
           url: https://softwaredownloads.sap.com/file/0010000001314502021
           download: false
     
         - name: "UIAPFI70 800: SP 0001"
           archive: K-80001INUIAPFI70.SAR
+          checksum: 9b1dbd775d9606a6cd154915bf5310146066b66d2b5ac5505481b6fa5572e65a
           url: https://softwaredownloads.sap.com/file/0010000000003002021
           download: false
     
         - name: "UIAPFI70 800: SP 0002"
           archive: K-80002INUIAPFI70.SAR
+          checksum: 3cbdc82e127d37d45aef2e3a65773f313a1e374c3731af50c47df39bb1c8eaf9
           url: https://softwaredownloads.sap.com/file/0010000000578282021
           download: false
     
         - name: "UIAPFI70 800: SP 0003"
           archive: K-80003INUIAPFI70.SAR
+          checksum: c554d9108572f08ed19e06c9c65f2067be941e85b791c000591c13d6989ad41e
           url: https://softwaredownloads.sap.com/file/0010000001550202021
           download: false
     
         - name: "UIAPFI70 800: Add-On Installation"
           archive: K-800AGINUIAPFI70.SAR
+          checksum: ddceff148d92a6d6fc3d952d79de797b3db4624eb8b0e6adc37ebb9bfd0feb13
           url: https://softwaredownloads.sap.com/file/0010000001013272020
           download: false
     
         - name: "EA-DFPS 805: SP 0001"
           archive: K-80501INEADFPS.SAR
+          checksum: 67d4a04f0f36a2984ad80eb9762d4810dd7c44e6302347bf25c0ba261efd1d4c
           url: https://softwaredownloads.sap.com/file/0010000000025172021
           download: false
     
         - name: "EA-PS 805: SP 0001"
           archive: K-80501INEAPS.SAR
+          checksum: d4967a7b06c33f07a2bb445944a31c0e6495368a8e35c6270fe101753f4dd592
           url: https://softwaredownloads.sap.com/file/0010000000025182021
           download: false
     
         - name: "FI-CAX 805: SP 0001"
           archive: K-80501INFICAX.SAR
+          checksum: 7aa61cc1c94fc6b9266db5da93e7f909c56a4817a97c5021c1580eca2d72c187
           url: https://softwaredownloads.sap.com/file/0010000000025192021
           download: false
     
         - name: "INSURANCE 805: SP 0001"
           archive: K-80501ININSURANC.SAR
+          checksum: 893a3d4999c59bfd4c2c9ec4235f3b74b8afecf41144f256470795afc467be9a
           url: https://softwaredownloads.sap.com/file/0010000000025202021
           download: false
     
         - name: "IS-OIL 805: SP 0001"
           archive: K-80501INISOIL.SAR
+          checksum: 4ca83b7b0e9ffa174472ed367773aa070597bfe2a86ddd46a06eb0675ac4f391
           url: https://softwaredownloads.sap.com/file/0010000000025212021
           download: false
     
         - name: "IS-PRA 805: SP 0001"
           archive: K-80501INISPRA.SAR
+          checksum: 6ab9096c799abe0535e22808fb7fc092ae3fbd071360f072dab7c6ea30056fef
           url: https://softwaredownloads.sap.com/file/0010000000025222021
           download: false
     
         - name: "IS-PS-CA 805: SP 0001"
           archive: K-80501INISPSCA.SAR
+          checksum: faeebe12ee9ad7a6a202ba1f1538b47d065af214812b96bc400e9a681267ee7a
           url: https://softwaredownloads.sap.com/file/0010000000025232021
           download: false
     
         - name: "IS-UT 805: SP 0001"
           archive: K-80501INISUT.SAR
+          checksum: f6f1f36bb905b44980f327ece0d97c9ed636ec17c0a3392c258d260426dea005
           url: https://softwaredownloads.sap.com/file/0010000000025242021
           download: false
     
         - name: "MDG_APPL 805: SP 0001"
           archive: K-80501INMDGAPPL.SAR
+          checksum: 1742ca67b9510108bd0314a98ffdadadb6b209a85d6d902c4c6722b1f9352e6a
           url: https://softwaredownloads.sap.com/file/0010000000025252021
           download: false
     
         - name: "MDG_FND 805: SP 0001"
           archive: K-80501INMDGFND.SAR
+          checksum: 9cebe04f7e21009260d254557f4bb74e6e63531284fdcf5a2088e9a05ff5f4e6
           url: https://softwaredownloads.sap.com/file/0010000000025262021
           download: false
     
         - name: "EA-DFPS 805: SP 0002"
           archive: K-80502INEADFPS.SAR
+          checksum: 72240c827702c5534d07ff9af998046e4e252e6b970b08a0a5cef3ee0945d643
           url: https://softwaredownloads.sap.com/file/0010000000595522021
           download: false
     
         - name: "EA-PS 805: SP 0002"
           archive: K-80502INEAPS.SAR
+          checksum: 04602fcfd313288a8c6f838a201f23371edde134d9de7c75b5344ded40314a1a
           url: https://softwaredownloads.sap.com/file/0010000000595532021
           download: false
     
         - name: "FI-CAX 805: SP 0002"
           archive: K-80502INFICAX.SAR
+          checksum: 8c0505104315ea48bf3c52afe3fdf71a7fdb0b70eef593bba55a83ca39dae0ec
           url: https://softwaredownloads.sap.com/file/0010000000595542021
           download: false
     
         - name: "INSURANCE 805: SP 0002"
           archive: K-80502ININSURANC.SAR
+          checksum: dbdaa5727ba845d14eacff611bd6e28b4580a689909023d48789577ab0820f5e
           url: https://softwaredownloads.sap.com/file/0010000000595552021
           download: false
     
         - name: "IS-OIL 805: SP 0002"
           archive: K-80502INISOIL.SAR
+          checksum: f27196a3d30e96113b118059983a8ae7816146a2f9ffc7496a51902778e446ee
           url: https://softwaredownloads.sap.com/file/0010000000595562021
           download: false
     
         - name: "IS-PRA 805: SP 0002"
           archive: K-80502INISPRA.SAR
+          checksum: 956ff8668f3578f4adf3366b04b226fa5edd19f08b2fb68d93c033b9099ce990
           url: https://softwaredownloads.sap.com/file/0010000000595572021
           download: false
     
         - name: "IS-PS-CA 805: SP 0002"
           archive: K-80502INISPSCA.SAR
+          checksum: 753c05ce51bf10977fb5d8873f9829bbc219c1915234e78b35c011bb7bd50e30
           url: https://softwaredownloads.sap.com/file/0010000000595582021
           download: false
     
         - name: "IS-UT 805: SP 0002"
           archive: K-80502INISUT.SAR
+          checksum: 4920e3d685b974ccddc467243eb761357899cd942a1bd0e63051609ffecb16a3
           url: https://softwaredownloads.sap.com/file/0010000000595592021
           download: false
     
         - name: "MDG_APPL 805: SP 0002"
           archive: K-80502INMDGAPPL.SAR
+          checksum: 3dfc40e3087f148c50d7d1eff0706bfb2aa052a8169b37844bb1d40afad38bbe
           url: https://softwaredownloads.sap.com/file/0010000000595602021
           download: false
     
         - name: "MDG_FND 805: SP 0002"
           archive: K-80502INMDGFND.SAR
+          checksum: ee8c9427c5bfcd777328f1ec574d28d979b3ab8cb5de08cc23ea2e4beb4587a0
           url: https://softwaredownloads.sap.com/file/0010000000595612021
           download: false
     
         - name: "EA-DFPS 805: SP 0003"
           archive: K-80503INEADFPS.SAR
+          checksum: fe183e02cd0fc36d39bb8f3505f22102eba2c5c971e1a04216cbbb33c4b510f6
           url: https://softwaredownloads.sap.com/file/0010000001433152021
           download: false
     
         - name: "EA-PS 805: SP 0003"
           archive: K-80503INEAPS.SAR
+          checksum: 142e978321bd58c79ec4a703b37f8e34e28aba24adf582e11a381b615005f249
           url: https://softwaredownloads.sap.com/file/0010000001433162021
           download: false
     
         - name: "FI-CAX 805: SP 0003"
           archive: K-80503INFICAX.SAR
+          checksum: 813adcba3f8c7203b8694c3a78536d170fd45f2277f6682928907ec82834dc1d
           url: https://softwaredownloads.sap.com/file/0010000001433172021
           download: false
     
         - name: "INSURANCE 805: SP 0003"
           archive: K-80503ININSURANC.SAR
+          checksum: bddea11dea9f1e2676eb035173b534f5851b0880799af98350969acdfacdf85a
           url: https://softwaredownloads.sap.com/file/0010000001433182021
           download: false
     
         - name: "IS-OIL 805: SP 0003"
           archive: K-80503INISOIL.SAR
+          checksum: c22a6ad1f2cb7535d5ac950c22abf7aabd35ba6b567474159a9b655f3782b50b
           url: https://softwaredownloads.sap.com/file/0010000001433192021
           download: false
     
         - name: "IS-PRA 805: SP 0003"
           archive: K-80503INISPRA.SAR
+          checksum: 75661aa0a341d515b1340fb632d722d0c8b93e42c6c756659d5c5c3fea1144f6
           url: https://softwaredownloads.sap.com/file/0010000001433212021
           download: false
     
         - name: "IS-PS-CA 805: SP 0003"
           archive: K-80503INISPSCA.SAR
+          checksum: cc135940a8a9db1e33be94d5e2b877c799e80aa27f25b7767e037f6b04c316e4
           url: https://softwaredownloads.sap.com/file/0010000001433222021
           download: false
     
         - name: "IS-UT 805: SP 0003"
           archive: K-80503INISUT.SAR
+          checksum: 100b1b2a083d9f3b823a7aee9311cdd1bc220b3e585c3f159c0836905dcaa8eb
           url: https://softwaredownloads.sap.com/file/0010000001433242021
           download: false
     
         - name: "MDG_APPL 805: SP 0003"
           archive: K-80503INMDGAPPL.SAR
+          checksum: 2056ac8ed72a72cbba4772160bc233223efe03fdb222d671378b7055f415f6e4
           url: https://softwaredownloads.sap.com/file/0010000001433252021
           download: false
     
         - name: "MDG_FND 805: SP 0003"
           archive: K-80503INMDGFND.SAR
+          checksum: 10af40cb72870ba2857cf51a19dcefef1736d934416776919b026a11d98276d8
           url: https://softwaredownloads.sap.com/file/0010000001433262021
           download: false
     
         - name: "SPAM/SAINT Update - Version 755/0082"
           archive: KD75582.SAR
+          checksum: 68097daa731e29cf57be08dae0009248ea67e11c903c5388807059b821311d3e
           url: https://softwaredownloads.sap.com/file/0010000000652292022
           download: false
     
         - name: "SAP_HR 608: SP 0083"
           archive: KE60883.SAR
+          checksum: 02b35c133b2aa72887085cbbf9c876d628077ed2da37cda311c204b6c88aa1a4
           url: https://softwaredownloads.sap.com/file/0010000001324772020
           download: false
     
         - name: "SAP_HR 608: SP 0084"
           archive: KE60884.SAR
+          checksum: 77e7373357923c82612850831630ce10090b4ab1cc6aa3bef39eb50ee40141d8
           url: https://softwaredownloads.sap.com/file/0010000001507762020
           download: false
     
         - name: "SAP_HR 608: SP 0085"
           archive: KE60885.SAR
+          checksum: 44eea91c31849457ea6019deb8ff29bb7b147791abf6feb6a2d678767ec1ef66
           url: https://softwaredownloads.sap.com/file/0010000001676522020
           download: false
     
         - name: "SAP_HR 608: SP 0086"
           archive: KE60886.SAR
+          checksum: ae2995470e261f906f029bb71dabb19d4d94dd9feb78342b18c13ab9ce37c98c
           url: https://softwaredownloads.sap.com/file/0010000001888812020
           download: false
     
         - name: "SAP_HR 608: SP 0087"
           archive: KE60887.SAR
+          checksum: 949d65f75c97c982587f96178472a5ca214023638680ba147868692a6ecd6b40
           url: https://softwaredownloads.sap.com/file/0010000002067072020
           download: false
     
         - name: "SAP_HR 608: SP 0088"
           archive: KE60888.SAR
+          checksum: a0df3ac6af2481f35cb8167eeb0d778e0aabf1410556e372e319692e07548d7c
           url: https://softwaredownloads.sap.com/file/0010000002135522020
           download: false
     
         - name: "SAP_HR 608: SP 0089"
           archive: KE60889.SAR
+          checksum: 28d2cb00a3e643c6eba7e8c373d47714929e0de97bb39d4a9b56b9208994b487
           url: https://softwaredownloads.sap.com/file/0010000000065492021
           download: false
     
         - name: "SAP_HR 608: SP 0090"
           archive: KE60890.SAR
+          checksum: ccc77cb17ed5f117d2a7a685ed4a5ef321953b9c778d9bcbd2f816015644af2c
           url: https://softwaredownloads.sap.com/file/0010000000184572021
           download: false
     
         - name: "SAP_HR 608: SP 0091"
           archive: KE60891.SAR
+          checksum: fc45e3265e38fb699a70e8bb6f1c291f06501286fc9974465853ce978e75f1c3
           url: https://softwaredownloads.sap.com/file/0010000000340862021
           download: false
     
         - name: "SAP_HR 608: SP 0092"
           archive: KE60892.SAR
+          checksum: 14ceb8d360775e1ada58a766a00c713d4b862f210f547942f8dbdcd7a336fc70
           url: https://softwaredownloads.sap.com/file/0010000000545482021
           download: false
     
         - name: "SAP_HR 608: SP 0093"
           archive: KE60893.SAR
+          checksum: 4723592215209ce60f1f7be3f983cda2c79da1f19a7223cf0d49bd6721e83cab
           url: https://softwaredownloads.sap.com/file/0010000000679612021
           download: false
     
         - name: "SAP_HR 608: SP 0094"
           archive: KE60894.SAR
+          checksum: cd16343fce0aafe6f27256dd114636c243cc82dbd26f4a69a7dced4de02eefe4
           url: https://softwaredownloads.sap.com/file/0010000000817222021
           download: false
     
         - name: "SAP_HR 608: SP 0095"
           archive: KE60895.SAR
+          checksum: 41ddbc52887e98b53d2d37c3efa273b563346fc614e8ebd9c49c04b2e6b50dbc
           url: https://softwaredownloads.sap.com/file/0010000000999632021
           download: false
     
         - name: "SAP_HR 608: SP 0096"
           archive: KE60896.SAR
+          checksum: f5f3c3d4ce6c96e78a4aad39144183b6f67a26abd57525366bf797077fab772f
           url: https://softwaredownloads.sap.com/file/0010000001143002021
           download: false
     
         - name: "SAP_HR 608: SP 0097"
           archive: KE60897.SAR
+          checksum: 4065937f917e5f43123d38ab8098f4acbf76888ede86f7c5690ec3bb2e641085
           url: https://softwaredownloads.sap.com/file/0010000001272002021
           download: false
     
         - name: "Servicetools for SAP Basis 731 and higher"
           archive: KITAB9Z.SAR
-          url: https://softwaredownloads.sap.com/file/0010000001758902020
-          download: false
-    
-        - name: "Servicetools for SAP Basis 731 and higher"
-          archive: KITABC1.SAR
+          checksum: 230dab337a626543a3015d19888aff5fa1483fb0e7710b6559319c521f84f154
           url: https://softwaredownloads.sap.com/file/0010000001758902020
           download: false
     
         - name: "Attribute Change Package 04 for SAP_BASIS 755"
           archive: SAP_BASIS755.SAR
+          checksum: dc8e377797649abdc9fd7a7c9ab90d10c7a4d7f8c77c3d5abb6de9925e223182
           url: https://softwaredownloads.sap.com/file/0010000001467632021
           download: false
     
         - name: "Attribute Change Package 35 for SAP_HR 608"
           archive: SAP_HR608.SAR
+          checksum: 26ced531487527864dc223d7f8e9c1574803d38519614bae9cdd63cdda9e6e82
           url: https://softwaredownloads.sap.com/file/0010000000249512014
           download: false
     
         - name: "Attribute Change Package 04 for SAP_UI 755"
           archive: SAP_UI755.SAR
+          checksum: 0bd4eee6628a2d8d66592f78d9b520f7c758b89cd133a824d5960836a3636d2b
           url: https://softwaredownloads.sap.com/file/0010000000211202021
           download: false
     
         - name: "Attribute Change Package 19 for SRA004 600"
           archive: SRA004600.SAR
+          checksum: 9148d468ff874691a662b6c6428b01a09a54c48af369e1accd8e6c72c5ddf823
           url: https://softwaredownloads.sap.com/file/0010000000060132013
           download: false
     
         - name: "Attribute Change Package 45 for ST-PI 740"
           archive: ST-PI740.SAR
+          checksum: 8406c3d057afd459406b3d2fa500a1050eb8ac3c81be165d19af6e5834725328
           url: https://softwaredownloads.sap.com/file/0010000000297212015
           download: false
     
         - name: "Attribute Change Package 01 for UIBAS001 600"
           archive: UIBAS001600.SAR
+          checksum: d69cd7b88f4f5adf04b44c882fa98f7687e062f3b8da02149186e74f510cad8a
           url: https://softwaredownloads.sap.com/file/0010000001415322021
           download: false
 

--- a/deploy/ansible/BOM-catalog/S4HANA_2021_ISS_v0001ms/S4HANA_2021_ISS_v0001ms.yaml
+++ b/deploy/ansible/BOM-catalog/S4HANA_2021_ISS_v0001ms/S4HANA_2021_ISS_v0001ms.yaml
@@ -283,7 +283,7 @@ materials:
 
     - name:                            "Attribute Change Package 22 for GBX01HR5 605"
       archive:                         GBX01HR5605.SAR
-      checksum:                        12d61484a6dc8a20fa4dc428b9c2b4948e60928e7abbd775cb7b21ce4898b366
+      checksum:                        739bc35d266c9d53d08efba15956dcada2d276254ff7d68d8a88c7378100dba2
       url:                             https://softwaredownloads.sap.com/file/0010000000033172015
       download:                        false
 
@@ -553,13 +553,13 @@ materials:
 
     - name:                            "Attribute Change Package 30 for UIHR002 100"
       archive:                         UIHR002100.SAR
-      checksum:                        4533a38bcc0ed51bb8655368e1f95fb90999004100f98cb6749c6c983451e4c7
+      checksum:                        af4dc627a4e9896a29506cff4b0804085299f97ce8a414ebf930d5bff0aad2b6
       url:                             https://softwaredownloads.sap.com/file/0010000020208092017
       download:                        false
 
     - name:                            "Attribute Change Package 13 for UIMDG001 200"
       archive:                         UIMDG001200.SAR
-      checksum:                        fcff8a8a5b7ebd8d7e13ede31a630018207ae75146cb1d58da1de235d86892b9
+      checksum:                        7764b042e148ce8162d59872f9ba31e3ee30a9dddb3dbf459038c417adf8a28d
       url:                             https://softwaredownloads.sap.com/file/0010000014247222017
       download:                        false
 
@@ -571,7 +571,7 @@ materials:
 
     - name:                            "Attribute Change Package 13 for UITRV001 300"
       archive:                         UITRV001300.SAR
-      checksum:                        a065e9426ed5f154b510546f43018703e416a9cfbdc5ea11f2f537b347b66603
+      checksum:                        2e25b1abd4a98ed6a36776d79c92fbce733c38b214e0f697c11db9efd11177cb
       url:                             https://softwaredownloads.sap.com/file/0010000000561182019
       download:                        false
 


### PR DESCRIPTION
## Problem
S4Hana 2020 BoM did not have checksums. Added those to ensure BoMs are better validated.

## Solution
Added BoM checksums manually

## Tests
Ran BoM validator Pipeline locally

## Notes
<Additional comments for the PR>