### PR TITLE
Corrected the condition job_result.rc 

### DIFF
--- a/deploy/ansible/roles-sap/5.1-dbload/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.1-dbload/tasks/main.yaml
@@ -188,7 +188,7 @@
         mode:                          0755
       when:
         - job_result is defined
-        - job_result.rc > 0
+        - job_result.rc == 0
 
   when:
     - not dbload_installed.stat.exists


### PR DESCRIPTION




## Problem
The step file was not created as condition was job_result.rc > 0  .

## Solution
job_result.rc > 0  ---> job_result.rc == 0

## Tests
Install should create a step file for DBLoad step if its executed successfully

## Notes
<Additional comments for the PR>