### PR TITLE
Make sure ansible can access azure resources

### DIFF
--- a/deploy/pipelines/01-deploy-control-plane.yaml
+++ b/deploy/pipelines/01-deploy-control-plane.yaml
@@ -376,14 +376,6 @@ stages:
                        file_key_vault=$(cat ${deployer_environment_file_name} | grep keyvault= | awk -F'=' '{print $2}' | xargs)
                        echo 'Deployer Key Vault' ${file_key_vault}
 
-                       deployer_ip=$(cat ${deployer_environment_file_name} | grep deployer_public_ip_address | awk -F'=' '{print $2}' | xargs )
-                       if [[ ! -z "$deployer_ip" ]]; then
-                           use_deployer_vm=true
-                        else
-                           use_deployer_vm=false
-                       fi
-                       echo 'Use Deployer VM' ${use_deployer_vm}
-
                        file_REMOTE_STATE_SA=$(cat ${deployer_environment_file_name} | grep REMOTE_STATE_SA | awk -F'=' '{print $2}' | xargs)
                        echo 'Terraform state file storage account' $file_REMOTE_STATE_SA
 
@@ -496,13 +488,6 @@ stages:
                             az pipelines variable-group variable create --group-id ${VARIABLE_GROUP_ID} --name Deployer_Key_Vault --value ${file_key_vault} --output none --only-show-errors
                         else
                             az pipelines variable-group variable update --group-id ${VARIABLE_GROUP_ID} --name Deployer_Key_Vault --value ${file_key_vault} --output none --only-show-errors
-                        fi
-
-                        az_var=$(az pipelines variable-group variable list --group-id ${VARIABLE_GROUP_ID} --query "Use_Deployer_VM.value")
-                        if [ -z ${az_var} ]; then
-                            az pipelines variable-group variable create --group-id ${VARIABLE_GROUP_ID} --name Use_Deployer_VM --value ${use_deployer_vm} --output none --only-show-errors
-                        else
-                            az pipelines variable-group variable update --group-id ${VARIABLE_GROUP_ID} --name Use_Deployer_VM --value ${use_deployer_vm} --output none --only-show-errors
                         fi
                     fi
                 exit $return_code

--- a/deploy/pipelines/01-deploy-control-plane.yaml
+++ b/deploy/pipelines/01-deploy-control-plane.yaml
@@ -376,6 +376,14 @@ stages:
                        file_key_vault=$(cat ${deployer_environment_file_name} | grep keyvault= | awk -F'=' '{print $2}' | xargs)
                        echo 'Deployer Key Vault' ${file_key_vault}
 
+                       deployer_ip=$(cat ${deployer_environment_file_name} | grep deployer_public_ip_address | awk -F'=' '{print $2}' | xargs )
+                       if [[ ! -z "$deployer_ip" ]]; then
+                           use_deployer_vm=true
+                        else
+                           use_deployer_vm=false
+                       fi
+                       echo 'Use Deployer VM' ${use_deployer_vm}
+
                        file_REMOTE_STATE_SA=$(cat ${deployer_environment_file_name} | grep REMOTE_STATE_SA | awk -F'=' '{print $2}' | xargs)
                        echo 'Terraform state file storage account' $file_REMOTE_STATE_SA
 
@@ -488,6 +496,13 @@ stages:
                             az pipelines variable-group variable create --group-id ${VARIABLE_GROUP_ID} --name Deployer_Key_Vault --value ${file_key_vault} --output none --only-show-errors
                         else
                             az pipelines variable-group variable update --group-id ${VARIABLE_GROUP_ID} --name Deployer_Key_Vault --value ${file_key_vault} --output none --only-show-errors
+                        fi
+
+                        az_var=$(az pipelines variable-group variable list --group-id ${VARIABLE_GROUP_ID} --query "Use_Deployer_VM.value")
+                        if [ -z ${az_var} ]; then
+                            az pipelines variable-group variable create --group-id ${VARIABLE_GROUP_ID} --name Use_Deployer_VM --value ${use_deployer_vm} --output none --only-show-errors
+                        else
+                            az pipelines variable-group variable update --group-id ${VARIABLE_GROUP_ID} --name Use_Deployer_VM --value ${use_deployer_vm} --output none --only-show-errors
                         fi
                     fi
                 exit $return_code

--- a/deploy/pipelines/05-DB-and-SAP-installation.yaml
+++ b/deploy/pipelines/05-DB-and-SAP-installation.yaml
@@ -227,7 +227,7 @@ stages:
 
               echo -e "$green--- az login ---$reset"
 
-                if [${USE_DEPLOYER_VM^^} == "TRUE" ]; then
+                if [ ${USE_DEPLOYER_VM^^} = "TRUE" ]; then
                   az login --identity --allow-no-subscriptions --output none
                 else
                   az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID --output none
@@ -250,6 +250,7 @@ stages:
             displayName:               Preparation for Ansible
             env:
               SYSTEM_ACCESSTOKEN:        $(System.AccessToken)
+              AZURE_DEVOPS_EXT_PAT:      $(System.AccessToken)
               ANSIBLE_HOST_KEY_CHECKING: false
               USE_DEPLOYER_VM:           $(Use_Deployer_VM)
               AZURE_CLIENT_ID:           $(ARM_CLIENT_ID)
@@ -292,7 +293,7 @@ stages:
 
           - script: |
               #Stage could be executed on a different machine by default, need to login again for ansible
-              if [${USE_DEPLOYER_VM^^} == "TRUE" ]; then
+              if [ ${USE_DEPLOYER_VM^^} = "TRUE" ]; then
                 az login --identity --allow-no-subscriptions --output none
               else
                 az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID --output none
@@ -348,7 +349,7 @@ stages:
             displayName:               Process sshkey
           - script: |
               #Stage could be executed on a different machine by default, need to login again for ansible
-              if [${USE_DEPLOYER_VM^^} == "TRUE" ]; then
+              if [ ${USE_DEPLOYER_VM^^} = "TRUE" ]; then
                 az login --identity --allow-no-subscriptions --output none
               else
                 az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID --output none
@@ -404,7 +405,7 @@ stages:
             displayName:               Process sshkey
           - script: |
               #Stage could be executed on a different machine by default, need to login again for ansible
-              if [${USE_DEPLOYER_VM^^} == "TRUE" ]; then
+              if [ ${USE_DEPLOYER_VM^^} = "TRUE" ]; then
                 az login --identity --allow-no-subscriptions --output none
               else
                 az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID --output none
@@ -461,7 +462,7 @@ stages:
             displayName:               Process sshkey
           - script: |
               #Stage could be executed on a different machine by default, need to login again for ansible
-              if [${USE_DEPLOYER_VM^^} == "TRUE" ]; then
+              if [ ${USE_DEPLOYER_VM^^} = "TRUE" ]; then
                 az login --identity --allow-no-subscriptions --output none
               else
                 az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID --output none
@@ -520,7 +521,7 @@ stages:
             displayName:               Process sshkey
           - script: |
               #Stage could be executed on a different machine by default, need to login again for ansible
-              if [${USE_DEPLOYER_VM^^} == "TRUE" ]; then
+              if [ ${USE_DEPLOYER_VM^^} = "TRUE" ]; then
                 az login --identity --allow-no-subscriptions --output none
               else
                 az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID --output none
@@ -600,7 +601,7 @@ stages:
             displayName:               Process sshkey
           - script: |
               #Stage could be executed on a different machine by default, need to login again for ansible
-              if [${USE_DEPLOYER_VM^^} == "TRUE" ]; then
+              if [ ${USE_DEPLOYER_VM^^} = "TRUE" ]; then
                 az login --identity --allow-no-subscriptions --output none
               else
                 az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID --output none
@@ -684,7 +685,7 @@ stages:
             displayName:               Process sshkey
           - script: |
               #Stage could be executed on a different machine by default, need to login again for ansible
-              if [${USE_DEPLOYER_VM^^} == "TRUE" ]; then
+              if [ ${USE_DEPLOYER_VM^^} = "TRUE" ]; then
                 az login --identity --allow-no-subscriptions --output none
               else
                 az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID --output none
@@ -765,7 +766,7 @@ stages:
             displayName:               Process sshkey
           - script: |
               #Stage could be executed on a different machine by default, need to login again for ansible
-              if [${USE_DEPLOYER_VM^^} == "TRUE" ]; then
+              if [ ${USE_DEPLOYER_VM^^} = "TRUE" ]; then
                 az login --identity --allow-no-subscriptions --output none
               else
                 az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID --output none
@@ -828,7 +829,7 @@ stages:
             displayName:               Process sshkey
           - script: |
               #Stage could be executed on a different machine by default, need to login again for ansible
-              if [${USE_DEPLOYER_VM^^} == "TRUE" ]; then
+              if [ ${USE_DEPLOYER_VM^^} = "TRUE" ]; then
                 az login --identity --allow-no-subscriptions --output none
               else
                 az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID --output none
@@ -915,7 +916,7 @@ stages:
             displayName:               Process sshkey
           - script: |
               #Stage could be executed on a different machine by default, need to login again for ansible
-              if [${USE_DEPLOYER_VM^^} == "TRUE" ]; then
+              if [ ${USE_DEPLOYER_VM^^} = "TRUE" ]; then
                 az login --identity --allow-no-subscriptions --output none
               else
                 az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID --output none
@@ -992,7 +993,7 @@ stages:
             displayName:               Process sshkey
           - script: |
               #Stage could be executed on a different machine by default, need to login again for ansible
-              if [${USE_DEPLOYER_VM^^} == "TRUE" ]; then
+              if [ ${USE_DEPLOYER_VM^^} = "TRUE" ]; then
                 az login --identity --allow-no-subscriptions --output none
               else
                 az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID --output none

--- a/deploy/pipelines/05-DB-and-SAP-installation.yaml
+++ b/deploy/pipelines/05-DB-and-SAP-installation.yaml
@@ -91,6 +91,7 @@ trigger:                               none
 
 variables:
   - group:                             "SDAF-General"
+  - group:                             "SDAF-MGMT"
   - group:                             SDAF-${{ parameters.environment }}
 
   - name:                              sap_system_folder
@@ -226,7 +227,12 @@ stages:
 
               echo -e "$green--- az login ---$reset"
 
-                az login --identity --allow-no-subscriptions --output none
+                if [${USE_DEPLOYER_VM^^} == "TRUE" ]; then
+                  az login --identity --allow-no-subscriptions --output none
+                else
+                  az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID --output none
+                fi
+
                 return_code=$?
                 if [ 0 != $return_code ]; then
                   echo -e "$boldred--- Login failed ---$reset"
@@ -245,6 +251,10 @@ stages:
               AZURE_DEVOPS_EXT_PAT:    $(System.AccessToken)
               ARM_SUBSCRIPTION_ID:     $(ARM_SUBSCRIPTION_ID)
               ANSIBLE_HOST_KEY_CHECKING: false
+              USE_DEPLOYER_VM:         $(Use_Deployer_VM)
+              ARM_CLIENT_ID:           $(ARM_CLIENT_ID)
+              ARM_CLIENT_SECRET:       $(ARM_CLIENT_SECRET)
+              ARM_TENANT_ID:           $(ARM_TENANT_ID)
             failOnStderr:              true
           - publish:                   $(Build.Repository.LocalPath)/$(Deployment_Configuration_Path)/SYSTEM/$(sap_system_folder)/artifacts
             artifact:                  ansible_data

--- a/deploy/pipelines/05-DB-and-SAP-installation.yaml
+++ b/deploy/pipelines/05-DB-and-SAP-installation.yaml
@@ -240,7 +240,7 @@ stages:
                   exit $return_code
                 fi
                 az account set --subscription $ARM_SUBSCRIPTION_ID
-                
+
                 az keyvault secret show --name ${ENVIRONMENT}-${LOCATION}-${NETWORK}-sid-sshkey --vault-name $workload_key_vault --query value -o tsv > artifacts/$(sap_system_folder)_sshkey
                 cp sap-parameters.yaml artifacts/.
                 cp ${SID}_hosts.yaml artifacts/.
@@ -291,24 +291,28 @@ stages:
               sudo chmod 600 $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey
             displayName:               "Variables & Process sshkey"
 
-          - task:                      Ansible@0
-            displayName:               Validate the input parameters
-            inputs:
-              ansibleInterface:        "agentMachine"
-              playbookPathOnAgentMachine: "$(DEPLOYMENT_REPO_PATH)/deploy/ansible/playbook_00_validate_parameters.yaml"
+          - script: |
+              #Stage could be executed on a different machine by default, need to login again for ansible
+              if [${USE_DEPLOYER_VM^^} == "TRUE" ]; then
+                az login --identity --allow-no-subscriptions --output none
+              else
+                az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID --output none
+              fi
+              az account set --subscription $AZURE_SUBSCRIPTION_ID
 
-              inventoriesAgentMachine: "file"
-              inventoryFileOnAgentMachine: $(Pipeline.Workspace)/ansible_data/$(SID_hosts)
-
-              args:                    '--private-key $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey -e "@$(Pipeline.Workspace)/ansible_data/$(SAP_parameters)" -e "_workspace_directory=$(parameters_folder)" $(ExtraParams)'
-              failOnStderr:            false
-
+              ansible-playbook -i $(Pipeline.Workspace)/ansible_data/$(SID_hosts) --private-key $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey -e "@$(Pipeline.Workspace)/ansible_data/$(SAP_parameters)" -e "_workspace_directory=$(parameters_folder)" $(ExtraParams) $(DEPLOYMENT_REPO_PATH)/deploy/ansible/playbook_00_validate_parameters.yaml 
+            displayName: Validate the input parameters
             env:
-              ANSIBLE_DISPLAY_SKIPPED_HOSTS: false
-              ANSIBLE_HOST_KEY_CHECKING:     false
-              ANSIBLE_PYTHON_INTERPRETER:    auto_silent
-              DEPLOYMENT_REPO_PATH:          $(DEPLOYMENT_REPO_PATH)
-              ANSIBLE_COLLECTIONS_PATHS:     ~/.ansible/collections:/opt/ansible/collections
+              AZURE_CLIENT_ID:                $(ARM_CLIENT_ID)
+              AZURE_CLIENT_SECRET:            $(ARM_CLIENT_SECRET)
+              AZURE_TENANT_ID:                $(ARM_TENANT_ID)
+              AZURE_SUBSCRIPTION_ID:          $(ARM_SUBSCRIPTION_ID)
+              ANSIBLE_COLLECTIONS_PATHS:      ~/.ansible/collections:/opt/ansible/collections
+              ANSIBLE_PYTHON_INTERPRETER:     auto_silent
+              ANSIBLE_DISPLAY_SKIPPED_HOSTS:  false
+              ANSIBLE_HOST_KEY_CHECKING:      false
+              DEPLOYMENT_REPO_PATH:           $(DEPLOYMENT_REPO_PATH)
+              USE_DEPLOYER_VM:                $(Use_Deployer_VM)
             continueOnError:           false
 
   - stage:                             Core_Operating_System_Configuration
@@ -343,22 +347,28 @@ stages:
           - script: |
               sudo chmod 600 $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey
             displayName:               Process sshkey
-          - task:                      Ansible@0
-            displayName:               Core Operating System Configuration
-            inputs:
-              ansibleInterface:        "agentMachine"
-              playbookPathOnAgentMachine: "$(DEPLOYMENT_REPO_PATH)/deploy/ansible/playbook_01_os_base_config.yaml"
+          - script: |
+              #Stage could be executed on a different machine by default, need to login again for ansible
+              if [${USE_DEPLOYER_VM^^} == "TRUE" ]; then
+                az login --identity --allow-no-subscriptions --output none
+              else
+                az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID --output none
+              fi
+              az account set --subscription $AZURE_SUBSCRIPTION_ID
 
-              inventoriesAgentMachine: "file"
-              inventoryFileOnAgentMachine: $(Pipeline.Workspace)/ansible_data/$(SID_hosts)
-              args:                    '--private-key $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey -e "@$(Pipeline.Workspace)/ansible_data/$(SAP_parameters)" -e "_workspace_directory=$(parameters_folder)" $(ExtraParams)'
-              failOnStderr:            false
-
+              ansible-playbook -i $(Pipeline.Workspace)/ansible_data/$(SID_hosts) --private-key $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey -e "@$(Pipeline.Workspace)/ansible_data/$(SAP_parameters)" -e "_workspace_directory=$(parameters_folder)" $(ExtraParams) $(DEPLOYMENT_REPO_PATH)/deploy/ansible/playbook_01_os_base_config.yaml 
+            displayName: Core Operating System Configuration
             env:
-              ANSIBLE_DISPLAY_SKIPPED_HOSTS: false
-              ANSIBLE_HOST_KEY_CHECKING:     false
-              DEPLOYMENT_REPO_PATH:    $(DEPLOYMENT_REPO_PATH)
-              ANSIBLE_COLLECTIONS_PATHS:     ~/.ansible/collections:/opt/ansible/collections
+              AZURE_CLIENT_ID:                $(ARM_CLIENT_ID)
+              AZURE_CLIENT_SECRET:            $(ARM_CLIENT_SECRET)
+              AZURE_TENANT_ID:                $(ARM_TENANT_ID)
+              AZURE_SUBSCRIPTION_ID:          $(ARM_SUBSCRIPTION_ID)
+              ANSIBLE_COLLECTIONS_PATHS:      ~/.ansible/collections:/opt/ansible/collections
+              ANSIBLE_PYTHON_INTERPRETER:     auto_silent
+              ANSIBLE_DISPLAY_SKIPPED_HOSTS:  false
+              ANSIBLE_HOST_KEY_CHECKING:      false
+              DEPLOYMENT_REPO_PATH:           $(DEPLOYMENT_REPO_PATH)
+              USE_DEPLOYER_VM:                $(Use_Deployer_VM)
             continueOnError:           false
 
   - stage:                             SAP_Operating_System_Configuration
@@ -393,23 +403,30 @@ stages:
           - script: |
               sudo chmod 600 $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey
             displayName:               Process sshkey
-          - task:                      Ansible@0
-            displayName:               SAP Operating System Configuration
-            inputs:
-              ansibleInterface:        "agentMachine"
-              playbookPathOnAgentMachine: "$(DEPLOYMENT_REPO_PATH)/deploy/ansible/playbook_02_os_sap_specific_config.yaml"
-              inventoriesAgentMachine: "file"
-              inventoryFileOnAgentMachine: $(Pipeline.Workspace)/ansible_data/$(SID_hosts)
-              args:                    '--private-key $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey -e "@$(Pipeline.Workspace)/ansible_data/$(SAP_parameters)" -e "_workspace_directory=$(parameters_folder)" $(ExtraParams)'
-              failOnStderr:            false
-            env:
-              ANSIBLE_DISPLAY_SKIPPED_HOSTS: false
-              ANSIBLE_HOST_KEY_CHECKING:     false
-              ANSIBLE_PYTHON_INTERPRETER:    auto_silent
-              DEPLOYMENT_REPO_PATH:          $(DEPLOYMENT_REPO_PATH)
-              ANSIBLE_COLLECTIONS_PATHS:     ~/.ansible/collections:/opt/ansible/collections
-            continueOnError:           false
+          - script: |
+              #Stage could be executed on a different machine by default, need to login again for ansible
+              if [${USE_DEPLOYER_VM^^} == "TRUE" ]; then
+                az login --identity --allow-no-subscriptions --output none
+              else
+                az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID --output none
+              fi
+              az account set --subscription $AZURE_SUBSCRIPTION_ID
 
+              ansible-playbook -i $(Pipeline.Workspace)/ansible_data/$(SID_hosts) --private-key $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey -e "@$(Pipeline.Workspace)/ansible_data/$(SAP_parameters)" -e "_workspace_directory=$(parameters_folder)" $(ExtraParams) $(DEPLOYMENT_REPO_PATH)/deploy/ansible/playbook_02_os_sap_specific_config.yaml 
+            displayName: SAP Operating System Configuration
+            env:
+              AZURE_CLIENT_ID:                $(ARM_CLIENT_ID)
+              AZURE_CLIENT_SECRET:            $(ARM_CLIENT_SECRET)
+              AZURE_TENANT_ID:                $(ARM_TENANT_ID)
+              AZURE_SUBSCRIPTION_ID:          $(ARM_SUBSCRIPTION_ID)
+              ANSIBLE_COLLECTIONS_PATHS:      ~/.ansible/collections:/opt/ansible/collections
+              ANSIBLE_PYTHON_INTERPRETER:     auto_silent
+              ANSIBLE_DISPLAY_SKIPPED_HOSTS:  false
+              ANSIBLE_HOST_KEY_CHECKING:      false
+              DEPLOYMENT_REPO_PATH:           $(DEPLOYMENT_REPO_PATH)
+              USE_DEPLOYER_VM:                $(Use_Deployer_VM)
+            continueOnError:           false
+            
   - stage:                             Software_Acquisition
     displayName:                       Software Acquisition
     dependsOn:
@@ -443,22 +460,28 @@ stages:
           - script: |
               sudo chmod 600 $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey
             displayName:               Process sshkey
-          - task:                      Ansible@0
-            displayName:               Software Acquisition
-            timeoutInMinutes:          0
-            inputs:
-              ansibleInterface:        "agentMachine"
-              playbookPathOnAgentMachine: "$(DEPLOYMENT_REPO_PATH)/deploy/ansible/playbook_03_bom_processing.yaml"
-              inventoriesAgentMachine: "file"
-              inventoryFileOnAgentMachine: $(Pipeline.Workspace)/ansible_data/$(SID_hosts)
-              args:                    '--private-key $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey -e "@$(Pipeline.Workspace)/ansible_data/$(SAP_parameters)" -e "_workspace_directory=$(parameters_folder)" $(ExtraParams)'
-              failOnStderr:            false
+          - script: |
+              #Stage could be executed on a different machine by default, need to login again for ansible
+              if [${USE_DEPLOYER_VM^^} == "TRUE" ]; then
+                az login --identity --allow-no-subscriptions --output none
+              else
+                az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID --output none
+              fi
+              az account set --subscription $AZURE_SUBSCRIPTION_ID
+
+              ansible-playbook -i $(Pipeline.Workspace)/ansible_data/$(SID_hosts) --private-key $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey -e "@$(Pipeline.Workspace)/ansible_data/$(SAP_parameters)" -e "_workspace_directory=$(parameters_folder)" $(ExtraParams) $(DEPLOYMENT_REPO_PATH)/deploy/ansible/playbook_03_bom_processing.yaml 
+            displayName: Software Acquisition
             env:
-              ANSIBLE_DISPLAY_SKIPPED_HOSTS: false
-              ANSIBLE_HOST_KEY_CHECKING:     false
-              ANSIBLE_PYTHON_INTERPRETER:    auto_silent
-              DEPLOYMENT_REPO_PATH:          $(DEPLOYMENT_REPO_PATH)
-              ANSIBLE_COLLECTIONS_PATHS:     ~/.ansible/collections:/opt/ansible/collections
+              AZURE_CLIENT_ID:                $(ARM_CLIENT_ID)
+              AZURE_CLIENT_SECRET:            $(ARM_CLIENT_SECRET)
+              AZURE_TENANT_ID:                $(ARM_TENANT_ID)
+              AZURE_SUBSCRIPTION_ID:          $(ARM_SUBSCRIPTION_ID)
+              ANSIBLE_COLLECTIONS_PATHS:      ~/.ansible/collections:/opt/ansible/collections
+              ANSIBLE_PYTHON_INTERPRETER:     auto_silent
+              ANSIBLE_DISPLAY_SKIPPED_HOSTS:  false
+              ANSIBLE_HOST_KEY_CHECKING:      false
+              DEPLOYMENT_REPO_PATH:           $(DEPLOYMENT_REPO_PATH)
+              USE_DEPLOYER_VM:                $(Use_Deployer_VM)
             continueOnError:           false
 
   - stage: Database_Installation
@@ -496,23 +519,30 @@ stages:
           - script: |
               sudo chmod 600 $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey
             displayName:               Process sshkey
-          - task:                      Ansible@0
-            displayName:               Database Installation
-            timeoutInMinutes:          0
-            inputs:
-              ansibleInterface:        "agentMachine"
-              playbookPathOnAgentMachine: "$(DEPLOYMENT_REPO_PATH)/deploy/ansible/playbook_04_00_00_db_install.yaml"
-              inventoriesAgentMachine: "file"
-              inventoryFileOnAgentMachine: $(Pipeline.Workspace)/ansible_data/$(SID_hosts)
-              args:                    '--private-key $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey -e "@$(Pipeline.Workspace)/ansible_data/$(SAP_parameters)" -e "_workspace_directory=$(parameters_folder)" $(ExtraParams)'
-              failOnStderr:            false
+          - script: |
+              #Stage could be executed on a different machine by default, need to login again for ansible
+              if [${USE_DEPLOYER_VM^^} == "TRUE" ]; then
+                az login --identity --allow-no-subscriptions --output none
+              else
+                az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID --output none
+              fi
+              az account set --subscription $AZURE_SUBSCRIPTION_ID
+
+              ansible-playbook -i $(Pipeline.Workspace)/ansible_data/$(SID_hosts) --private-key $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey -e "@$(Pipeline.Workspace)/ansible_data/$(SAP_parameters)" -e "_workspace_directory=$(parameters_folder)" $(ExtraParams) $(DEPLOYMENT_REPO_PATH)/deploy/ansible/playbook_04_00_00_db_install.yaml 
+            displayName: Database Installation
             env:
-              ANSIBLE_DISPLAY_SKIPPED_HOSTS: false
-              ANSIBLE_HOST_KEY_CHECKING:     false
-              ANSIBLE_PYTHON_INTERPRETER:    auto_silent
-              DEPLOYMENT_REPO_PATH:          $(DEPLOYMENT_REPO_PATH)
-              ANSIBLE_COLLECTIONS_PATHS:     ~/.ansible/collections:/opt/ansible/collections
+              AZURE_CLIENT_ID:                $(ARM_CLIENT_ID)
+              AZURE_CLIENT_SECRET:            $(ARM_CLIENT_SECRET)
+              AZURE_TENANT_ID:                $(ARM_TENANT_ID)
+              AZURE_SUBSCRIPTION_ID:          $(ARM_SUBSCRIPTION_ID)
+              ANSIBLE_COLLECTIONS_PATHS:      ~/.ansible/collections:/opt/ansible/collections
+              ANSIBLE_PYTHON_INTERPRETER:     auto_silent
+              ANSIBLE_DISPLAY_SKIPPED_HOSTS:  false
+              ANSIBLE_HOST_KEY_CHECKING:      false
+              DEPLOYMENT_REPO_PATH:           $(DEPLOYMENT_REPO_PATH)
+              USE_DEPLOYER_VM:                $(Use_Deployer_VM)
             continueOnError:           false
+
           - script: |
               #!/bin/bash
               green="\e[1;32m" ; reset="\e[0m" ; boldred="\e[1;31m"
@@ -569,23 +599,30 @@ stages:
           - script: |
               sudo chmod 600 $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey
             displayName:               Process sshkey
-          - task:                      Ansible@0
-            displayName:               SCS Installation
-            timeoutInMinutes:          0
-            inputs:
-              ansibleInterface:        "agentMachine"
-              playbookPathOnAgentMachine: "$(DEPLOYMENT_REPO_PATH)/deploy/ansible/playbook_05_00_00_sap_scs_install.yaml"
-              inventoriesAgentMachine: "file"
-              inventoryFileOnAgentMachine: $(Pipeline.Workspace)/ansible_data/$(SID_hosts)
-              args:                    '--private-key $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey -e "@$(Pipeline.Workspace)/ansible_data/$(SAP_parameters)" -e "_workspace_directory=$(parameters_folder)" $(ExtraParams)'
-              failOnStderr:            false
+          - script: |
+              #Stage could be executed on a different machine by default, need to login again for ansible
+              if [${USE_DEPLOYER_VM^^} == "TRUE" ]; then
+                az login --identity --allow-no-subscriptions --output none
+              else
+                az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID --output none
+              fi
+              az account set --subscription $AZURE_SUBSCRIPTION_ID
+
+              ansible-playbook -i $(Pipeline.Workspace)/ansible_data/$(SID_hosts) --private-key $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey -e "@$(Pipeline.Workspace)/ansible_data/$(SAP_parameters)" -e "_workspace_directory=$(parameters_folder)" $(ExtraParams) $(DEPLOYMENT_REPO_PATH)/deploy/ansible/playbook_05_00_00_sap_scs_install.yaml 
+            displayName: SCS Installation
             env:
-              ANSIBLE_DISPLAY_SKIPPED_HOSTS: false
-              ANSIBLE_HOST_KEY_CHECKING:     false
-              ANSIBLE_PYTHON_INTERPRETER:    auto_silent
-              DEPLOYMENT_REPO_PATH:          $(DEPLOYMENT_REPO_PATH)
-              ANSIBLE_COLLECTIONS_PATHS:     ~/.ansible/collections:/opt/ansible/collections
-              continueOnError:           true
+              AZURE_CLIENT_ID:                $(ARM_CLIENT_ID)
+              AZURE_CLIENT_SECRET:            $(ARM_CLIENT_SECRET)
+              AZURE_TENANT_ID:                $(ARM_TENANT_ID)
+              AZURE_SUBSCRIPTION_ID:          $(ARM_SUBSCRIPTION_ID)
+              ANSIBLE_COLLECTIONS_PATHS:      ~/.ansible/collections:/opt/ansible/collections
+              ANSIBLE_PYTHON_INTERPRETER:     auto_silent
+              ANSIBLE_DISPLAY_SKIPPED_HOSTS:  false
+              ANSIBLE_HOST_KEY_CHECKING:      false
+              DEPLOYMENT_REPO_PATH:           $(DEPLOYMENT_REPO_PATH)
+              USE_DEPLOYER_VM:                $(Use_Deployer_VM)
+            continueOnError:           false
+
           - script: |
               #!/bin/bash
               green="\e[1;32m" ; reset="\e[0m" ; boldred="\e[1;31m"
@@ -646,23 +683,30 @@ stages:
           - script: |
               sudo chmod 600 $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey
             displayName:               Process sshkey
-          - task:                      Ansible@0
-            displayName:               Database Load
-            timeoutInMinutes:          0
-            inputs:
-              ansibleInterface:        "agentMachine"
-              playbookPathOnAgentMachine: "$(DEPLOYMENT_REPO_PATH)/deploy/ansible/playbook_05_01_sap_dbload.yaml"
-              inventoriesAgentMachine: "file"
-              inventoryFileOnAgentMachine: $(Pipeline.Workspace)/ansible_data/$(SID_hosts)
-              args:                    '--private-key $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey -e "@$(Pipeline.Workspace)/ansible_data/$(SAP_parameters)" -e "_workspace_directory=$(parameters_folder)" $(ExtraParams)'
-              failOnStderr:            false
+          - script: |
+              #Stage could be executed on a different machine by default, need to login again for ansible
+              if [${USE_DEPLOYER_VM^^} == "TRUE" ]; then
+                az login --identity --allow-no-subscriptions --output none
+              else
+                az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID --output none
+              fi
+              az account set --subscription $AZURE_SUBSCRIPTION_ID
+
+              ansible-playbook -i $(Pipeline.Workspace)/ansible_data/$(SID_hosts) --private-key $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey -e "@$(Pipeline.Workspace)/ansible_data/$(SAP_parameters)" -e "_workspace_directory=$(parameters_folder)" $(ExtraParams) $(DEPLOYMENT_REPO_PATH)/deploy/ansible/playbook_05_01_sap_dbload.yaml 
+            displayName: Database Load
             env:
-              ANSIBLE_DISPLAY_SKIPPED_HOSTS: false
-              ANSIBLE_HOST_KEY_CHECKING:     false
-              ANSIBLE_PYTHON_INTERPRETER:    auto_silent
-              DEPLOYMENT_REPO_PATH:          $(DEPLOYMENT_REPO_PATH)
-              ANSIBLE_COLLECTIONS_PATHS:     ~/.ansible/collections:/opt/ansible/collections
-            continueOnError:           true
+              AZURE_CLIENT_ID:                $(ARM_CLIENT_ID)
+              AZURE_CLIENT_SECRET:            $(ARM_CLIENT_SECRET)
+              AZURE_TENANT_ID:                $(ARM_TENANT_ID)
+              AZURE_SUBSCRIPTION_ID:          $(ARM_SUBSCRIPTION_ID)
+              ANSIBLE_COLLECTIONS_PATHS:      ~/.ansible/collections:/opt/ansible/collections
+              ANSIBLE_PYTHON_INTERPRETER:     auto_silent
+              ANSIBLE_DISPLAY_SKIPPED_HOSTS:  false
+              ANSIBLE_HOST_KEY_CHECKING:      false
+              DEPLOYMENT_REPO_PATH:           $(DEPLOYMENT_REPO_PATH)
+              USE_DEPLOYER_VM:                $(Use_Deployer_VM)
+            continueOnError:           false
+
           - script: |
               #!/bin/bash
               green="\e[1;32m" ; reset="\e[0m" ; boldred="\e[1;31m"
@@ -720,24 +764,29 @@ stages:
           - script: |
               sudo chmod 600 $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey
             displayName:               Process sshkey
-          - task:                      Ansible@0
-            displayName:               High Availability Setup
-            timeoutInMinutes:          0
-            inputs:
-              ansibleInterface:        "agentMachine"
-              playbookPathOnAgentMachine: "$(DEPLOYMENT_REPO_PATH)/deploy/ansible/playbook_04_00_01_db_ha.yaml"
-              inventoriesAgentMachine: "file"
-              inventoryFileOnAgentMachine: $(Pipeline.Workspace)/ansible_data/$(SID_hosts)
-              args:                    '--private-key $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey -e "@$(Pipeline.Workspace)/ansible_data/$(SAP_parameters)" -e "_workspace_directory=$(parameters_folder)" $(ExtraParams)'
-              failOnStderr:            false
+          - script: |
+              #Stage could be executed on a different machine by default, need to login again for ansible
+              if [${USE_DEPLOYER_VM^^} == "TRUE" ]; then
+                az login --identity --allow-no-subscriptions --output none
+              else
+                az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID --output none
+              fi
+              az account set --subscription $AZURE_SUBSCRIPTION_ID
+
+              ansible-playbook -i $(Pipeline.Workspace)/ansible_data/$(SID_hosts) --private-key $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey -e "@$(Pipeline.Workspace)/ansible_data/$(SAP_parameters)" -e "_workspace_directory=$(parameters_folder)" $(ExtraParams) $(DEPLOYMENT_REPO_PATH)/deploy/ansible/playbook_04_00_01_db_ha.yaml 
+            displayName: High Availability Setup
             env:
-              ANSIBLE_DISPLAY_SKIPPED_HOSTS: false
-              ANSIBLE_HOST_KEY_CHECKING:     false
-              ANSIBLE_PYTHON_INTERPRETER:    auto_silent
-              DEPLOYMENT_REPO_PATH:          $(DEPLOYMENT_REPO_PATH)
-              ANSIBLE_COLLECTIONS_PATHS:     ~/.ansible/collections:/opt/ansible/collections
+              AZURE_CLIENT_ID:                $(ARM_CLIENT_ID)
+              AZURE_CLIENT_SECRET:            $(ARM_CLIENT_SECRET)
+              AZURE_TENANT_ID:                $(ARM_TENANT_ID)
+              AZURE_SUBSCRIPTION_ID:          $(ARM_SUBSCRIPTION_ID)
+              ANSIBLE_COLLECTIONS_PATHS:      ~/.ansible/collections:/opt/ansible/collections
+              ANSIBLE_PYTHON_INTERPRETER:     auto_silent
+              ANSIBLE_DISPLAY_SKIPPED_HOSTS:  false
+              ANSIBLE_HOST_KEY_CHECKING:      false
+              DEPLOYMENT_REPO_PATH:           $(DEPLOYMENT_REPO_PATH)
+              USE_DEPLOYER_VM:                $(Use_Deployer_VM)
             continueOnError:           false
-            name: HA
 
   - stage: PAS_Installation
     displayName:                       PAS Installation
@@ -778,24 +827,30 @@ stages:
           - script: |
               sudo chmod 600 $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey
             displayName:               Process sshkey
-          - task:                      Ansible@0
-            displayName:               PAS Installation
-            timeoutInMinutes:          0
-            inputs:
-              ansibleInterface:        "agentMachine"
-              playbookPathOnAgentMachine: "$(DEPLOYMENT_REPO_PATH)/deploy/ansible/playbook_05_02_sap_pas_install.yaml"
-              inventoriesAgentMachine: "file"
-              inventoryFileOnAgentMachine: $(Pipeline.Workspace)/ansible_data/$(SID_hosts)
-              args:                    '--private-key $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey -e "@$(Pipeline.Workspace)/ansible_data/$(SAP_parameters)" -e "_workspace_directory=$(parameters_folder)" $(ExtraParams)'
-              failOnStderr:            false
-            env:
-              ANSIBLE_DISPLAY_SKIPPED_HOSTS: false
-              ANSIBLE_HOST_KEY_CHECKING:     false
-              ANSIBLE_PYTHON_INTERPRETER:    auto_silent
+          - script: |
+              #Stage could be executed on a different machine by default, need to login again for ansible
+              if [${USE_DEPLOYER_VM^^} == "TRUE" ]; then
+                az login --identity --allow-no-subscriptions --output none
+              else
+                az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID --output none
+              fi
+              az account set --subscription $AZURE_SUBSCRIPTION_ID
 
-              DEPLOYMENT_REPO_PATH:          $(DEPLOYMENT_REPO_PATH)
-              ANSIBLE_COLLECTIONS_PATHS:     ~/.ansible/collections:/opt/ansible/collections
-            continueOnError:           true
+              ansible-playbook -i $(Pipeline.Workspace)/ansible_data/$(SID_hosts) --private-key $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey -e "@$(Pipeline.Workspace)/ansible_data/$(SAP_parameters)" -e "_workspace_directory=$(parameters_folder)" $(ExtraParams) $(DEPLOYMENT_REPO_PATH)/deploy/ansible/playbook_05_02_sap_pas_install.yaml 
+            displayName: PAS Installation
+            env:
+              AZURE_CLIENT_ID:                $(ARM_CLIENT_ID)
+              AZURE_CLIENT_SECRET:            $(ARM_CLIENT_SECRET)
+              AZURE_TENANT_ID:                $(ARM_TENANT_ID)
+              AZURE_SUBSCRIPTION_ID:          $(ARM_SUBSCRIPTION_ID)
+              ANSIBLE_COLLECTIONS_PATHS:      ~/.ansible/collections:/opt/ansible/collections
+              ANSIBLE_PYTHON_INTERPRETER:     auto_silent
+              ANSIBLE_DISPLAY_SKIPPED_HOSTS:  false
+              ANSIBLE_HOST_KEY_CHECKING:      false
+              DEPLOYMENT_REPO_PATH:           $(DEPLOYMENT_REPO_PATH)
+              USE_DEPLOYER_VM:                $(Use_Deployer_VM)
+            continueOnError:           false
+
           - script: |
               #!/bin/bash
               green="\e[1;32m" ; reset="\e[0m" ; boldred="\e[1;31m"
@@ -859,23 +914,30 @@ stages:
           - script: |
               sudo chmod 600 $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey
             displayName:               Process sshkey
-          - task:                      Ansible@0
-            displayName:               Application Server Install
-            inputs:
-              ansibleInterface:        "agentMachine"
-              playbookPathOnAgentMachine: "$(DEPLOYMENT_REPO_PATH)/deploy/ansible/playbook_05_03_sap_app_install.yaml"
-              inventoriesAgentMachine: "file"
-              inventoryFileOnAgentMachine: $(Pipeline.Workspace)/ansible_data/$(SID_hosts)
-              args:                    '--private-key $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey -e "@$(Pipeline.Workspace)/ansible_data/$(SAP_parameters)" -e "_workspace_directory=$(parameters_folder)" $(ExtraParams)'
-              failOnStderr:            false
-            env:
-              ANSIBLE_DISPLAY_SKIPPED_HOSTS: false
-              ANSIBLE_HOST_KEY_CHECKING:     false
-              ANSIBLE_PYTHON_INTERPRETER:    auto_silent
+          - script: |
+              #Stage could be executed on a different machine by default, need to login again for ansible
+              if [${USE_DEPLOYER_VM^^} == "TRUE" ]; then
+                az login --identity --allow-no-subscriptions --output none
+              else
+                az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID --output none
+              fi
+              az account set --subscription $AZURE_SUBSCRIPTION_ID
 
-              DEPLOYMENT_REPO_PATH:          $(DEPLOYMENT_REPO_PATH)
-              ANSIBLE_COLLECTIONS_PATHS:     ~/.ansible/collections:/opt/ansible/collections
-            continueOnError:           true
+              ansible-playbook -i $(Pipeline.Workspace)/ansible_data/$(SID_hosts) --private-key $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey -e "@$(Pipeline.Workspace)/ansible_data/$(SAP_parameters)" -e "_workspace_directory=$(parameters_folder)" $(ExtraParams) $(DEPLOYMENT_REPO_PATH)/deploy/ansible/playbook_05_03_sap_app_install.yaml 
+            displayName: Application Server Install
+            env:
+              AZURE_CLIENT_ID:                $(ARM_CLIENT_ID)
+              AZURE_CLIENT_SECRET:            $(ARM_CLIENT_SECRET)
+              AZURE_TENANT_ID:                $(ARM_TENANT_ID)
+              AZURE_SUBSCRIPTION_ID:          $(ARM_SUBSCRIPTION_ID)
+              ANSIBLE_COLLECTIONS_PATHS:      ~/.ansible/collections:/opt/ansible/collections
+              ANSIBLE_PYTHON_INTERPRETER:     auto_silent
+              ANSIBLE_DISPLAY_SKIPPED_HOSTS:  false
+              ANSIBLE_HOST_KEY_CHECKING:      false
+              DEPLOYMENT_REPO_PATH:           $(DEPLOYMENT_REPO_PATH)
+              USE_DEPLOYER_VM:                $(Use_Deployer_VM)
+            continueOnError:           false
+
           - script: |
               #!/bin/bash
               green="\e[1;32m" ; reset="\e[0m" ; boldred="\e[1;31m"
@@ -929,22 +991,30 @@ stages:
           - script: |
               sudo chmod 600 $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey
             displayName:               Process sshkey
-          - task:                      Ansible@0
-            displayName:               WebDispatcher Installation
-            inputs:
-              ansibleInterface:        "agentMachine"
-              playbookPathOnAgentMachine: "$(DEPLOYMENT_REPO_PATH)/deploy/ansible/playbook_05_04_sap_web_install.yaml"
-              inventoriesAgentMachine: "file"
-              inventoryFileOnAgentMachine: $(Pipeline.Workspace)/ansible_data/$(SID_hosts)
-              args:                    '--private-key $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey -e "@$(Pipeline.Workspace)/ansible_data/$(SAP_parameters)" -e "_workspace_directory=$(parameters_folder)" $(ExtraParams)'
-              failOnStderr:            false
+          - script: |
+              #Stage could be executed on a different machine by default, need to login again for ansible
+              if [${USE_DEPLOYER_VM^^} == "TRUE" ]; then
+                az login --identity --allow-no-subscriptions --output none
+              else
+                az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID --output none
+              fi
+              az account set --subscription $AZURE_SUBSCRIPTION_ID
+
+              ansible-playbook -i $(Pipeline.Workspace)/ansible_data/$(SID_hosts) --private-key $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey -e "@$(Pipeline.Workspace)/ansible_data/$(SAP_parameters)" -e "_workspace_directory=$(parameters_folder)" $(ExtraParams) $(DEPLOYMENT_REPO_PATH)/deploy/ansible/playbook_05_04_sap_web_install.yaml 
+            displayName: WebDispatcher Installation
             env:
-              ANSIBLE_DISPLAY_SKIPPED_HOSTS: false
-              ANSIBLE_HOST_KEY_CHECKING:     false
-              ANSIBLE_PYTHON_INTERPRETER:    auto_silent
-              DEPLOYMENT_REPO_PATH:          $(DEPLOYMENT_REPO_PATH)
-              ANSIBLE_COLLECTIONS_PATHS:     ~/.ansible/collections:/opt/ansible/collections
-            continueOnError:           true
+              AZURE_CLIENT_ID:                $(ARM_CLIENT_ID)
+              AZURE_CLIENT_SECRET:            $(ARM_CLIENT_SECRET)
+              AZURE_TENANT_ID:                $(ARM_TENANT_ID)
+              AZURE_SUBSCRIPTION_ID:          $(ARM_SUBSCRIPTION_ID)
+              ANSIBLE_COLLECTIONS_PATHS:      ~/.ansible/collections:/opt/ansible/collections
+              ANSIBLE_PYTHON_INTERPRETER:     auto_silent
+              ANSIBLE_DISPLAY_SKIPPED_HOSTS:  false
+              ANSIBLE_HOST_KEY_CHECKING:      false
+              DEPLOYMENT_REPO_PATH:           $(DEPLOYMENT_REPO_PATH)
+              USE_DEPLOYER_VM:                $(Use_Deployer_VM)
+            continueOnError:           false
+
           - script: |
               #!/bin/bash
               green="\e[1;32m" ; reset="\e[0m" ; boldred="\e[1;31m"

--- a/deploy/pipelines/05-DB-and-SAP-installation.yaml
+++ b/deploy/pipelines/05-DB-and-SAP-installation.yaml
@@ -239,7 +239,7 @@ stages:
                   echo "##vso[task.logissue type=error]az login failed."
                   exit $return_code
                 fi
-                az account set --subscription $ARM_SUBSCRIPTION_ID
+                az account set --subscription $AZURE_SUBSCRIPTION_ID
 
                 az keyvault secret show --name ${ENVIRONMENT}-${LOCATION}-${NETWORK}-sid-sshkey --vault-name $workload_key_vault --query value -o tsv > artifacts/$(sap_system_folder)_sshkey
                 cp sap-parameters.yaml artifacts/.
@@ -249,14 +249,13 @@ stages:
             name:                      Preparation
             displayName:               Preparation for Ansible
             env:
-              SYSTEM_ACCESSTOKEN:      $(System.AccessToken)
-              AZURE_DEVOPS_EXT_PAT:    $(System.AccessToken)
-              ARM_SUBSCRIPTION_ID:     $(ARM_SUBSCRIPTION_ID)
+              SYSTEM_ACCESSTOKEN:        $(System.AccessToken)
               ANSIBLE_HOST_KEY_CHECKING: false
-              USE_DEPLOYER_VM:         $(Use_Deployer_VM)
-              ARM_CLIENT_ID:           $(ARM_CLIENT_ID)
-              ARM_CLIENT_SECRET:       $(ARM_CLIENT_SECRET)
-              ARM_TENANT_ID:           $(ARM_TENANT_ID)
+              USE_DEPLOYER_VM:           $(Use_Deployer_VM)
+              AZURE_CLIENT_ID:           $(ARM_CLIENT_ID)
+              AZURE_CLIENT_SECRET:       $(ARM_CLIENT_SECRET)
+              AZURE_TENANT_ID:           $(ARM_TENANT_ID)
+              AZURE_SUBSCRIPTION_ID:     $(ARM_SUBSCRIPTION_ID)
             failOnStderr:              true
           - publish:                   $(Build.Repository.LocalPath)/$(Deployment_Configuration_Path)/SYSTEM/$(sap_system_folder)/artifacts
             artifact:                  ansible_data

--- a/deploy/pipelines/05-DB-and-SAP-installation.yaml
+++ b/deploy/pipelines/05-DB-and-SAP-installation.yaml
@@ -91,7 +91,6 @@ trigger:                               none
 
 variables:
   - group:                             "SDAF-General"
-  - group:                             "SDAF-MGMT"
   - group:                             SDAF-${{ parameters.environment }}
 
   - name:                              sap_system_folder
@@ -226,8 +225,9 @@ stages:
                 fi
 
               echo -e "$green--- az login ---$reset"
-
-                if [ ${USE_DEPLOYER_VM^^} = "TRUE" ]; then
+                #If the deployer_file exists we run on a deployer cofigured by the framework instead of a azdo hosted one
+                deployer_file=/etc/profile.d/deploy_server.sh
+                if [ -f "$deployer_file" ]; then
                   az login --identity --allow-no-subscriptions --output none
                 else
                   az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID --output none
@@ -252,7 +252,6 @@ stages:
               SYSTEM_ACCESSTOKEN:        $(System.AccessToken)
               AZURE_DEVOPS_EXT_PAT:      $(System.AccessToken)
               ANSIBLE_HOST_KEY_CHECKING: false
-              USE_DEPLOYER_VM:           $(Use_Deployer_VM)
               AZURE_CLIENT_ID:           $(ARM_CLIENT_ID)
               AZURE_CLIENT_SECRET:       $(ARM_CLIENT_SECRET)
               AZURE_TENANT_ID:           $(ARM_TENANT_ID)
@@ -291,29 +290,20 @@ stages:
               sudo chmod 600 $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey
             displayName:               "Variables & Process sshkey"
 
-          - script: |
-              #Stage could be executed on a different machine by default, need to login again for ansible
-              if [ ${USE_DEPLOYER_VM^^} = "TRUE" ]; then
-                az login --identity --allow-no-subscriptions --output none
-              else
-                az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID --output none
-              fi
-              az account set --subscription $AZURE_SUBSCRIPTION_ID
+          - template: templates\run-ansible.yaml
+            parameters:
+              displayName:                  "Validate the input parameters"
+              ansibleFilePath:              $(DEPLOYMENT_REPO_PATH)/deploy/ansible/playbook_00_validate_parameters.yaml
+              privateKey:                   $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey
+              parametersFolder:             "_workspace_directory=$(parameters_folder)"
+              sapParams:                    "@$(Pipeline.Workspace)/ansible_data/$(SAP_parameters)"
+              sidHosts:                     $(SID_hosts)
+              extraParams:                  $(ExtraParams)
+              azureClientId:                $(ARM_CLIENT_ID)
+              azureClientSecret:            $(ARM_CLIENT_SECRET)
+              azureTenantId:                $(ARM_TENANT_ID)
+              azureSubscriptionId:          $(ARM_SUBSCRIPTION_ID)
 
-              ansible-playbook -i $(Pipeline.Workspace)/ansible_data/$(SID_hosts) --private-key $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey -e "@$(Pipeline.Workspace)/ansible_data/$(SAP_parameters)" -e "_workspace_directory=$(parameters_folder)" $(ExtraParams) $(DEPLOYMENT_REPO_PATH)/deploy/ansible/playbook_00_validate_parameters.yaml 
-            displayName: Validate the input parameters
-            env:
-              AZURE_CLIENT_ID:                $(ARM_CLIENT_ID)
-              AZURE_CLIENT_SECRET:            $(ARM_CLIENT_SECRET)
-              AZURE_TENANT_ID:                $(ARM_TENANT_ID)
-              AZURE_SUBSCRIPTION_ID:          $(ARM_SUBSCRIPTION_ID)
-              ANSIBLE_COLLECTIONS_PATHS:      ~/.ansible/collections:/opt/ansible/collections
-              ANSIBLE_PYTHON_INTERPRETER:     auto_silent
-              ANSIBLE_DISPLAY_SKIPPED_HOSTS:  false
-              ANSIBLE_HOST_KEY_CHECKING:      false
-              DEPLOYMENT_REPO_PATH:           $(DEPLOYMENT_REPO_PATH)
-              USE_DEPLOYER_VM:                $(Use_Deployer_VM)
-            continueOnError:           false
 
   - stage:                             Core_Operating_System_Configuration
     displayName:                       Core Operating System Configuration
@@ -347,29 +337,20 @@ stages:
           - script: |
               sudo chmod 600 $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey
             displayName:               Process sshkey
-          - script: |
-              #Stage could be executed on a different machine by default, need to login again for ansible
-              if [ ${USE_DEPLOYER_VM^^} = "TRUE" ]; then
-                az login --identity --allow-no-subscriptions --output none
-              else
-                az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID --output none
-              fi
-              az account set --subscription $AZURE_SUBSCRIPTION_ID
 
-              ansible-playbook -i $(Pipeline.Workspace)/ansible_data/$(SID_hosts) --private-key $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey -e "@$(Pipeline.Workspace)/ansible_data/$(SAP_parameters)" -e "_workspace_directory=$(parameters_folder)" $(ExtraParams) $(DEPLOYMENT_REPO_PATH)/deploy/ansible/playbook_01_os_base_config.yaml 
-            displayName: Core Operating System Configuration
-            env:
-              AZURE_CLIENT_ID:                $(ARM_CLIENT_ID)
-              AZURE_CLIENT_SECRET:            $(ARM_CLIENT_SECRET)
-              AZURE_TENANT_ID:                $(ARM_TENANT_ID)
-              AZURE_SUBSCRIPTION_ID:          $(ARM_SUBSCRIPTION_ID)
-              ANSIBLE_COLLECTIONS_PATHS:      ~/.ansible/collections:/opt/ansible/collections
-              ANSIBLE_PYTHON_INTERPRETER:     auto_silent
-              ANSIBLE_DISPLAY_SKIPPED_HOSTS:  false
-              ANSIBLE_HOST_KEY_CHECKING:      false
-              DEPLOYMENT_REPO_PATH:           $(DEPLOYMENT_REPO_PATH)
-              USE_DEPLOYER_VM:                $(Use_Deployer_VM)
-            continueOnError:           false
+          - template: templates\run-ansible.yaml
+            parameters:
+              displayName:                  "Core Operating System Configuration"
+              ansibleFilePath:              $(DEPLOYMENT_REPO_PATH)/deploy/ansible/playbook_01_os_base_config.yaml
+              privateKey:                   $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey
+              parametersFolder:             "_workspace_directory=$(parameters_folder)"
+              sapParams:                    "@$(Pipeline.Workspace)/ansible_data/$(SAP_parameters)"
+              sidHosts:                     $(SID_hosts)
+              extraParams:                  $(ExtraParams)
+              azureClientId:                $(ARM_CLIENT_ID)
+              azureClientSecret:            $(ARM_CLIENT_SECRET)
+              azureTenantId:                $(ARM_TENANT_ID)
+              azureSubscriptionId:          $(ARM_SUBSCRIPTION_ID)
 
   - stage:                             SAP_Operating_System_Configuration
     displayName:                       SAP Operating System Configuration
@@ -403,29 +384,20 @@ stages:
           - script: |
               sudo chmod 600 $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey
             displayName:               Process sshkey
-          - script: |
-              #Stage could be executed on a different machine by default, need to login again for ansible
-              if [ ${USE_DEPLOYER_VM^^} = "TRUE" ]; then
-                az login --identity --allow-no-subscriptions --output none
-              else
-                az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID --output none
-              fi
-              az account set --subscription $AZURE_SUBSCRIPTION_ID
 
-              ansible-playbook -i $(Pipeline.Workspace)/ansible_data/$(SID_hosts) --private-key $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey -e "@$(Pipeline.Workspace)/ansible_data/$(SAP_parameters)" -e "_workspace_directory=$(parameters_folder)" $(ExtraParams) $(DEPLOYMENT_REPO_PATH)/deploy/ansible/playbook_02_os_sap_specific_config.yaml 
-            displayName: SAP Operating System Configuration
-            env:
-              AZURE_CLIENT_ID:                $(ARM_CLIENT_ID)
-              AZURE_CLIENT_SECRET:            $(ARM_CLIENT_SECRET)
-              AZURE_TENANT_ID:                $(ARM_TENANT_ID)
-              AZURE_SUBSCRIPTION_ID:          $(ARM_SUBSCRIPTION_ID)
-              ANSIBLE_COLLECTIONS_PATHS:      ~/.ansible/collections:/opt/ansible/collections
-              ANSIBLE_PYTHON_INTERPRETER:     auto_silent
-              ANSIBLE_DISPLAY_SKIPPED_HOSTS:  false
-              ANSIBLE_HOST_KEY_CHECKING:      false
-              DEPLOYMENT_REPO_PATH:           $(DEPLOYMENT_REPO_PATH)
-              USE_DEPLOYER_VM:                $(Use_Deployer_VM)
-            continueOnError:           false
+          - template: templates\run-ansible.yaml
+            parameters:
+              displayName:                  "SAP Operating System Configuration"
+              ansibleFilePath:              $(DEPLOYMENT_REPO_PATH)/deploy/ansible/playbook_02_os_sap_specific_config.yaml
+              privateKey:                   $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey
+              parametersFolder:             "_workspace_directory=$(parameters_folder)"
+              sapParams:                    "@$(Pipeline.Workspace)/ansible_data/$(SAP_parameters)"
+              sidHosts:                     $(SID_hosts)
+              extraParams:                  $(ExtraParams)
+              azureClientId:                $(ARM_CLIENT_ID)
+              azureClientSecret:            $(ARM_CLIENT_SECRET)
+              azureTenantId:                $(ARM_TENANT_ID)
+              azureSubscriptionId:          $(ARM_SUBSCRIPTION_ID)
             
   - stage:                             Software_Acquisition
     displayName:                       Software Acquisition
@@ -460,29 +432,20 @@ stages:
           - script: |
               sudo chmod 600 $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey
             displayName:               Process sshkey
-          - script: |
-              #Stage could be executed on a different machine by default, need to login again for ansible
-              if [ ${USE_DEPLOYER_VM^^} = "TRUE" ]; then
-                az login --identity --allow-no-subscriptions --output none
-              else
-                az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID --output none
-              fi
-              az account set --subscription $AZURE_SUBSCRIPTION_ID
 
-              ansible-playbook -i $(Pipeline.Workspace)/ansible_data/$(SID_hosts) --private-key $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey -e "@$(Pipeline.Workspace)/ansible_data/$(SAP_parameters)" -e "_workspace_directory=$(parameters_folder)" $(ExtraParams) $(DEPLOYMENT_REPO_PATH)/deploy/ansible/playbook_03_bom_processing.yaml 
-            displayName: Software Acquisition
-            env:
-              AZURE_CLIENT_ID:                $(ARM_CLIENT_ID)
-              AZURE_CLIENT_SECRET:            $(ARM_CLIENT_SECRET)
-              AZURE_TENANT_ID:                $(ARM_TENANT_ID)
-              AZURE_SUBSCRIPTION_ID:          $(ARM_SUBSCRIPTION_ID)
-              ANSIBLE_COLLECTIONS_PATHS:      ~/.ansible/collections:/opt/ansible/collections
-              ANSIBLE_PYTHON_INTERPRETER:     auto_silent
-              ANSIBLE_DISPLAY_SKIPPED_HOSTS:  false
-              ANSIBLE_HOST_KEY_CHECKING:      false
-              DEPLOYMENT_REPO_PATH:           $(DEPLOYMENT_REPO_PATH)
-              USE_DEPLOYER_VM:                $(Use_Deployer_VM)
-            continueOnError:           false
+          - template: templates\run-ansible.yaml
+            parameters:
+              displayName:                  "Software Acquisition"
+              ansibleFilePath:              $(DEPLOYMENT_REPO_PATH)/deploy/ansible/playbook_03_bom_processing.yaml
+              privateKey:                   $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey
+              parametersFolder:             "_workspace_directory=$(parameters_folder)"
+              sapParams:                    "@$(Pipeline.Workspace)/ansible_data/$(SAP_parameters)"
+              sidHosts:                     $(SID_hosts)
+              extraParams:                  $(ExtraParams)
+              azureClientId:                $(ARM_CLIENT_ID)
+              azureClientSecret:            $(ARM_CLIENT_SECRET)
+              azureTenantId:                $(ARM_TENANT_ID)
+              azureSubscriptionId:          $(ARM_SUBSCRIPTION_ID)
 
   - stage: Database_Installation
     displayName:                       Database Installation
@@ -519,29 +482,20 @@ stages:
           - script: |
               sudo chmod 600 $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey
             displayName:               Process sshkey
-          - script: |
-              #Stage could be executed on a different machine by default, need to login again for ansible
-              if [ ${USE_DEPLOYER_VM^^} = "TRUE" ]; then
-                az login --identity --allow-no-subscriptions --output none
-              else
-                az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID --output none
-              fi
-              az account set --subscription $AZURE_SUBSCRIPTION_ID
 
-              ansible-playbook -i $(Pipeline.Workspace)/ansible_data/$(SID_hosts) --private-key $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey -e "@$(Pipeline.Workspace)/ansible_data/$(SAP_parameters)" -e "_workspace_directory=$(parameters_folder)" $(ExtraParams) $(DEPLOYMENT_REPO_PATH)/deploy/ansible/playbook_04_00_00_db_install.yaml 
-            displayName: Database Installation
-            env:
-              AZURE_CLIENT_ID:                $(ARM_CLIENT_ID)
-              AZURE_CLIENT_SECRET:            $(ARM_CLIENT_SECRET)
-              AZURE_TENANT_ID:                $(ARM_TENANT_ID)
-              AZURE_SUBSCRIPTION_ID:          $(ARM_SUBSCRIPTION_ID)
-              ANSIBLE_COLLECTIONS_PATHS:      ~/.ansible/collections:/opt/ansible/collections
-              ANSIBLE_PYTHON_INTERPRETER:     auto_silent
-              ANSIBLE_DISPLAY_SKIPPED_HOSTS:  false
-              ANSIBLE_HOST_KEY_CHECKING:      false
-              DEPLOYMENT_REPO_PATH:           $(DEPLOYMENT_REPO_PATH)
-              USE_DEPLOYER_VM:                $(Use_Deployer_VM)
-            continueOnError:           false
+          - template: templates\run-ansible.yaml
+            parameters:
+              displayName:                  "Database Installation"
+              ansibleFilePath:              $(DEPLOYMENT_REPO_PATH)/deploy/ansible/playbook_04_00_00_db_install.yaml
+              privateKey:                   $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey
+              parametersFolder:             "_workspace_directory=$(parameters_folder)"
+              sapParams:                    "@$(Pipeline.Workspace)/ansible_data/$(SAP_parameters)"
+              sidHosts:                     $(SID_hosts)
+              extraParams:                  $(ExtraParams)
+              azureClientId:                $(ARM_CLIENT_ID)
+              azureClientSecret:            $(ARM_CLIENT_SECRET)
+              azureTenantId:                $(ARM_TENANT_ID)
+              azureSubscriptionId:          $(ARM_SUBSCRIPTION_ID)
 
           - script: |
               #!/bin/bash
@@ -599,29 +553,20 @@ stages:
           - script: |
               sudo chmod 600 $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey
             displayName:               Process sshkey
-          - script: |
-              #Stage could be executed on a different machine by default, need to login again for ansible
-              if [ ${USE_DEPLOYER_VM^^} = "TRUE" ]; then
-                az login --identity --allow-no-subscriptions --output none
-              else
-                az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID --output none
-              fi
-              az account set --subscription $AZURE_SUBSCRIPTION_ID
 
-              ansible-playbook -i $(Pipeline.Workspace)/ansible_data/$(SID_hosts) --private-key $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey -e "@$(Pipeline.Workspace)/ansible_data/$(SAP_parameters)" -e "_workspace_directory=$(parameters_folder)" $(ExtraParams) $(DEPLOYMENT_REPO_PATH)/deploy/ansible/playbook_05_00_00_sap_scs_install.yaml 
-            displayName: SCS Installation
-            env:
-              AZURE_CLIENT_ID:                $(ARM_CLIENT_ID)
-              AZURE_CLIENT_SECRET:            $(ARM_CLIENT_SECRET)
-              AZURE_TENANT_ID:                $(ARM_TENANT_ID)
-              AZURE_SUBSCRIPTION_ID:          $(ARM_SUBSCRIPTION_ID)
-              ANSIBLE_COLLECTIONS_PATHS:      ~/.ansible/collections:/opt/ansible/collections
-              ANSIBLE_PYTHON_INTERPRETER:     auto_silent
-              ANSIBLE_DISPLAY_SKIPPED_HOSTS:  false
-              ANSIBLE_HOST_KEY_CHECKING:      false
-              DEPLOYMENT_REPO_PATH:           $(DEPLOYMENT_REPO_PATH)
-              USE_DEPLOYER_VM:                $(Use_Deployer_VM)
-            continueOnError:           false
+          - template: templates\run-ansible.yaml
+            parameters:
+              displayName:                  "SCS Installation"
+              ansibleFilePath:              $(DEPLOYMENT_REPO_PATH)/deploy/ansible/playbook_05_00_00_sap_scs_install.yaml
+              privateKey:                   $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey
+              parametersFolder:             "_workspace_directory=$(parameters_folder)"
+              sapParams:                    "@$(Pipeline.Workspace)/ansible_data/$(SAP_parameters)"
+              sidHosts:                     $(SID_hosts)
+              extraParams:                  $(ExtraParams)
+              azureClientId:                $(ARM_CLIENT_ID)
+              azureClientSecret:            $(ARM_CLIENT_SECRET)
+              azureTenantId:                $(ARM_TENANT_ID)
+              azureSubscriptionId:          $(ARM_SUBSCRIPTION_ID)
 
           - script: |
               #!/bin/bash
@@ -683,29 +628,20 @@ stages:
           - script: |
               sudo chmod 600 $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey
             displayName:               Process sshkey
-          - script: |
-              #Stage could be executed on a different machine by default, need to login again for ansible
-              if [ ${USE_DEPLOYER_VM^^} = "TRUE" ]; then
-                az login --identity --allow-no-subscriptions --output none
-              else
-                az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID --output none
-              fi
-              az account set --subscription $AZURE_SUBSCRIPTION_ID
 
-              ansible-playbook -i $(Pipeline.Workspace)/ansible_data/$(SID_hosts) --private-key $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey -e "@$(Pipeline.Workspace)/ansible_data/$(SAP_parameters)" -e "_workspace_directory=$(parameters_folder)" $(ExtraParams) $(DEPLOYMENT_REPO_PATH)/deploy/ansible/playbook_05_01_sap_dbload.yaml 
-            displayName: Database Load
-            env:
-              AZURE_CLIENT_ID:                $(ARM_CLIENT_ID)
-              AZURE_CLIENT_SECRET:            $(ARM_CLIENT_SECRET)
-              AZURE_TENANT_ID:                $(ARM_TENANT_ID)
-              AZURE_SUBSCRIPTION_ID:          $(ARM_SUBSCRIPTION_ID)
-              ANSIBLE_COLLECTIONS_PATHS:      ~/.ansible/collections:/opt/ansible/collections
-              ANSIBLE_PYTHON_INTERPRETER:     auto_silent
-              ANSIBLE_DISPLAY_SKIPPED_HOSTS:  false
-              ANSIBLE_HOST_KEY_CHECKING:      false
-              DEPLOYMENT_REPO_PATH:           $(DEPLOYMENT_REPO_PATH)
-              USE_DEPLOYER_VM:                $(Use_Deployer_VM)
-            continueOnError:           false
+          - template: templates\run-ansible.yaml
+            parameters:
+              displayName:                  "Database Load"
+              ansibleFilePath:              $(DEPLOYMENT_REPO_PATH)/deploy/ansible/playbook_05_01_sap_dbload.yaml
+              privateKey:                   $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey
+              parametersFolder:             "_workspace_directory=$(parameters_folder)"
+              sapParams:                    "@$(Pipeline.Workspace)/ansible_data/$(SAP_parameters)"
+              sidHosts:                     $(SID_hosts)
+              extraParams:                  $(ExtraParams)
+              azureClientId:                $(ARM_CLIENT_ID)
+              azureClientSecret:            $(ARM_CLIENT_SECRET)
+              azureTenantId:                $(ARM_TENANT_ID)
+              azureSubscriptionId:          $(ARM_SUBSCRIPTION_ID)
 
           - script: |
               #!/bin/bash
@@ -764,29 +700,20 @@ stages:
           - script: |
               sudo chmod 600 $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey
             displayName:               Process sshkey
-          - script: |
-              #Stage could be executed on a different machine by default, need to login again for ansible
-              if [ ${USE_DEPLOYER_VM^^} = "TRUE" ]; then
-                az login --identity --allow-no-subscriptions --output none
-              else
-                az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID --output none
-              fi
-              az account set --subscription $AZURE_SUBSCRIPTION_ID
 
-              ansible-playbook -i $(Pipeline.Workspace)/ansible_data/$(SID_hosts) --private-key $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey -e "@$(Pipeline.Workspace)/ansible_data/$(SAP_parameters)" -e "_workspace_directory=$(parameters_folder)" $(ExtraParams) $(DEPLOYMENT_REPO_PATH)/deploy/ansible/playbook_04_00_01_db_ha.yaml 
-            displayName: High Availability Setup
-            env:
-              AZURE_CLIENT_ID:                $(ARM_CLIENT_ID)
-              AZURE_CLIENT_SECRET:            $(ARM_CLIENT_SECRET)
-              AZURE_TENANT_ID:                $(ARM_TENANT_ID)
-              AZURE_SUBSCRIPTION_ID:          $(ARM_SUBSCRIPTION_ID)
-              ANSIBLE_COLLECTIONS_PATHS:      ~/.ansible/collections:/opt/ansible/collections
-              ANSIBLE_PYTHON_INTERPRETER:     auto_silent
-              ANSIBLE_DISPLAY_SKIPPED_HOSTS:  false
-              ANSIBLE_HOST_KEY_CHECKING:      false
-              DEPLOYMENT_REPO_PATH:           $(DEPLOYMENT_REPO_PATH)
-              USE_DEPLOYER_VM:                $(Use_Deployer_VM)
-            continueOnError:           false
+          - template: templates\run-ansible.yaml
+            parameters:
+              displayName:                  "High Availability Setup"
+              ansibleFilePath:              $(DEPLOYMENT_REPO_PATH)/deploy/ansible/playbook_04_00_01_db_ha.yaml
+              privateKey:                   $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey
+              parametersFolder:             "_workspace_directory=$(parameters_folder)"
+              sapParams:                    "@$(Pipeline.Workspace)/ansible_data/$(SAP_parameters)"
+              sidHosts:                     $(SID_hosts)
+              extraParams:                  $(ExtraParams)
+              azureClientId:                $(ARM_CLIENT_ID)
+              azureClientSecret:            $(ARM_CLIENT_SECRET)
+              azureTenantId:                $(ARM_TENANT_ID)
+              azureSubscriptionId:          $(ARM_SUBSCRIPTION_ID)
 
   - stage: PAS_Installation
     displayName:                       PAS Installation
@@ -827,29 +754,20 @@ stages:
           - script: |
               sudo chmod 600 $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey
             displayName:               Process sshkey
-          - script: |
-              #Stage could be executed on a different machine by default, need to login again for ansible
-              if [ ${USE_DEPLOYER_VM^^} = "TRUE" ]; then
-                az login --identity --allow-no-subscriptions --output none
-              else
-                az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID --output none
-              fi
-              az account set --subscription $AZURE_SUBSCRIPTION_ID
 
-              ansible-playbook -i $(Pipeline.Workspace)/ansible_data/$(SID_hosts) --private-key $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey -e "@$(Pipeline.Workspace)/ansible_data/$(SAP_parameters)" -e "_workspace_directory=$(parameters_folder)" $(ExtraParams) $(DEPLOYMENT_REPO_PATH)/deploy/ansible/playbook_05_02_sap_pas_install.yaml 
-            displayName: PAS Installation
-            env:
-              AZURE_CLIENT_ID:                $(ARM_CLIENT_ID)
-              AZURE_CLIENT_SECRET:            $(ARM_CLIENT_SECRET)
-              AZURE_TENANT_ID:                $(ARM_TENANT_ID)
-              AZURE_SUBSCRIPTION_ID:          $(ARM_SUBSCRIPTION_ID)
-              ANSIBLE_COLLECTIONS_PATHS:      ~/.ansible/collections:/opt/ansible/collections
-              ANSIBLE_PYTHON_INTERPRETER:     auto_silent
-              ANSIBLE_DISPLAY_SKIPPED_HOSTS:  false
-              ANSIBLE_HOST_KEY_CHECKING:      false
-              DEPLOYMENT_REPO_PATH:           $(DEPLOYMENT_REPO_PATH)
-              USE_DEPLOYER_VM:                $(Use_Deployer_VM)
-            continueOnError:           false
+          - template: templates\run-ansible.yaml
+            parameters:
+              displayName:                  "PAS Installation"
+              ansibleFilePath:              $(DEPLOYMENT_REPO_PATH)/deploy/ansible/playbook_05_02_sap_pas_install.yaml
+              privateKey:                   $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey
+              parametersFolder:             "_workspace_directory=$(parameters_folder)"
+              sapParams:                    "@$(Pipeline.Workspace)/ansible_data/$(SAP_parameters)"
+              sidHosts:                     $(SID_hosts)
+              extraParams:                  $(ExtraParams)
+              azureClientId:                $(ARM_CLIENT_ID)
+              azureClientSecret:            $(ARM_CLIENT_SECRET)
+              azureTenantId:                $(ARM_TENANT_ID)
+              azureSubscriptionId:          $(ARM_SUBSCRIPTION_ID)
 
           - script: |
               #!/bin/bash
@@ -914,29 +832,20 @@ stages:
           - script: |
               sudo chmod 600 $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey
             displayName:               Process sshkey
-          - script: |
-              #Stage could be executed on a different machine by default, need to login again for ansible
-              if [ ${USE_DEPLOYER_VM^^} = "TRUE" ]; then
-                az login --identity --allow-no-subscriptions --output none
-              else
-                az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID --output none
-              fi
-              az account set --subscription $AZURE_SUBSCRIPTION_ID
 
-              ansible-playbook -i $(Pipeline.Workspace)/ansible_data/$(SID_hosts) --private-key $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey -e "@$(Pipeline.Workspace)/ansible_data/$(SAP_parameters)" -e "_workspace_directory=$(parameters_folder)" $(ExtraParams) $(DEPLOYMENT_REPO_PATH)/deploy/ansible/playbook_05_03_sap_app_install.yaml 
-            displayName: Application Server Install
-            env:
-              AZURE_CLIENT_ID:                $(ARM_CLIENT_ID)
-              AZURE_CLIENT_SECRET:            $(ARM_CLIENT_SECRET)
-              AZURE_TENANT_ID:                $(ARM_TENANT_ID)
-              AZURE_SUBSCRIPTION_ID:          $(ARM_SUBSCRIPTION_ID)
-              ANSIBLE_COLLECTIONS_PATHS:      ~/.ansible/collections:/opt/ansible/collections
-              ANSIBLE_PYTHON_INTERPRETER:     auto_silent
-              ANSIBLE_DISPLAY_SKIPPED_HOSTS:  false
-              ANSIBLE_HOST_KEY_CHECKING:      false
-              DEPLOYMENT_REPO_PATH:           $(DEPLOYMENT_REPO_PATH)
-              USE_DEPLOYER_VM:                $(Use_Deployer_VM)
-            continueOnError:           false
+          - template: templates\run-ansible.yaml
+            parameters:
+              displayName:                  "Application Server Install"
+              ansibleFilePath:              $(DEPLOYMENT_REPO_PATH)/deploy/ansible/playbook_05_03_sap_app_install.yaml
+              privateKey:                   $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey
+              parametersFolder:             "_workspace_directory=$(parameters_folder)"
+              sapParams:                    "@$(Pipeline.Workspace)/ansible_data/$(SAP_parameters)"
+              sidHosts:                     $(SID_hosts)
+              extraParams:                  $(ExtraParams)
+              azureClientId:                $(ARM_CLIENT_ID)
+              azureClientSecret:            $(ARM_CLIENT_SECRET)
+              azureTenantId:                $(ARM_TENANT_ID)
+              azureSubscriptionId:          $(ARM_SUBSCRIPTION_ID)
 
           - script: |
               #!/bin/bash
@@ -991,29 +900,20 @@ stages:
           - script: |
               sudo chmod 600 $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey
             displayName:               Process sshkey
-          - script: |
-              #Stage could be executed on a different machine by default, need to login again for ansible
-              if [ ${USE_DEPLOYER_VM^^} = "TRUE" ]; then
-                az login --identity --allow-no-subscriptions --output none
-              else
-                az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID --output none
-              fi
-              az account set --subscription $AZURE_SUBSCRIPTION_ID
 
-              ansible-playbook -i $(Pipeline.Workspace)/ansible_data/$(SID_hosts) --private-key $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey -e "@$(Pipeline.Workspace)/ansible_data/$(SAP_parameters)" -e "_workspace_directory=$(parameters_folder)" $(ExtraParams) $(DEPLOYMENT_REPO_PATH)/deploy/ansible/playbook_05_04_sap_web_install.yaml 
-            displayName: WebDispatcher Installation
-            env:
-              AZURE_CLIENT_ID:                $(ARM_CLIENT_ID)
-              AZURE_CLIENT_SECRET:            $(ARM_CLIENT_SECRET)
-              AZURE_TENANT_ID:                $(ARM_TENANT_ID)
-              AZURE_SUBSCRIPTION_ID:          $(ARM_SUBSCRIPTION_ID)
-              ANSIBLE_COLLECTIONS_PATHS:      ~/.ansible/collections:/opt/ansible/collections
-              ANSIBLE_PYTHON_INTERPRETER:     auto_silent
-              ANSIBLE_DISPLAY_SKIPPED_HOSTS:  false
-              ANSIBLE_HOST_KEY_CHECKING:      false
-              DEPLOYMENT_REPO_PATH:           $(DEPLOYMENT_REPO_PATH)
-              USE_DEPLOYER_VM:                $(Use_Deployer_VM)
-            continueOnError:           false
+          - template: templates\run-ansible.yaml
+            parameters:
+              displayName:                  "WebDispatcher Installation"
+              ansibleFilePath:              $(DEPLOYMENT_REPO_PATH)/deploy/ansible/playbook_05_04_sap_web_install.yaml
+              privateKey:                   $(Pipeline.Workspace)/ansible_data/$(CONFIGURATION_NAME)_sshkey
+              parametersFolder:             "_workspace_directory=$(parameters_folder)"
+              sapParams:                    "@$(Pipeline.Workspace)/ansible_data/$(SAP_parameters)"
+              sidHosts:                     $(SID_hosts)
+              extraParams:                  $(ExtraParams)
+              azureClientId:                $(ARM_CLIENT_ID)
+              azureClientSecret:            $(ARM_CLIENT_SECRET)
+              azureTenantId:                $(ARM_TENANT_ID)
+              azureSubscriptionId:          $(ARM_SUBSCRIPTION_ID)
 
           - script: |
               #!/bin/bash

--- a/deploy/pipelines/05-DB-and-SAP-installation.yaml
+++ b/deploy/pipelines/05-DB-and-SAP-installation.yaml
@@ -239,6 +239,8 @@ stages:
                   echo "##vso[task.logissue type=error]az login failed."
                   exit $return_code
                 fi
+                az account set --subscription $ARM_SUBSCRIPTION_ID
+                
                 az keyvault secret show --name ${ENVIRONMENT}-${LOCATION}-${NETWORK}-sid-sshkey --vault-name $workload_key_vault --query value -o tsv > artifacts/$(sap_system_folder)_sshkey
                 cp sap-parameters.yaml artifacts/.
                 cp ${SID}_hosts.yaml artifacts/.

--- a/deploy/pipelines/templates/run-ansible.yaml
+++ b/deploy/pipelines/templates/run-ansible.yaml
@@ -1,0 +1,48 @@
+parameters:
+    azureClientId: ''
+    azureClientSecret: ''
+    azureTenantId: ''
+    azureSubscriptionId: ''
+    displayName: ''
+    ansibleFilePath: ''
+    sidHosts:  ''
+    privateKey:  ''
+    parametersFolder: ''
+    extraParams: ''
+    sapParams: ''
+steps:
+- script: |
+    #Stage could be executed on a different machine by default, need to login again for ansible
+    #If the deployer_file exists we run on a deployer cofigured by the framework instead of a azdo hosted one
+    deployer_file=/etc/profile.d/deploy_server.sh
+    if [ -f "$deployer_file" ]; then
+      az login --identity --allow-no-subscriptions --output none
+    else
+      az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID --output none
+    fi
+    az account set --subscription $AZURE_SUBSCRIPTION_ID
+
+    ansible-playbook -i $INVENTORY \
+                     --private-key $PRIVATE_KEY \
+                     -e $SAP_PARAMS \
+                     -e "_workspace_directory=$PARAMETERS_FOLDER" \
+                     $EXTRA_PARAMS \
+                     $ANSIBLE_FILE_PATH
+
+  displayName: ${{ parameters.displayName }}
+  env:
+    AZURE_CLIENT_ID:                ${{ parameters.azureClientId }}
+    AZURE_CLIENT_SECRET:            ${{ parameters.azureClientSecret }}
+    AZURE_TENANT_ID:                ${{ parameters.azureTenantId }}
+    AZURE_SUBSCRIPTION_ID:          ${{ parameters.azureSubscriptionId }}
+    ANSIBLE_COLLECTIONS_PATHS:      ~/.ansible/collections:/opt/ansible/collections
+    ANSIBLE_PYTHON_INTERPRETER:     auto_silent
+    ANSIBLE_DISPLAY_SKIPPED_HOSTS:  false
+    ANSIBLE_HOST_KEY_CHECKING:      false
+    ANSIBLE_FILE_PATH:              ${{ parameters.ansibleFilePath }}
+    PARAMETERS_FOLDER:              ${{ parameters.parametersFolder }}
+    EXTRA_PARAMS:                   ${{ parameters.extraParams }}
+    SAP_PARAMS:                     ${{ parameters.sapParams }}
+    PRIVATE_KEY:                    ${{ parameters.privateKey }}
+    INVENTORY:                      $(Pipeline.Workspace)/ansible_data/${{ parameters.sidHosts }}
+  continueOnError:           false


### PR DESCRIPTION
## Problem
When running the ansible scripts they need access to the resources created in azure. 
When deploying using azure devops there will be an new machine for each stage, they are short lived. Therefor in each stage there should be at least te az login to make sure ansible can do it's job.
Issues with the ansible task

## Solution
Created the variable Use_Deploy_VM on the management plane to be able to test to login using a system managed identity or use the service principle. (when deploy using azdo public/private agents that are shortlived, there is no such thing as a system managed identity available). This variable is being set by deploying the control-plane

Replacing all the ansible tasks with the scripting provides the login into azure and proper call of the ansible playbooks.

## Tests
Run the 05-pipeline with all options checked

## Notes
<Additional comments for the PR>