### PR TITLE
🐛 set deployer_environment_file to prevent lock

### DIFF
--- a/deploy/pipelines/03-sap-system-deployment.yaml
+++ b/deploy/pipelines/03-sap-system-deployment.yaml
@@ -157,6 +157,7 @@ stages:
 
               echo -e "$green--- Define variables ---$reset"
                 cd $HOME/SYSTEM/$(sap_system_folder)
+                deployer_environment_file_name=$HOME/.sap_deployment_automation/$(deployer_environment)$(deployer_region)
 
                 if [ -z $(REMOTE_STATE_SA) ]; then
                   export REMOTE_STATE_SA=$(cat ${deployer_environment_file_name}      | grep REMOTE_STATE_SA      | awk -F'=' '{print $2}' | xargs) ; echo 'Terraform state file storage account' $REMOTE_STATE_SA


### PR DESCRIPTION
## Problem
When deploying system there is a cat with grep construction to get deployer info from the file. However the variable filename is not set so it will wait until timeout

## Solution
Set the variable

## Tests
Run 03 pipeline

## Notes
<Additional comments for the PR>