### PR TITLE
Declare idle_timeout_scs_ers var and pass it to the app_tier module

### DIFF
--- a/deploy/terraform/run/sap_system/module.tf
+++ b/deploy/terraform/run/sap_system/module.tf
@@ -85,7 +85,6 @@ module "common_infrastructure" {
   sapmnt_private_endpoint_id         = var.sapmnt_private_endpoint_id
   deploy_application_security_groups = var.deploy_application_security_groups
   use_service_endpoint               = var.use_service_endpoint
-
 }
 
 
@@ -192,6 +191,7 @@ module "app_tier" {
   cloudinit_growpart_config                    = null # This needs more consideration module.common_infrastructure.cloudinit_growpart_config
   license_type                                 = var.license_type
   use_loadbalancers_for_standalone_deployments = var.use_loadbalancers_for_standalone_deployments
+  idle_timeout_scs_ers                         = var.idle_timeout_scs_ers
   use_secondary_ips                            = var.use_secondary_ips
   deploy_application_security_groups           = var.deploy_application_security_groups
   use_msi_for_clusters                         = var.use_msi_for_clusters

--- a/deploy/terraform/run/sap_system/tfvar_variables.tf
+++ b/deploy/terraform/run/sap_system/tfvar_variables.tf
@@ -725,6 +725,11 @@ variable "use_loadbalancers_for_standalone_deployments" {
   default     = true
 }
 
+variable "idle_timeout_scs_ers" {
+  description = "Sets the idle timeout setting for the SCS and ERS loadbalancer"
+  default     = 4
+}
+
 variable "bom_name" {
   description = "NAme of the SAP Application Bill of Material file"
   default     = ""


### PR DESCRIPTION
## Problem
The introduced idle_timeout_scs_ers variable for the timeout of the SCS/ERS loadbalancers wasn't declared in the sap_system run  module. 

## Solution
Declare the variable in the sap_system run module and pass it to the app_tier module.

## Tests

## Notes
