### PR TITLE
🐛 use PAT token instead of system.access due to priveledges

### DIFF
--- a/deploy/pipelines/02-sap-workload-zone.yaml
+++ b/deploy/pipelines/02-sap-workload-zone.yaml
@@ -167,7 +167,6 @@ stages:
                 az config set extension.use_dynamic_install=yes_without_prompt >/dev/null 2>&1
                 az devops configure -d organization=$(System.CollectionUri)
                 az devops configure -d project=$(System.TeamProject)
-                export AZURE_DEVOPS_EXT_PAT=$(System.AccessToken)
 
                 export PARENT_VARIABLE_GROUP_ID=$(az pipelines variable-group list --query "[?name=='$(parent_variable_group)'].id | [0]")
                 echo '$(parent_variable_group) id: ' $PARENT_VARIABLE_GROUP_ID
@@ -450,5 +449,6 @@ stages:
               ARM_CLIENT_ID:           $(ARM_CLIENT_ID)
               ARM_CLIENT_SECRET:       $(ARM_CLIENT_SECRET)
               ARM_TENANT_ID:           $(ARM_TENANT_ID)
+              AZURE_DEVOPS_EXT_PAT:    $(PAT)
             failOnStderr:              false
 ...


### PR DESCRIPTION
## Problem
In pipeline sap-workload-zone your trying to write back keyvault name into the library for the landscape you just deployed. However passing in System.Access does not have the priveledges to do that action.

## Solution
 Need to pass $PAT to AZURE_DEVOPS_EXT_PAT to have the correct access like you did in 01-deploy-control-plane

## Tests
Run pipeline 02, and validate that there is not access error at the end of the deployment phase. It would still report green.

## Notes
<Additional comments for the PR>