### PR TITLE
🐛 Add missing parameter for removal of library secrets 

### DIFF
--- a/deploy/terraform/bootstrap/sap_library/module.tf
+++ b/deploy/terraform/bootstrap/sap_library/module.tf
@@ -9,21 +9,22 @@ module "sap_library" {
     azurerm.deployer      = azurerm.deployer
     azurerm.dnsmanagement = azurerm.dnsmanagement
   }
-  infrastructure                    = local.infrastructure
-  storage_account_sapbits           = local.storage_account_sapbits
-  storage_account_tfstate           = local.storage_account_tfstate
-  software                          = var.software
-  deployer                          = local.deployer
-  key_vault                         = local.key_vault
-  service_principal                 = var.use_deployer ? local.service_principal : local.account
-  deployer_tfstate                  = try(data.terraform_remote_state.deployer[0].outputs, [])
-  naming                            = length(var.name_override_file) > 0 ? local.custom_names : module.sap_namegenerator.naming
-  dns_label                         = var.dns_label
-  use_private_endpoint              = var.use_private_endpoint
-  use_custom_dns_a_registration     = var.use_custom_dns_a_registration
-  management_dns_subscription_id    = var.management_dns_subscription_id
-  management_dns_resourcegroup_name = var.management_dns_resourcegroup_name
-  use_webapp                        = var.use_webapp
+  infrastructure                     = local.infrastructure
+  storage_account_sapbits            = local.storage_account_sapbits
+  storage_account_tfstate            = local.storage_account_tfstate
+  software                           = var.software
+  deployer                           = local.deployer
+  key_vault                          = local.key_vault
+  service_principal                  = var.use_deployer ? local.service_principal : local.account
+  deployer_tfstate                   = try(data.terraform_remote_state.deployer[0].outputs, [])
+  naming                             = length(var.name_override_file) > 0 ? local.custom_names : module.sap_namegenerator.naming
+  dns_label                          = var.dns_label
+  use_private_endpoint               = var.use_private_endpoint
+  use_custom_dns_a_registration      = var.use_custom_dns_a_registration
+  management_dns_subscription_id     = var.management_dns_subscription_id
+  management_dns_resourcegroup_name  = var.management_dns_resourcegroup_name
+  enable_purge_control_for_keyvaults = var.enable_purge_control_for_keyvaults
+  use_webapp                         = var.use_webapp
 }
 
 module "sap_namegenerator" {


### PR DESCRIPTION
## Problem
During previous PR, while syncing the different repo's, missed one setting to enable the deletion of the control plane. That setting needs to be passed to setup the provider to not do the purge after the softdelte if purge prevention is enabled

## Solution
Pass the variable to the module in the bootstrap, same way we do during the run.

## Tests
1. Deploy control-plane (pipeline 01)
2. Remove control-plane (pipeline 10, just the control-plane option)

## Notes
<Additional comments for the PR>