### PR TITLE
Private Endpoints with custom DNS A records

### DIFF
--- a/deploy/terraform/bootstrap/sap_deployer/module.tf
+++ b/deploy/terraform/bootstrap/sap_deployer/module.tf
@@ -4,7 +4,10 @@ Description:
   Example to deploy deployer(s) using local backend.
 */
 module "sap_deployer" {
-  source         = "../../terraform-units/modules/sap_deployer"
+  source = "../../terraform-units/modules/sap_deployer"
+  providers = {
+    azurerm.dnsmanagement = azurerm.dnsmanagement
+  }
   infrastructure = local.infrastructure
   deployer       = local.deployer
   options        = local.options
@@ -21,6 +24,9 @@ module "sap_deployer" {
   enable_purge_control_for_keyvaults           = var.enable_purge_control_for_keyvaults
   arm_client_id                                = var.arm_client_id
   use_private_endpoint                         = var.use_private_endpoint
+  use_custom_dns_a_registration                = var.use_custom_dns_a_registration
+  management_dns_subscription_id               = var.management_dns_subscription_id
+  management_dns_resourcegroup_name            = var.management_dns_resourcegroup_name
   use_webapp                                   = var.use_webapp
   configure                                    = false
   tf_version                                   = var.tf_version

--- a/deploy/terraform/bootstrap/sap_deployer/providers.tf
+++ b/deploy/terraform/bootstrap/sap_deployer/providers.tf
@@ -18,7 +18,21 @@ data "azurerm_client_config" "current" {
 }
 
 provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy               = !var.enable_purge_control_for_keyvaults
+      purge_soft_deleted_keys_on_destroy         = !var.enable_purge_control_for_keyvaults
+      purge_soft_deleted_secrets_on_destroy      = !var.enable_purge_control_for_keyvaults
+      purge_soft_deleted_certificates_on_destroy = !var.enable_purge_control_for_keyvaults
+    }
+  }
+}
+
+provider "azurerm" {
   features {}
+  alias                      = "dnsmanagement"
+  subscription_id            = try(var.management_dns_subscription_id, null)
+  skip_provider_registration = true
 }
 
 terraform {

--- a/deploy/terraform/bootstrap/sap_deployer/tfvar_variables.tf
+++ b/deploy/terraform/bootstrap/sap_deployer/tfvar_variables.tf
@@ -12,13 +12,13 @@ variable "environment" {
 
 variable "codename" {
   description = "Additional component for naming the resources"
-  default = ""
-  type    = string
+  default     = ""
+  type        = string
 }
 
 variable "location" {
   description = "Defines the Azure location where the resources will be deployed"
-  type = string
+  type        = string
 }
 
 ###############################################################################
@@ -30,17 +30,17 @@ variable "location" {
 
 variable "resourcegroup_name" {
   description = "If defined, the name of the resource group into which the resources will be deployed"
-  default = ""
+  default     = ""
 }
 
 variable "resourcegroup_arm_id" {
   description = "Azure resource identifier for the resource group into which the resources will be deployed"
-  default = ""
+  default     = ""
 }
 
 variable "resourcegroup_tags" {
   description = "tags to be added to the resource group"
-  default = {}
+  default     = {}
 }
 
 ###############################################################################
@@ -51,22 +51,22 @@ variable "resourcegroup_tags" {
 
 variable "management_network_name" {
   description = "The name of the VNet into which the deployer will be deployed"
-  default = ""
+  default     = ""
 }
 
 variable "management_network_logical_name" {
   description = "The logical name of the VNet, used for naming purposes"
-  default = ""
+  default     = ""
 }
 
 variable "management_network_arm_id" {
   description = "Azure resource identifier for the existing VNet into which the deployer will be deployed"
-  default = ""
+  default     = ""
 }
 
 variable "management_network_address_space" {
   description = "The address space of the VNet into which the deployer will be deployed"
-  default = ""
+  default     = ""
 }
 
 ###############################################################################
@@ -77,17 +77,17 @@ variable "management_network_address_space" {
 
 variable "management_subnet_name" {
   description = "The name of the subnet into which the deployer will be deployed"
-  default = ""
+  default     = ""
 }
 
 variable "management_subnet_arm_id" {
   description = "Azure resource identifier for the existing subnet into which the deployer will be deployed"
-  default = ""
+  default     = ""
 }
 
 variable "management_subnet_address_prefix" {
   description = "The address prefix of the subnet into which the deployer will be deployed"
-  default = ""
+  default     = ""
 }
 
 ###############################################################################
@@ -98,19 +98,19 @@ variable "management_subnet_address_prefix" {
 
 variable "management_firewall_subnet_arm_id" {
   description = "Azure resource identifier for the existing subnet into which the firewall will be deployed"
-  default = ""
+  default     = ""
 }
 
 variable "management_firewall_subnet_address_prefix" {
   description = "value of the address prefix of the subnet into which the firewall will be deployed"
-  default = ""
+  default     = ""
 }
 
 
 variable "firewall_deployment" {
   description = "Boolean flag indicating if an Azure Firewall should be deployed"
   default     = false
-  type = bool
+  type        = bool
 }
 
 variable "firewall_rule_subnets" {
@@ -131,12 +131,12 @@ variable "firewall_allowed_ipaddresses" {
 
 variable "management_bastion_subnet_arm_id" {
   description = "Azure resource identifier Azure Bastion subnet"
-  default = ""
+  default     = ""
 }
 
 variable "management_bastion_subnet_address_prefix" {
   description = "Subnet adress range for the bastion subnet"
-  default = ""
+  default     = ""
 }
 
 
@@ -153,12 +153,12 @@ variable "bastion_deployment" {
 
 variable "management_subnet_nsg_name" {
   description = "The name of the network security group"
-  default = ""
+  default     = ""
 }
 
 variable "management_subnet_nsg_arm_id" {
   description = "value of the Azure resource identifier for the network security group"
-  default = ""
+  default     = ""
 }
 
 variable "management_subnet_nsg_allowed_ips" {
@@ -167,8 +167,8 @@ variable "management_subnet_nsg_allowed_ips" {
 
 variable "deployer_enable_public_ip" {
   description = "value to enable/disable public ip"
-  default = false
-  type = bool
+  default     = false
+  type        = bool
 }
 
 ###############################################################################
@@ -179,22 +179,22 @@ variable "deployer_enable_public_ip" {
 
 variable "deployer_size" {
   description = "The size of the deployer VM"
-  default = ""
+  default     = ""
 }
 
 variable "deployer_count" {
   description = "Number of deployer VMs to be created"
-  default = 1
+  default     = 1
 }
 
 variable "deployer_disk_type" {
   description = "The type of the disk for the deployer VM"
-  default = "Premium_LRS"
+  default     = "Premium_LRS"
 }
 
 variable "deployer_use_DHCP" {
   description = "If true, the deployers will use Azure Provided IP addresses"
-  default = false
+  default     = false
 }
 
 variable "deployer_image" {
@@ -247,37 +247,37 @@ variable "deployer_authentication_path_to_private_key" {
 
 variable "user_keyvault_id" {
   description = "Azure resource identifier for the deployment credentials Azure Key Vault"
-  default = ""
+  default     = ""
 }
 
 variable "deployer_private_key_secret_name" {
   description = "Defines the name of the secret in the Azure Key Vault that contains the private key"
-  default = ""
+  default     = ""
 }
 variable "deployer_public_key_secret_name" {
   description = "Defines the name of the secret in the Azure Key Vault that contains the public key"
-  default = ""
+  default     = ""
 }
 
 variable "deployer_username_secret_name" {
   description = "Defines the name of the secret in the Azure Key Vault that contains the user name"
-  default = ""
+  default     = ""
 }
 
 variable "deployer_password_secret_name" {
   description = "Defines the name of the secret in the Azure Key Vault that contains the password"
-  default = ""
+  default     = ""
 }
 
 variable "enable_purge_control_for_keyvaults" {
   description = "Disables the purge protection for Azure keyvaults."
-  default = false
-  type = bool
+  default     = false
+  type        = bool
 }
 
 variable "additional_users_to_add_to_keyvault_policies" {
   description = "List of object IDs to add to key vault policies"
-  default = [""]
+  default     = [""]
 }
 
 #########################################################################################
@@ -288,26 +288,43 @@ variable "additional_users_to_add_to_keyvault_policies" {
 
 variable "deployer_assign_subscription_permissions" {
   description = "Boolean flag indicating if the subscription permissions should be assigned"
-  default = false
-  type = bool
+  default     = false
+  type        = bool
 }
 
 variable "use_private_endpoint" {
   description = "Boolean value indicating if private endpoint should be used for the deployment"
-  default = false
-  type = bool
+  default     = false
+  type        = bool
 }
 
+variable "use_custom_dns_a_registration" {
+  description = "Boolean value indicating if a custom dns a record should be created when using private endpoints"
+  default     = false
+  type        = bool
+}
+
+variable "management_dns_subscription_id" {
+  description = "String value giving the possibility to register custom dns a records in a separate subscription"
+  default     = null
+  type        = string
+}
+
+variable "management_dns_resourcegroup_name" {
+  description = "String value giving the possibility to register custom dns a records in a separate resourcegroup"
+  default     = null
+  type        = string
+}
 
 variable "deployer_diagnostics_account_arm_id" {
   description = "Azure resource identifier for an existing storage accout that will be used for diagnostic logs"
-  default = ""
+  default     = ""
 }
 
 
 variable "tf_version" {
   description = "Terraform version to install on deployer"
-  default = "1.2.6"
+  default     = "1.2.6"
 }
 
 variable "name_override_file" {
@@ -356,21 +373,21 @@ variable "app_registration_app_id" {
 }
 
 variable "sa_connection_string" {
-  type = string
+  type    = string
   default = ""
 }
 
 variable "webapp_client_secret" {
-  type = string
+  type    = string
   default = ""
 }
 
 variable "webapp_subnet_arm_id" {
   description = "Azure resource identifier Web App subnet"
-  default = ""
+  default     = ""
 }
 
 variable "webapp_subnet_address_prefix" {
   description = "Subnet adress range for the Web App subnet"
-  default = ""
+  default     = ""
 }

--- a/deploy/terraform/bootstrap/sap_library/module.tf
+++ b/deploy/terraform/bootstrap/sap_library/module.tf
@@ -4,22 +4,26 @@
 */
 module "sap_library" {
   source = "../../terraform-units/modules/sap_library"
-   providers = {
-     azurerm.main     = azurerm
-     azurerm.deployer = azurerm.deployer
-   }
-  infrastructure          = local.infrastructure
-  storage_account_sapbits = local.storage_account_sapbits
-  storage_account_tfstate = local.storage_account_tfstate
-  software                = var.software
-  deployer                = local.deployer
-  key_vault               = local.key_vault
-  service_principal       = var.use_deployer ? local.service_principal : local.account
-  deployer_tfstate        = try(data.terraform_remote_state.deployer[0].outputs, [])
-  naming                  = length(var.name_override_file) > 0 ? local.custom_names : module.sap_namegenerator.naming
-  dns_label               = var.dns_label
-  use_private_endpoint    = var.use_private_endpoint
-  use_webapp              = var.use_webapp
+  providers = {
+    azurerm.main          = azurerm
+    azurerm.deployer      = azurerm.deployer
+    azurerm.dnsmanagement = azurerm.dnsmanagement
+  }
+  infrastructure                    = local.infrastructure
+  storage_account_sapbits           = local.storage_account_sapbits
+  storage_account_tfstate           = local.storage_account_tfstate
+  software                          = var.software
+  deployer                          = local.deployer
+  key_vault                         = local.key_vault
+  service_principal                 = var.use_deployer ? local.service_principal : local.account
+  deployer_tfstate                  = try(data.terraform_remote_state.deployer[0].outputs, [])
+  naming                            = length(var.name_override_file) > 0 ? local.custom_names : module.sap_namegenerator.naming
+  dns_label                         = var.dns_label
+  use_private_endpoint              = var.use_private_endpoint
+  use_custom_dns_a_registration     = var.use_custom_dns_a_registration
+  management_dns_subscription_id    = var.management_dns_subscription_id
+  management_dns_resourcegroup_name = var.management_dns_resourcegroup_name
+  use_webapp                        = var.use_webapp
 }
 
 module "sap_namegenerator" {

--- a/deploy/terraform/bootstrap/sap_library/providers.tf
+++ b/deploy/terraform/bootstrap/sap_library/providers.tf
@@ -18,7 +18,14 @@ data "azurerm_client_config" "current" {
 }
 
 provider "azurerm" {
-  features {}
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy               = !var.enable_purge_control_for_keyvaults
+      purge_soft_deleted_keys_on_destroy         = !var.enable_purge_control_for_keyvaults
+      purge_soft_deleted_secrets_on_destroy      = !var.enable_purge_control_for_keyvaults
+      purge_soft_deleted_certificates_on_destroy = !var.enable_purge_control_for_keyvaults
+    }
+  }
   subscription_id = var.use_deployer ? local.spn.subscription_id : null
   client_id       = var.use_deployer ? local.spn.client_id : null
   client_secret   = var.use_deployer ? local.spn.client_secret : null
@@ -26,8 +33,22 @@ provider "azurerm" {
 }
 
 provider "azurerm" {
-  features {}
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy               = !var.enable_purge_control_for_keyvaults
+      purge_soft_deleted_keys_on_destroy         = !var.enable_purge_control_for_keyvaults
+      purge_soft_deleted_secrets_on_destroy      = !var.enable_purge_control_for_keyvaults
+      purge_soft_deleted_certificates_on_destroy = !var.enable_purge_control_for_keyvaults
+    }
+  }
   alias = "deployer"
+}
+
+provider "azurerm" {
+  features {}
+  alias                      = "dnsmanagement"
+  subscription_id            = try(var.management_dns_subscription_id, null)
+  skip_provider_registration = true
 }
 
 provider "azuread" {
@@ -55,7 +76,7 @@ terraform {
       source = "hashicorp/azuread"
     }
     azurerm = {
-      source = "hashicorp/azurerm"
+      source  = "hashicorp/azurerm"
       version = "~> 3.0"
     }
   }

--- a/deploy/terraform/bootstrap/sap_library/tfvar_variables.tf
+++ b/deploy/terraform/bootstrap/sap_library/tfvar_variables.tf
@@ -157,12 +157,30 @@ variable "library_ansible_blob_container_name" {
 
 variable "enable_purge_control_for_keyvaults" {
   description = "Disables the purge protection for Azure keyvaults."
-  default = false
-  type = bool
+  default     = false
+  type        = bool
 }
 
 variable "use_private_endpoint" {
   default = false
+}
+
+variable "use_custom_dns_a_registration" {
+  description = "Boolean value indicating if a custom dns a record should be created when using private endpoints"
+  default     = false
+  type        = bool
+}
+
+variable "management_dns_subscription_id" {
+  description = "String value giving the possibility to register custom dns a records in a separate subscription"
+  default     = null
+  type        = string
+}
+
+variable "management_dns_resourcegroup_name" {
+  description = "String value giving the possibility to register custom dns a records in a separate resourcegroup"
+  default     = null
+  type        = string
 }
 
 variable "use_webapp" {
@@ -171,5 +189,5 @@ variable "use_webapp" {
 
 variable "name_override_file" {
   description = "If provided, contains a json formatted file defining the name overrides"
-  default = ""
+  default     = ""
 }

--- a/deploy/terraform/run/sap_deployer/module.tf
+++ b/deploy/terraform/run/sap_deployer/module.tf
@@ -4,7 +4,10 @@ Description:
   Example to deploy deployer(s) using local backend.
 */
 module "sap_deployer" {
-  source         = "../../terraform-units/modules/sap_deployer/"
+  source = "../../terraform-units/modules/sap_deployer/"
+  providers = {
+    azurerm.dnsmanagement = azurerm.dnsmanagement
+  }
   infrastructure = local.infrastructure
   deployer       = local.deployer
   options        = local.options
@@ -21,6 +24,9 @@ module "sap_deployer" {
   enable_purge_control_for_keyvaults           = var.enable_purge_control_for_keyvaults
   arm_client_id                                = var.arm_client_id
   use_private_endpoint                         = var.use_private_endpoint
+  use_custom_dns_a_registration                = var.use_custom_dns_a_registration
+  management_dns_subscription_id               = var.management_dns_subscription_id
+  management_dns_resourcegroup_name            = var.management_dns_resourcegroup_name
   use_webapp                                   = var.use_webapp
   configure                                    = true
   tf_version                                   = var.tf_version

--- a/deploy/terraform/run/sap_deployer/providers.tf
+++ b/deploy/terraform/run/sap_deployer/providers.tf
@@ -14,8 +14,22 @@ Description:
 */
 
 provider "azurerm" {
-  features {}
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy               = !var.enable_purge_control_for_keyvaults
+      purge_soft_deleted_keys_on_destroy         = !var.enable_purge_control_for_keyvaults
+      purge_soft_deleted_secrets_on_destroy      = !var.enable_purge_control_for_keyvaults
+      purge_soft_deleted_certificates_on_destroy = !var.enable_purge_control_for_keyvaults
+    }
+  }
   partner_id = "f94f50f2-2539-42f8-9c8e-c65b28c681f7"
+}
+
+provider "azurerm" {
+  features {}
+  alias                      = "dnsmanagement"
+  subscription_id            = try(var.management_dns_subscription_id, null)
+  skip_provider_registration = true
 }
 
 terraform {

--- a/deploy/terraform/run/sap_deployer/tfvar_variables.tf
+++ b/deploy/terraform/run/sap_deployer/tfvar_variables.tf
@@ -12,13 +12,13 @@ variable "environment" {
 
 variable "codename" {
   description = "Additional component for naming the resources"
-  default = ""
-  type    = string
+  default     = ""
+  type        = string
 }
 
 variable "location" {
   description = "Defines the Azure location where the resources will be deployed"
-  type = string
+  type        = string
 }
 
 ###############################################################################
@@ -30,17 +30,17 @@ variable "location" {
 
 variable "resourcegroup_name" {
   description = "If defined, the name of the resource group into which the resources will be deployed"
-  default = ""
+  default     = ""
 }
 
 variable "resourcegroup_arm_id" {
   description = "Azure resource identifier for the resource group into which the resources will be deployed"
-  default = ""
+  default     = ""
 }
 
 variable "resourcegroup_tags" {
   description = "tags to be added to the resource group"
-  default = {}
+  default     = {}
 }
 
 ###############################################################################
@@ -51,22 +51,22 @@ variable "resourcegroup_tags" {
 
 variable "management_network_name" {
   description = "The name of the VNet into which the deployer will be deployed"
-  default = ""
+  default     = ""
 }
 
 variable "management_network_logical_name" {
   description = "The logical name of the VNet, used for naming purposes"
-  default = ""
+  default     = ""
 }
 
 variable "management_network_arm_id" {
   description = "Azure resource identifier for the existing VNet into which the deployer will be deployed"
-  default = ""
+  default     = ""
 }
 
 variable "management_network_address_space" {
   description = "The address space of the VNet into which the deployer will be deployed"
-  default = ""
+  default     = ""
 }
 
 ###############################################################################
@@ -77,17 +77,17 @@ variable "management_network_address_space" {
 
 variable "management_subnet_name" {
   description = "The name of the subnet into which the deployer will be deployed"
-  default = ""
+  default     = ""
 }
 
 variable "management_subnet_arm_id" {
   description = "Azure resource identifier for the existing subnet into which the deployer will be deployed"
-  default = ""
+  default     = ""
 }
 
 variable "management_subnet_address_prefix" {
   description = "The address prefix of the subnet into which the deployer will be deployed"
-  default = ""
+  default     = ""
 }
 
 ###############################################################################
@@ -98,19 +98,19 @@ variable "management_subnet_address_prefix" {
 
 variable "management_firewall_subnet_arm_id" {
   description = "Azure resource identifier for the existing subnet into which the firewall will be deployed"
-  default = ""
+  default     = ""
 }
 
 variable "management_firewall_subnet_address_prefix" {
   description = "value of the address prefix of the subnet into which the firewall will be deployed"
-  default = ""
+  default     = ""
 }
 
 
 variable "firewall_deployment" {
   description = "Boolean flag indicating if an Azure Firewall should be deployed"
   default     = false
-  type = bool
+  type        = bool
 }
 
 variable "firewall_rule_subnets" {
@@ -131,12 +131,12 @@ variable "firewall_allowed_ipaddresses" {
 
 variable "management_bastion_subnet_arm_id" {
   description = "Azure resource identifier Azure Bastion subnet"
-  default = ""
+  default     = ""
 }
 
 variable "management_bastion_subnet_address_prefix" {
   description = "Subnet adress range for the bastion subnet"
-  default = ""
+  default     = ""
 }
 
 
@@ -153,12 +153,12 @@ variable "bastion_deployment" {
 
 variable "management_subnet_nsg_name" {
   description = "The name of the network security group"
-  default = ""
+  default     = ""
 }
 
 variable "management_subnet_nsg_arm_id" {
   description = "value of the Azure resource identifier for the network security group"
-  default = ""
+  default     = ""
 }
 
 variable "management_subnet_nsg_allowed_ips" {
@@ -167,8 +167,8 @@ variable "management_subnet_nsg_allowed_ips" {
 
 variable "deployer_enable_public_ip" {
   description = "value to enable/disable public ip"
-  default = false
-  type = bool
+  default     = false
+  type        = bool
 }
 
 ###############################################################################
@@ -179,22 +179,22 @@ variable "deployer_enable_public_ip" {
 
 variable "deployer_size" {
   description = "The size of the deployer VM"
-  default = ""
+  default     = ""
 }
 
 variable "deployer_count" {
   description = "Number of deployer VMs to be created"
-  default = 1
+  default     = 1
 }
 
 variable "deployer_disk_type" {
   description = "The type of the disk for the deployer VM"
-  default = "Premium_LRS"
+  default     = "Premium_LRS"
 }
 
 variable "deployer_use_DHCP" {
   description = "If true, the deployers will use Azure Provided IP addresses"
-  default = false
+  default     = false
 }
 
 variable "deployer_image" {
@@ -247,37 +247,37 @@ variable "deployer_authentication_path_to_private_key" {
 
 variable "user_keyvault_id" {
   description = "Azure resource identifier for the deployment credentials Azure Key Vault"
-  default = ""
+  default     = ""
 }
 
 variable "deployer_private_key_secret_name" {
   description = "Defines the name of the secret in the Azure Key Vault that contains the private key"
-  default = ""
+  default     = ""
 }
 variable "deployer_public_key_secret_name" {
   description = "Defines the name of the secret in the Azure Key Vault that contains the public key"
-  default = ""
+  default     = ""
 }
 
 variable "deployer_username_secret_name" {
   description = "Defines the name of the secret in the Azure Key Vault that contains the user name"
-  default = ""
+  default     = ""
 }
 
 variable "deployer_password_secret_name" {
   description = "Defines the name of the secret in the Azure Key Vault that contains the password"
-  default = ""
+  default     = ""
 }
 
 variable "enable_purge_control_for_keyvaults" {
   description = "Disables the purge protection for Azure keyvaults."
-  default = false
-  type = bool
+  default     = false
+  type        = bool
 }
 
 variable "additional_users_to_add_to_keyvault_policies" {
   description = "List of object IDs to add to key vault policies"
-  default = [""]
+  default     = [""]
 }
 
 #########################################################################################
@@ -288,26 +288,43 @@ variable "additional_users_to_add_to_keyvault_policies" {
 
 variable "deployer_assign_subscription_permissions" {
   description = "Boolean flag indicating if the subscription permissions should be assigned"
-  default = false
-  type = bool
+  default     = false
+  type        = bool
 }
 
 variable "use_private_endpoint" {
   description = "Boolean value indicating if private endpoint should be used for the deployment"
-  default = false
-  type = bool
+  default     = false
+  type        = bool
 }
 
+variable "use_custom_dns_a_registration" {
+  description = "Boolean value indicating if a custom dns a record should be created when using private endpoints"
+  default     = false
+  type        = bool
+}
+
+variable "management_dns_subscription_id" {
+  description = "String value giving the possibility to register custom dns a records in a separate subscription"
+  default     = null
+  type        = string
+}
+
+variable "management_dns_resourcegroup_name" {
+  description = "String value giving the possibility to register custom dns a records in a separate resourcegroup"
+  default     = null
+  type        = string
+}
 
 variable "deployer_diagnostics_account_arm_id" {
   description = "Azure resource identifier for an existing storage accout that will be used for diagnostic logs"
-  default = ""
+  default     = ""
 }
 
 
 variable "tf_version" {
   description = "Terraform version to install on deployer"
-  default = "1.2.6"
+  default     = "1.2.6"
 }
 
 variable "name_override_file" {
@@ -357,21 +374,21 @@ variable "app_registration_app_id" {
 }
 
 variable "sa_connection_string" {
-  type = string
+  type    = string
   default = ""
 }
 
 variable "webapp_client_secret" {
-  type = string
+  type    = string
   default = ""
 }
 
 variable "webapp_subnet_arm_id" {
   description = "Azure resource identifier Web App subnet"
-  default = ""
+  default     = ""
 }
 
 variable "webapp_subnet_address_prefix" {
   description = "Subnet adress range for the Web App subnet"
-  default = ""
+  default     = ""
 }

--- a/deploy/terraform/run/sap_landscape/module.tf
+++ b/deploy/terraform/run/sap_landscape/module.tf
@@ -5,8 +5,9 @@
 
 module "sap_landscape" {
   providers = {
-    azurerm.main     = azurerm
-    azurerm.deployer = azurerm.deployer
+    azurerm.main          = azurerm
+    azurerm.deployer      = azurerm.deployer
+    azurerm.dnsmanagement = azurerm.dnsmanagement
   }
   source         = "../../terraform-units/modules/sap_landscape"
   infrastructure = local.infrastructure
@@ -31,6 +32,10 @@ module "sap_landscape" {
   )
   enable_purge_control_for_keyvaults = var.enable_purge_control_for_keyvaults
   use_private_endpoint               = var.use_private_endpoint
+  use_custom_dns_a_registration      = var.use_custom_dns_a_registration
+  management_dns_subscription_id     = var.management_dns_subscription_id
+  management_dns_resourcegroup_name  = var.management_dns_resourcegroup_name
+
 
   Agent_IP = var.Agent_IP
 

--- a/deploy/terraform/run/sap_landscape/providers.tf
+++ b/deploy/terraform/run/sap_landscape/providers.tf
@@ -18,7 +18,11 @@ provider "azurerm" {
       prevent_deletion_if_contains_resources = true
     }
     key_vault {
-      purge_soft_delete_on_destroy = !var.enable_purge_control_for_keyvaults
+      purge_soft_delete_on_destroy               = !var.enable_purge_control_for_keyvaults
+      purge_soft_deleted_keys_on_destroy         = !var.enable_purge_control_for_keyvaults
+      purge_soft_deleted_secrets_on_destroy      = !var.enable_purge_control_for_keyvaults
+      purge_soft_deleted_certificates_on_destroy = !var.enable_purge_control_for_keyvaults
+
     }
   }
   subscription_id = local.spn.subscription_id
@@ -35,6 +39,13 @@ provider "azurerm" {
   features {}
   subscription_id = length(local.deployer_subscription_id) > 0 ? local.deployer_subscription_id : null
   alias           = "deployer"
+}
+
+provider "azurerm" {
+  features {}
+  alias                      = "dnsmanagement"
+  subscription_id            = try(var.management_dns_subscription_id, null)
+  skip_provider_registration = true
 }
 
 provider "azurerm" {

--- a/deploy/terraform/run/sap_landscape/tfvar_variables.tf
+++ b/deploy/terraform/run/sap_landscape/tfvar_variables.tf
@@ -17,8 +17,8 @@ variable "codename" {
 
 variable "location" {
   description = "The Azure region for the resources"
-  type    = string
-  default = ""
+  type        = string
+  default     = ""
 }
 
 variable "name_override_file" {
@@ -34,17 +34,17 @@ variable "name_override_file" {
 
 variable "resourcegroup_name" {
   description = "If provided, the name of the resource group to be created"
-  default = ""
+  default     = ""
 }
 
 variable "resourcegroup_arm_id" {
   description = "If provided, the Azure resource group id"
-  default = ""
+  default     = ""
 }
 
 variable "resourcegroup_tags" {
   description = "Tags to be applied to the resource group"
-  default = {}
+  default     = {}
 }
 
 #########################################################################################
@@ -55,22 +55,22 @@ variable "resourcegroup_tags" {
 
 variable "network_name" {
   description = "If provided, the name of the Virtual network"
-  default = ""
+  default     = ""
 }
 
 variable "network_logical_name" {
   description = "The logical name of the virtual network, used for resource naming"
-  default = ""
+  default     = ""
 }
 
 variable "network_address_space" {
   description = "The address space of the virtual network"
-  default = ""
+  default     = ""
 }
 
 variable "network_arm_id" {
   description = "If provided, the Azure resource id of the virtual network"
-  default = ""
+  default     = ""
 }
 
 #########################################################################################
@@ -81,27 +81,27 @@ variable "network_arm_id" {
 
 variable "admin_subnet_name" {
   description = "If provided, the name of the admin subnet"
-  default = ""
+  default     = ""
 }
 
 variable "admin_subnet_arm_id" {
   description = "If provided, Azure resource id for the admin subnet"
-  default = ""
+  default     = ""
 }
 
 variable "admin_subnet_address_prefix" {
   description = "The address prefix for the admin subnet"
-  default = ""
+  default     = ""
 }
 
 variable "admin_subnet_nsg_name" {
   description = "If provided, the name of the admin subnet NSG"
-  default = ""
+  default     = ""
 }
 
 variable "admin_subnet_nsg_arm_id" {
   description = "If provided, Azure resource id for the admin subnet NSG"
-  default = ""
+  default     = ""
 }
 
 
@@ -113,27 +113,27 @@ variable "admin_subnet_nsg_arm_id" {
 
 variable "db_subnet_name" {
   description = "If provided, the name of the db subnet"
-  default = ""
+  default     = ""
 }
 
 variable "db_subnet_arm_id" {
   description = "If provided, Azure resource id for the db subnet"
-  default = ""
+  default     = ""
 }
 
 variable "db_subnet_address_prefix" {
   description = "The address prefix for the db subnet"
-  default = ""
+  default     = ""
 }
 
 variable "db_subnet_nsg_name" {
   description = "If provided, the name of the db subnet NSG"
-  default = ""
+  default     = ""
 }
 
 variable "db_subnet_nsg_arm_id" {
   description = "If provided, Azure resource id for the db subnet NSG"
-  default = ""
+  default     = ""
 }
 
 
@@ -145,27 +145,27 @@ variable "db_subnet_nsg_arm_id" {
 
 variable "app_subnet_name" {
   description = "If provided, the name of the app subnet"
-  default = ""
+  default     = ""
 }
 
 variable "app_subnet_arm_id" {
   description = "If provided, Azure resource id for the app subnet"
-  default = ""
+  default     = ""
 }
 
 variable "app_subnet_address_prefix" {
   description = "The address prefix for the app subnet"
-  default = ""
+  default     = ""
 }
 
 variable "app_subnet_nsg_name" {
   description = "If provided, the name of the app subnet NSG"
-  default = ""
+  default     = ""
 }
 
 variable "app_subnet_nsg_arm_id" {
   description = "If provided, Azure resource id for the app subnet NSG"
-  default = ""
+  default     = ""
 }
 
 
@@ -177,27 +177,27 @@ variable "app_subnet_nsg_arm_id" {
 
 variable "web_subnet_name" {
   description = "If provided, the name of the web subnet"
-  default = ""
+  default     = ""
 }
 
 variable "web_subnet_arm_id" {
   description = "If provided, Azure resource id for the web subnet"
-  default = ""
+  default     = ""
 }
 
 variable "web_subnet_address_prefix" {
   description = "The address prefix for the web subnet"
-  default = ""
+  default     = ""
 }
 
 variable "web_subnet_nsg_name" {
   description = "If provided, the name of the web subnet NSG"
-  default = ""
+  default     = ""
 }
 
 variable "web_subnet_nsg_arm_id" {
   description = "If provided, Azure resource id for the web subnet NSG"
-  default = ""
+  default     = ""
 }
 
 
@@ -209,17 +209,17 @@ variable "web_subnet_nsg_arm_id" {
 
 variable "anf_subnet_name" {
   description = "If provided, the name of the ANF subnet"
-  default = ""
+  default     = ""
 }
 
 variable "anf_subnet_arm_id" {
   description = "If provided, Azure resource id for the ANF subnet"
-  default = ""
+  default     = ""
 }
 
 variable "anf_subnet_address_prefix" {
   description = "The address prefix for the ANF subnet"
-  default = ""
+  default     = ""
 }
 
 variable "anf_subnet_nsg_name" {
@@ -238,28 +238,28 @@ variable "anf_subnet_nsg_arm_id" {
 
 variable "user_keyvault_id" {
   description = "If provided, the Azure resource identifier of the credentials keyvault"
-  default = ""
+  default     = ""
 }
 
 variable "spn_keyvault_id" {
   description = "If provided, the Azure resource identifier of the deployment credential keyvault"
-  default = ""
+  default     = ""
 }
 
 variable "enable_purge_control_for_keyvaults" {
   description = "Disables the purge protection for Azure keyvaults."
-  default = false
-  type = bool
+  default     = false
+  type        = bool
 }
 
 variable "enable_rbac_authorization_for_keyvault" {
   description = "Enables RBAC authorization for Azure keyvault"
-  default = false
+  default     = false
 }
 
 variable "additional_users_to_add_to_keyvault_policies" {
   description = "List of object IDs to add to key vault policies"
-  default = [""]
+  default     = [""]
 }
 
 #########################################################################################
@@ -270,27 +270,27 @@ variable "additional_users_to_add_to_keyvault_policies" {
 
 variable "automation_username" {
   description = "The username for the automation account"
-  default = "azureadm"
+  default     = "azureadm"
 }
 
 variable "automation_password" {
   description = "If provided, the password for the automation account"
-  default = ""
+  default     = ""
 }
 
 variable "automation_path_to_public_key" {
   description = "If provided, the path to the existing public key for the automation account"
-  default = ""
+  default     = ""
 }
 
 variable "automation_path_to_private_key" {
   description = "If provided, the path to the existing private key for the automation account"
-  default = ""
+  default     = ""
 }
 
 variable "use_spn" {
   description = "Log in using a service principal when performing the deployment"
-  default = true
+  default     = true
 }
 
 #########################################################################################
@@ -301,30 +301,47 @@ variable "use_spn" {
 
 variable "diagnostics_storage_account_arm_id" {
   description = "If provided, Azure resource id for the diagnostics storage account"
-  default = ""
+  default     = ""
 }
 
 variable "witness_storage_account_arm_id" {
   description = "If provided, Azure resource id for the witness storage account"
-  default = ""
+  default     = ""
 }
 
 variable "use_private_endpoint" {
   description = "Boolean value indicating if private endpoint should be used for the deployment"
-  default = false
-  type = bool
+  default     = false
+  type        = bool
 }
 
+variable "use_custom_dns_a_registration" {
+  description = "Boolean value indicating if a custom dns a record should be created when using private endpoints"
+  default     = false
+  type        = bool
+}
+
+variable "management_dns_subscription_id" {
+  description = "String value giving the possibility to register custom dns a records in a separate subscription"
+  default     = null
+  type        = string
+}
+
+variable "management_dns_resourcegroup_name" {
+  description = "String value giving the possibility to register custom dns a records in a separate resourcegroup"
+  default     = null
+  type        = string
+}
 variable "transport_storage_account_id" {
   description = "Azure Resource Identifier for the Transport media storage account"
-  type    = string
-  default = ""
+  type        = string
+  default     = ""
 }
 
 variable "transport_private_endpoint_id" {
   description = "Azure Resource Identifier for an private endpoint connection"
   type        = string
-  default = ""
+  default     = ""
 }
 
 variable "transport_volume_size" {
@@ -334,8 +351,8 @@ variable "transport_volume_size" {
 
 variable "install_storage_account_id" {
   description = "Azure Resource Identifier for the Installation media storage account"
-  type    = string
-  default = ""
+  type        = string
+  default     = ""
 }
 
 variable "install_volume_size" {
@@ -346,7 +363,7 @@ variable "install_volume_size" {
 variable "install_private_endpoint_id" {
   description = "Azure Resource Identifier for an private endpoint connection"
   type        = string
-  default = ""
+  default     = ""
 }
 
 
@@ -404,12 +421,12 @@ variable "ANF_transport_volume_name" {
 
 variable "ANF_transport_volume_throughput" {
   description = "If defined provides the throughput of the transport volume"
-  default = 128
+  default     = 128
 }
 
 variable "ANF_transport_volume_size" {
   description = "If defined provides the size of the transport volume"
-  default = 128
+  default     = 128
 }
 
 variable "ANF_use_existing_install_volume" {
@@ -424,12 +441,12 @@ variable "ANF_install_volume_name" {
 
 variable "ANF_install_volume_throughput" {
   description = "If defined provides the throughput of the install volume"
-  default = 128
+  default     = 128
 }
 
 variable "ANF_install_volume_size" {
   description = "If defined provides the size of the install volume"
-  default = 1024
+  default     = 1024
 }
 
 #########################################################################################
@@ -440,42 +457,42 @@ variable "ANF_install_volume_size" {
 
 variable "iscsi_subnet_name" {
   description = "If provided, the name of the iSCSI subnet"
-  default = ""
+  default     = ""
 }
 
 variable "iscsi_subnet_arm_id" {
   description = "If provided, Azure resource id for the iSCSI subnet"
-  default = ""
+  default     = ""
 }
 
 variable "iscsi_subnet_address_prefix" {
   description = "The address prefix for the iSCSI subnet"
-  default = ""
+  default     = ""
 }
 
 variable "iscsi_subnet_nsg_name" {
   description = "If provided, the name of the iSCSI subnet NSG"
-  default = ""
+  default     = ""
 }
 
 variable "iscsi_subnet_nsg_arm_id" {
   description = "If provided, Azure resource id for the iSCSI subnet NSG"
-  default = ""
+  default     = ""
 }
 
 variable "iscsi_count" {
   description = "The number of iSCSI Virtual Machines to create"
-  default = 0
+  default     = 0
 }
 
 variable "iscsi_size" {
   description = "The size of the iSCSI Virtual Machine"
-  default = ""
+  default     = ""
 }
 
 variable "iscsi_useDHCP" {
   description = "value indicating if iSCSI Virtual Machine should use DHCP"
-  default = false
+  default     = false
 }
 
 variable "iscsi_image" {
@@ -491,16 +508,16 @@ variable "iscsi_image" {
 
 variable "iscsi_authentication_type" {
   description = "iSCSI Virtual Machine authentication type"
-  default = "key"
+  default     = "key"
 }
 
 variable "iscsi_authentication_username" {
   description = "User name for iSCSI Virtual Machine"
-  default = "azureadm"
+  default     = "azureadm"
 }
 
 
 variable "iscsi_nic_ips" {
   description = "IP addresses for the iSCSI Virtual Machine NICs"
-  default = []
+  default     = []
 }

--- a/deploy/terraform/run/sap_library/module.tf
+++ b/deploy/terraform/run/sap_library/module.tf
@@ -3,23 +3,28 @@
   Setup sap library
 */
 module "sap_library" {
-   providers = {
-     azurerm.main     = azurerm
-     azurerm.deployer = azurerm.deployer
-   }
-  source                  = "../../terraform-units/modules/sap_library"
-  infrastructure          = local.infrastructure
-  storage_account_sapbits = local.storage_account_sapbits
-  storage_account_tfstate = local.storage_account_tfstate
-  software                = var.software
-  deployer                = local.deployer
-  key_vault               = local.key_vault
-  service_principal       = var.use_deployer ? local.service_principal : local.account
-  deployer_tfstate        = try(data.terraform_remote_state.deployer[0].outputs, [])
-  naming                  = length(var.name_override_file) > 0 ? local.custom_names : module.sap_namegenerator.naming
-  dns_label               = var.dns_label
-  use_private_endpoint    = var.use_private_endpoint
-  use_webapp              = var.use_webapp
+  providers = {
+    azurerm.main          = azurerm
+    azurerm.deployer      = azurerm.deployer
+    azurerm.dnsmanagement = azurerm.dnsmanagement
+  }
+  source                             = "../../terraform-units/modules/sap_library"
+  infrastructure                     = local.infrastructure
+  storage_account_sapbits            = local.storage_account_sapbits
+  storage_account_tfstate            = local.storage_account_tfstate
+  software                           = var.software
+  deployer                           = local.deployer
+  key_vault                          = local.key_vault
+  service_principal                  = var.use_deployer ? local.service_principal : local.account
+  deployer_tfstate                   = try(data.terraform_remote_state.deployer[0].outputs, [])
+  naming                             = length(var.name_override_file) > 0 ? local.custom_names : module.sap_namegenerator.naming
+  dns_label                          = var.dns_label
+  use_private_endpoint               = var.use_private_endpoint
+  use_custom_dns_a_registration      = var.use_custom_dns_a_registration
+  management_dns_subscription_id     = var.management_dns_subscription_id
+  management_dns_resourcegroup_name  = var.management_dns_resourcegroup_name
+  enable_purge_control_for_keyvaults = var.enable_purge_control_for_keyvaults
+  use_webapp                         = var.use_webapp
 }
 
 module "sap_namegenerator" {

--- a/deploy/terraform/run/sap_library/providers.tf
+++ b/deploy/terraform/run/sap_library/providers.tf
@@ -18,7 +18,14 @@ data "azurerm_client_config" "current" {
 }
 
 provider "azurerm" {
-  features {}
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy               = !var.enable_purge_control_for_keyvaults
+      purge_soft_deleted_keys_on_destroy         = !var.enable_purge_control_for_keyvaults
+      purge_soft_deleted_secrets_on_destroy      = !var.enable_purge_control_for_keyvaults
+      purge_soft_deleted_certificates_on_destroy = !var.enable_purge_control_for_keyvaults
+    }
+  }
   subscription_id = local.spn.subscription_id
   client_id       = var.use_deployer ? local.spn.client_id : null
   client_secret   = var.use_deployer ? local.spn.client_secret : null
@@ -28,8 +35,22 @@ provider "azurerm" {
 }
 
 provider "azurerm" {
-  features {}
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy               = !var.enable_purge_control_for_keyvaults
+      purge_soft_deleted_keys_on_destroy         = !var.enable_purge_control_for_keyvaults
+      purge_soft_deleted_secrets_on_destroy      = !var.enable_purge_control_for_keyvaults
+      purge_soft_deleted_certificates_on_destroy = !var.enable_purge_control_for_keyvaults
+    }
+  }
   alias = "deployer"
+}
+
+provider "azurerm" {
+  features {}
+  alias                      = "dnsmanagement"
+  subscription_id            = try(var.management_dns_subscription_id, null)
+  skip_provider_registration = true
 }
 
 provider "azuread" {

--- a/deploy/terraform/run/sap_library/tfvar_variables.tf
+++ b/deploy/terraform/run/sap_library/tfvar_variables.tf
@@ -163,11 +163,35 @@ variable "use_private_endpoint" {
   default = false
 }
 
+variable "use_custom_dns_a_registration" {
+  description = "Boolean value indicating if a custom dns a record should be created when using private endpoints"
+  default     = false
+  type        = bool
+}
+
+variable "management_dns_subscription_id" {
+  description = "String value giving the possibility to register custom dns a records in a separate subscription"
+  default     = null
+  type        = string
+}
+
+variable "management_dns_resourcegroup_name" {
+  description = "String value giving the possibility to register custom dns a records in a separate resourcegroup"
+  default     = null
+  type        = string
+}
+
 variable "use_webapp" {
   default = false
 }
 
 variable "name_override_file" {
   description = "If provided, contains a json formatted file defining the name overrides"
-  default = ""
+  default     = ""
+}
+
+variable "enable_purge_control_for_keyvaults" {
+  description = "Disables the purge protection for Azure keyvaults. USE THIS ONLY FOR TEST ENVIRONMENTS"
+  default     = true
+  type        = bool
 }

--- a/deploy/terraform/terraform-units/modules/sap_deployer/key_vault.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/key_vault.tf
@@ -36,6 +36,29 @@ resource "azurerm_key_vault" "kv_user" {
   }
 }
 
+resource "azurerm_private_dns_a_record" "kv_user" {
+  count               = var.use_private_endpoint && var.use_custom_dns_a_registration ? 1 : 0
+  name                = split(".", azurerm_private_endpoint.kv_user[count.index].custom_dns_configs[count.index].fqdn)[0]
+  zone_name           = "privatelink.vaultcore.azure.net"
+  resource_group_name = var.management_dns_resourcegroup_name
+  ttl                 = 3600
+  records             = azurerm_private_endpoint.kv_user[count.index].custom_dns_configs[count.index].ip_addresses
+
+  provider = azurerm.dnsmanagement
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+
+#Errors can occure when the dns record has not properly been activated, add a wait timer to give
+#it just a little bit more time
+resource "time_sleep" "wait_for_dns_refresh" {
+  create_duration = "120s"
+
+  depends_on = [azurerm_private_dns_a_record.kv_user]
+}
+
 // Import an existing user Key Vault
 data "azurerm_key_vault" "kv_user" {
   count               = (local.user_keyvault_exist) ? 1 : 0
@@ -104,7 +127,8 @@ resource "tls_private_key" "deployer" {
 resource "azurerm_key_vault_secret" "ppk" {
   depends_on = [
     azurerm_key_vault_access_policy.kv_user_pre_deployer[0],
-    azurerm_key_vault_access_policy.kv_user_msi[0]
+    azurerm_key_vault_access_policy.kv_user_msi[0],
+    time_sleep.wait_for_dns_refresh
   ]
   count        = (local.enable_key && !local.key_exist) ? 1 : 0
   name         = local.ppk_secret_name
@@ -115,7 +139,8 @@ resource "azurerm_key_vault_secret" "ppk" {
 resource "azurerm_key_vault_secret" "pk" {
   depends_on = [
     azurerm_key_vault_access_policy.kv_user_pre_deployer[0],
-    azurerm_key_vault_access_policy.kv_user_msi[0]
+    azurerm_key_vault_access_policy.kv_user_msi[0],
+    time_sleep.wait_for_dns_refresh
   ]
   count        = (local.enable_key && !local.key_exist) ? 1 : 0
   name         = local.pk_secret_name
@@ -126,7 +151,8 @@ resource "azurerm_key_vault_secret" "pk" {
 resource "azurerm_key_vault_secret" "username" {
   depends_on = [
     azurerm_key_vault_access_policy.kv_user_pre_deployer[0],
-    azurerm_key_vault_access_policy.kv_user_msi[0]
+    azurerm_key_vault_access_policy.kv_user_msi[0],
+    time_sleep.wait_for_dns_refresh
   ]
   count        = (!local.username_exist) ? 1 : 0
   name         = local.username_secret_name
@@ -153,7 +179,8 @@ resource "random_password" "deployer" {
 resource "azurerm_key_vault_secret" "pwd" {
   depends_on = [
     azurerm_key_vault_access_policy.kv_user_pre_deployer[0],
-    azurerm_key_vault_access_policy.kv_user_msi[0]
+    azurerm_key_vault_access_policy.kv_user_msi[0],
+    time_sleep.wait_for_dns_refresh
   ]
   count = (local.enable_password && !local.pwd_exist) ? 1 : 0
   name  = local.pwd_secret_name
@@ -165,24 +192,36 @@ resource "azurerm_key_vault_secret" "pwd" {
 }
 
 data "azurerm_key_vault_secret" "pk" {
+  depends_on = [
+    time_sleep.wait_for_dns_refresh
+  ]
   count        = (local.enable_key && local.key_exist) ? 1 : 0
   name         = local.pk_secret_name
   key_vault_id = local.user_key_vault_id
 }
 
 data "azurerm_key_vault_secret" "ppk" {
+  depends_on = [
+    time_sleep.wait_for_dns_refresh
+  ]
   count        = (local.enable_key && local.key_exist) ? 1 : 0
   name         = local.ppk_secret_name
   key_vault_id = local.user_key_vault_id
 }
 
 data "azurerm_key_vault_secret" "username" {
+  depends_on = [
+    time_sleep.wait_for_dns_refresh
+  ]
   count        = (local.username_exist) ? 1 : 0
   name         = local.username_secret_name
   key_vault_id = local.user_key_vault_id
 }
 
 data "azurerm_key_vault_secret" "pwd" {
+  depends_on = [
+    time_sleep.wait_for_dns_refresh
+  ]
   count        = (local.enable_password && local.pwd_exist) ? 1 : 0
   name         = local.pwd_secret_name
   key_vault_id = local.user_key_vault_id

--- a/deploy/terraform/terraform-units/modules/sap_deployer/providers.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/providers.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source                = "hashicorp/azurerm"
+      configuration_aliases = [azurerm.dnsmanagement]
+      version               = "~> 3.0"
+    }
+  }
+}

--- a/deploy/terraform/terraform-units/modules/sap_deployer/variables_global.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/variables_global.tf
@@ -17,7 +17,7 @@ variable "key_vault" {
 
 variable "additional_users_to_add_to_keyvault_policies" {
   description = "List of object IDs to add to key vault policies"
-} 
+}
 
 
 variable "enable_purge_control_for_keyvaults" {
@@ -44,34 +44,52 @@ variable "naming" {
 
 variable "firewall_deployment" {
   description = "Boolean flag indicating if an Azure Firewall should be deployed"
-  type = bool
+  type        = bool
 }
 
 variable "assign_subscription_permissions" {
   description = "Assign permissions on the subscription"
-  type = bool
+  type        = bool
 }
 
 variable "bootstrap" {}
 
 variable "use_private_endpoint" {
   description = "Boolean value indicating if private endpoint should be used for the deployment"
-  default = false
+  default     = false
+}
+
+variable "use_custom_dns_a_registration" {
+  description = "Boolean value indicating if a custom dns a record should be created when using private endpoints"
+  default     = false
+  type        = bool
+}
+
+variable "management_dns_subscription_id" {
+  description = "String value giving the possibility to register custom dns a records in a separate subscription"
+  default     = null
+  type        = string
+}
+
+variable "management_dns_resourcegroup_name" {
+  description = "String value giving the possibility to register custom dns a records in a separate resourcegroup"
+  default     = null
+  type        = string
 }
 
 variable "configure" {
   description = "Value indicating if deployer should be configured"
-  default = false
+  default     = false
 }
 
 variable "tf_version" {
   description = "Terraform version to install on deployer"
-  default = ""
+  default     = ""
 }
 
 variable "bastion_deployment" {
   description = "Value indicating if Azure Bastion should be deployed"
-  default = false
+  default     = false
 }
 
 ###############################################################################
@@ -91,8 +109,8 @@ variable "auto_configure_deployer" {
 
 variable "deployer_vm_count" {
   description = "Number of deployer VMs to create"
-  type    = number
-  default = 1
+  type        = number
+  default     = 1
 }
 
 variable "arm_client_id" {

--- a/deploy/terraform/terraform-units/modules/sap_landscape/providers.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source                = "hashicorp/azurerm"
-      configuration_aliases = [azurerm.main, azurerm.deployer]
+      configuration_aliases = [azurerm.main, azurerm.deployer, azurerm.dnsmanagement]
       version               = "~> 3.0"
     }
   }

--- a/deploy/terraform/terraform-units/modules/sap_landscape/storage_accounts.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/storage_accounts.tf
@@ -30,7 +30,7 @@ resource "azurerm_storage_account" "storage_bootdiag" {
 
   network_rules {
     default_action = "Deny"
-    ip_rules       = length(var.Agent_IP) > 0 ? [var.Agent_IP] : []
+    ip_rules       = var.use_private_endpoint ? ([]) : length(var.Agent_IP) > 0 ? [var.Agent_IP] : []
     bypass         = ["AzureServices", "Logging", "Metrics"]
     virtual_network_subnet_ids = var.use_private_endpoint ? (
       []
@@ -53,6 +53,21 @@ resource "azurerm_storage_account" "storage_bootdiag" {
         ]
       )
     )
+  }
+}
+
+resource "azurerm_private_dns_a_record" "storage_bootdiag" {
+  count               = var.use_private_endpoint && var.use_custom_dns_a_registration ? 1 : 0
+  name                = split(".", azurerm_private_endpoint.storage_bootdiag[count.index].custom_dns_configs[count.index].fqdn)[0]
+  zone_name           = "privatelink.file.core.windows.net"
+  resource_group_name = var.management_dns_resourcegroup_name
+  ttl                 = 3600
+  records             = azurerm_private_endpoint.storage_bootdiag[count.index].custom_dns_configs[count.index].ip_addresses
+
+  provider = azurerm.dnsmanagement
+
+  lifecycle {
+    ignore_changes = [tags]
   }
 }
 
@@ -128,7 +143,7 @@ resource "azurerm_storage_account" "witness_storage" {
 
   network_rules {
     default_action = "Deny"
-    ip_rules       = length(var.Agent_IP) > 0 ? [var.Agent_IP] : []
+    ip_rules       = var.use_private_endpoint ? ([]) : length(var.Agent_IP) > 0 ? [var.Agent_IP] : []
     bypass         = ["AzureServices", "Logging", "Metrics"]
     virtual_network_subnet_ids = var.use_private_endpoint ? (
       []
@@ -147,6 +162,21 @@ resource "azurerm_storage_account" "witness_storage" {
         ]
       )
     )
+  }
+}
+
+resource "azurerm_private_dns_a_record" "witness_storage" {
+  count               = var.use_private_endpoint && var.use_custom_dns_a_registration ? 1 : 0
+  name                = split(".", azurerm_private_endpoint.witness_storage[count.index].custom_dns_configs[count.index].fqdn)[0]
+  zone_name           = "privatelink.file.core.windows.net"
+  resource_group_name = var.management_dns_resourcegroup_name
+  ttl                 = 3600
+  records             = azurerm_private_endpoint.witness_storage[count.index].custom_dns_configs[count.index].ip_addresses
+
+  provider = azurerm.dnsmanagement
+
+  lifecycle {
+    ignore_changes = [tags]
   }
 }
 
@@ -227,7 +257,7 @@ resource "azurerm_storage_account" "transport" {
 
   network_rules {
     default_action = "Deny"
-    ip_rules       = length(var.Agent_IP) > 0 ? [var.Agent_IP] : []
+    ip_rules       = var.use_private_endpoint ? ([]) : length(var.Agent_IP) > 0 ? [var.Agent_IP] : []
     bypass         = ["AzureServices", "Logging", "Metrics"]
     virtual_network_subnet_ids = var.use_private_endpoint ? (
       compact(
@@ -250,6 +280,21 @@ resource "azurerm_storage_account" "transport" {
         ]
       )
     )
+  }
+}
+
+resource "azurerm_private_dns_a_record" "transport" {
+  count               = var.use_private_endpoint && var.use_custom_dns_a_registration && var.NFS_provider == "AFS" ? 1 : 0
+  name                = split(".", azurerm_private_endpoint.transport[count.index].custom_dns_configs[count.index].fqdn)[0]
+  zone_name           = "privatelink.file.core.windows.net"
+  resource_group_name = var.management_dns_resourcegroup_name
+  ttl                 = 3600
+  records             = azurerm_private_endpoint.transport[count.index].custom_dns_configs[count.index].ip_addresses
+
+  provider = azurerm.dnsmanagement
+
+  lifecycle {
+    ignore_changes = [tags]
   }
 }
 
@@ -389,7 +434,7 @@ resource "azurerm_storage_account" "install" {
 
   network_rules {
     default_action = "Deny"
-    ip_rules       = length(var.Agent_IP) > 0 ? [var.Agent_IP] : []
+    ip_rules       = var.use_private_endpoint ? ([]) : length(var.Agent_IP) > 0 ? [var.Agent_IP] : []
     bypass         = ["AzureServices", "Logging", "Metrics"]
     virtual_network_subnet_ids = var.use_private_endpoint ? (
       compact(
@@ -428,6 +473,21 @@ resource "azurerm_storage_account" "install" {
         ]
       )
     )
+  }
+}
+
+resource "azurerm_private_dns_a_record" "install" {
+  count               = var.use_private_endpoint && var.use_custom_dns_a_registration && var.NFS_provider == "AFS" ? 1 : 0
+  name                = split(".", azurerm_private_endpoint.install[count.index].custom_dns_configs[count.index].fqdn)[0]
+  zone_name           = "privatelink.file.core.windows.net"
+  resource_group_name = var.management_dns_resourcegroup_name
+  ttl                 = 3600
+  records             = azurerm_private_endpoint.install[count.index].custom_dns_configs[count.index].ip_addresses
+
+  provider = azurerm.dnsmanagement
+
+  lifecycle {
+    ignore_changes = [tags]
   }
 }
 

--- a/deploy/terraform/terraform-units/modules/sap_landscape/variables_global.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/variables_global.tf
@@ -163,7 +163,7 @@ variable "install_storage_account_id" {
 variable "install_private_endpoint_id" {
   description = "Azure Resource Identifier for an private endpoint connection"
   type        = string
-  default = ""
+  default     = ""
 }
 
 #########################################################################################
@@ -234,6 +234,24 @@ variable "use_private_endpoint" {
   type        = bool
   description = "Private endpoint"
   default     = false
+}
+
+variable "use_custom_dns_a_registration" {
+  description = "Boolean value indicating if a custom dns a record should be created when using private endpoints"
+  default     = false
+  type        = bool
+}
+
+variable "management_dns_subscription_id" {
+  description = "String value giving the possibility to register custom dns a records in a separate subscription"
+  default     = null
+  type        = string
+}
+
+variable "management_dns_resourcegroup_name" {
+  description = "String value giving the possibility to register custom dns a records in a separate resourcegroup"
+  default     = null
+  type        = string
 }
 
 variable "NFS_provider" {

--- a/deploy/terraform/terraform-units/modules/sap_library/providers.tf
+++ b/deploy/terraform/terraform-units/modules/sap_library/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source                = "hashicorp/azurerm"
-      configuration_aliases = [azurerm.main, azurerm.deployer]
+      configuration_aliases = [azurerm.main, azurerm.deployer, azurerm.dnsmanagement]
       version               = "~> 3.0"
     }
   }

--- a/deploy/terraform/terraform-units/modules/sap_library/storage_accounts.tf
+++ b/deploy/terraform/terraform-units/modules/sap_library/storage_accounts.tf
@@ -31,22 +31,48 @@ resource "azurerm_storage_account" "storage_tfstate" {
   }
 
   network_rules {
-    default_action = var.use_private_endpoint  ? "Deny" : "Allow"
+    default_action = var.use_private_endpoint ? "Deny" : "Allow"
     ip_rules = var.use_private_endpoint && local.deployer_public_ip_address_used ? (
       [local.deployer_public_ip_address]) : (
       []
     )
-    virtual_network_subnet_ids = var.use_private_endpoint && local.deployer_tfstate_subnet_used ? (
+    virtual_network_subnet_ids = !var.use_private_endpoint && local.deployer_tfstate_subnet_used ? (
       var.use_webapp ? (
         [var.deployer_tfstate.subnet_webapp_id, var.deployer_tfstate.subnet_mgmt_id]) : (
-        [var.deployer_tfstate.subnet_mgmt_id])) : (
+      [var.deployer_tfstate.subnet_mgmt_id])) : (
       []
-    ) 
+    )
   }
 
   min_tls_version                 = "TLS1_2"
   allow_nested_items_to_be_public = false
 
+}
+
+resource "azurerm_private_dns_a_record" "storage_tfstate_pep_a_record_registry" {
+  count               = var.use_private_endpoint && !local.sa_tfstate_exists ? 1 : 0
+  name                = split(".", azurerm_private_endpoint.storage_tfstate[count.index].custom_dns_configs[count.index].fqdn)[0]
+  zone_name           = "privatelink.blob.core.windows.net"
+  resource_group_name = var.management_dns_resourcegroup_name
+  ttl                 = 3600
+  records             = azurerm_private_endpoint.storage_tfstate[count.index].custom_dns_configs[count.index].ip_addresses
+
+  provider = azurerm.dnsmanagement
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+
+#Errors can occure when the dns record has not properly been activated, add a wait timer to give
+#it just a little bit more time
+resource "time_sleep" "wait_for_dns_refresh" {
+  create_duration = "120s"
+
+  depends_on = [
+    azurerm_private_dns_a_record.storage_tfstate_pep_a_record_registry,
+    azurerm_private_dns_a_record.storage_sapbits_pep_a_record_registry
+  ]
 }
 
 // Imports existing storage account to use for tfstate
@@ -68,6 +94,11 @@ resource "azurerm_storage_container" "storagecontainer_tfstate" {
     azurerm_storage_account.storage_tfstate[0].name
   )
   container_access_type = "private"
+
+  depends_on = [
+    time_sleep.wait_for_dns_refresh,
+    azurerm_private_endpoint.storage_tfstate
+  ]
 }
 
 data "azurerm_storage_container" "storagecontainer_tfstate" {
@@ -78,6 +109,11 @@ data "azurerm_storage_container" "storagecontainer_tfstate" {
     data.azurerm_storage_account.storage_tfstate[0].name) : (
     azurerm_storage_account.storage_tfstate[0].name
   )
+
+  depends_on = [
+    time_sleep.wait_for_dns_refresh,
+    azurerm_private_endpoint.storage_tfstate
+  ]
 }
 
 resource "azurerm_private_endpoint" "storage_tfstate" {
@@ -108,7 +144,7 @@ resource "azurerm_private_endpoint" "storage_tfstate" {
       azurerm_storage_account.storage_tfstate[0].id
     )
     subresource_names = [
-      "File"
+      "Blob"
     ]
   }
 }
@@ -133,12 +169,12 @@ resource "azurerm_storage_account" "storage_sapbits" {
   enable_https_traffic_only = true
 
   network_rules {
-    default_action = var.use_private_endpoint  ? "Deny" : "Allow"
+    default_action = var.use_private_endpoint ? "Deny" : "Allow"
     ip_rules = var.use_private_endpoint && local.deployer_public_ip_address_used ? (
       [local.deployer_public_ip_address]) : (
       []
     )
-    virtual_network_subnet_ids = var.use_private_endpoint && local.deployer_tfstate_subnet_used ? (
+    virtual_network_subnet_ids = !var.use_private_endpoint && local.deployer_tfstate_subnet_used ? (
       [var.deployer_tfstate.subnet_mgmt_id]) : (
       []
     )
@@ -147,6 +183,21 @@ resource "azurerm_storage_account" "storage_sapbits" {
   min_tls_version                 = "TLS1_2"
   allow_nested_items_to_be_public = false
 
+}
+
+resource "azurerm_private_dns_a_record" "storage_sapbits_pep_a_record_registry" {
+  count               = var.use_private_endpoint && !local.sa_sapbits_exists ? 1 : 0
+  name                = split(".", azurerm_private_endpoint.storage_sapbits[count.index].custom_dns_configs[count.index].fqdn)[0]
+  zone_name           = "privatelink.blob.core.windows.net"
+  resource_group_name = var.management_dns_resourcegroup_name
+  ttl                 = 3600
+  records             = azurerm_private_endpoint.storage_sapbits[count.index].custom_dns_configs[count.index].ip_addresses
+
+  provider = azurerm.dnsmanagement
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
 }
 
 data "azurerm_storage_account" "storage_sapbits" {
@@ -186,7 +237,7 @@ resource "azurerm_private_endpoint" "storage_sapbits" {
       azurerm_storage_account.storage_sapbits[0].id
     )
     subresource_names = [
-      "File"
+      "Blob"
     ]
   }
 }
@@ -201,6 +252,10 @@ data "azurerm_storage_container" "storagecontainer_sapbits" {
     data.azurerm_storage_account.storage_sapbits[0].name) : (
     azurerm_storage_account.storage_sapbits[0].name
   )
+  depends_on = [
+    azurerm_private_endpoint.storage_sapbits,
+    time_sleep.wait_for_dns_refresh
+  ]
 }
 
 // Creates the storage container inside the storage account for SAP bits
@@ -213,6 +268,10 @@ resource "azurerm_storage_container" "storagecontainer_sapbits" {
     azurerm_storage_account.storage_sapbits[0].name
   )
   container_access_type = "private"
+  depends_on = [
+    azurerm_private_endpoint.storage_sapbits,
+    time_sleep.wait_for_dns_refresh
+  ]
 }
 
 // Creates file share inside the storage account for SAP bits

--- a/deploy/terraform/terraform-units/modules/sap_library/variables_global.tf
+++ b/deploy/terraform/terraform-units/modules/sap_library/variables_global.tf
@@ -100,6 +100,30 @@ variable "use_private_endpoint" {
   default = false
 }
 
+variable "use_custom_dns_a_registration" {
+  description = "Boolean value indicating if a custom dns a record should be created when using private endpoints"
+  default     = false
+  type        = bool
+}
+
+variable "management_dns_subscription_id" {
+  description = "String value giving the possibility to register custom dns a records in a separate subscription"
+  default     = null
+  type        = string
+}
+
+variable "management_dns_resourcegroup_name" {
+  description = "String value giving the possibility to register custom dns a records in a separate resourcegroup"
+  default     = null
+  type        = string
+}
+
+variable "enable_purge_control_for_keyvaults" {
+  description = "Allow the deployment to control the purge protection"
+  type        = bool
+  default     = true
+}
+
 variable "use_webapp" {
   default = false
 }


### PR DESCRIPTION
## Problem
Following company policies, all resources should be configured with Private End Points (PEP) and network access needs to be restricted. Due to automatic DNS registration is disabled the need is there to register a DNS-A record for each PEP deployed. That DNS-A record can be managed in a separate subscription.

During testing of the removal I encountered the issue of purging secrets.

## Solution
- [X] Adding DNS-A records to resources (keyvault, storage account)
- [X] Adding a Wait for DNS resolution when deployment continues with actions on the resources (adding containers, or adding secrets)
- [X] Adding a Management-DNS provider to register DNS-A records in a separate subscription/resourcegroup, optionally
- [X] Adding additional feature configuration to not only cover kevault deletion when purge is disabled but also do this for the keys and secrets in that vault.
- [X] When a PEP is used there should be no need for IP exclusions anymore
- 

## Tests
Create a configuration for deployer, library, landscape, system with the following enabled
```
enable_purge_control_for_keyvaults=true
use_private_endpoint=true
use_custom_dns_a_registration=true
management_dns_subscription_id="<SubscriptionId for DNS-A records>"
management_dns_resourcegroup_name="<Resourcegroup name for DNS-A records"
```

1. run deploy controlplane (pipeline 01)
2. run deploy landscape (pipeline 02)
3. run deploy system (pipeline 03)
4. remove all (pipeline 10)

## Notes
Due to inability to deploy without private endpoints I was not able to test the negative of my tests

```
enable_purge_control_for_keyvaults=true
use_private_endpoint=false
use_custom_dns_a_registration=fasle
```