### PR TITLE
Fix #254

### DIFF
--- a/deploy/scripts/deploy_utils.sh
+++ b/deploy/scripts/deploy_utils.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export PATH=/opt/terraform/bin:/opt/ansible/bin:${PATH}
+export PATH=${PATH}:/opt/terraform/bin:/opt/ansible/bin
 
 #########################################################################
 # Helper utilities


### PR DESCRIPTION
## Problem
prepare_region.sh fails due to Azure CLI detection error. Detail is described in #254 .
Because current code prioritizes ansible python (/opt/ansible/bin/python3.9) rather than default python (/usr/bin/python), execution of az command fails with "No module" error.

## Solution
prioritize default path so that /usr/bin/python is used for az command.

## Tests
execute prepare_region.sh

## Notes
