### PR TITLE
Update main.yaml

### DIFF
--- a/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/main.yaml
+++ b/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/main.yaml
@@ -60,7 +60,7 @@
     - (item.node_tier == "all" or item.node_tier == node_tier)
     - not scs_high_availability
     - node_tier != 'observer'
-    - node_tier == 'app' and usr_sap_mountpoint is undefined
+    - ((node_tier == 'app' and usr_sap_mountpoint is undefined) or node_tier != 'app')
 
 - name:                                "2.6 SAP Mounts: - Mount local file systems (shared)"
   ansible.builtin.mount:


### PR DESCRIPTION
## Problem
/usr/sap does not mount on normal deployments on SCS, DB or PAS, only on APP working, below conditional is missing a condition that doesn't allow ansible to get correctly into the task to mount the mountpoint:
```
- name:                                "2.6 SAP Mounts: - Mount local sap file systems"
  mount:
    src:                               "{{ item.src }}"
    path:                              "{{ item.path }}"
    fstype:                            "{{ item.type }}"
    opts:                              defaults
    state:                             mounted
  loop:
    - { node_tier: 'all',  type: 'xfs', src: '/dev/vg_sap/lv_usrsap', path: '/usr/sap' }
  when:
    - (item.node_tier == "all" or item.node_tier == node_tier)
    - not scs_high_availability
    - node_tier != 'observer'
    - node_tier == 'app' and usr_sap_mountpoint is undefined
```

## Solution
```
- name:                                "2.6 SAP Mounts: - Mount local sap file systems"
  mount:
    src:                               "{{ item.src }}"
    path:                              "{{ item.path }}"
    fstype:                            "{{ item.type }}"
    opts:                              defaults
    state:                             mounted
  loop:
    - { node_tier: 'all',  type: 'xfs', src: '/dev/vg_sap/lv_usrsap', path: '/usr/sap' }
  when:
    - (item.node_tier == "all" or item.node_tier == node_tier)
    - not scs_high_availability
    - node_tier != 'observer'
    - ((node_tier == 'app' and usr_sap_mountpoint is undefined) or node_tier != 'app')
```

## Tests
```
# Before Fixing
scsinstance:/home/user # lsblk
NAME                      MAJ:MIN RM  SIZE RO TYPE MOUNTPOINT
nvme1n1                   259:0    0  100G  0 disk
├─vg_sap-lv_usrsap        254:0    0   32G  0 lvm
└─vg_sap-lv_usrsapinstall 254:1    0   68G  0 lvm  /usr/sap/install
nvme0n1                   259:1    0   30G  0 disk
├─nvme0n1p1               259:2    0    2M  0 part
├─nvme0n1p2               259:3    0   20M  0 part /boot/efi
└─nvme0n1p3               259:4    0   30G  0 part /
# After Fixing
scsinstance:/home/user # lsblk
NAME                      MAJ:MIN RM  SIZE RO TYPE MOUNTPOINT
nvme1n1                   259:0    0  100G  0 disk
├─vg_sap-lv_usrsap        254:0    0   32G  0 lvm  /usr/sap
└─vg_sap-lv_usrsapinstall 254:1    0   68G  0 lvm  /usr/sap/install
nvme0n1                   259:1    0   30G  0 disk
├─nvme0n1p1               259:2    0    2M  0 part
├─nvme0n1p2               259:3    0   20M  0 part /boot/efi
└─nvme0n1p3               259:4    0   30G  0 part /
```
