### PR TITLE
Preserve statefile onerror

### DIFF
--- a/deploy/pipelines/10-remover-terraform.yaml
+++ b/deploy/pipelines/10-remover-terraform.yaml
@@ -249,10 +249,7 @@ stages:
                 cd $HOME/SYSTEM/$(sap_system_folder)
                 ${DEPLOYMENT_REPO_PATH}/deploy/scripts/remover.sh --parameterfile $(sap_system_configuration) --type sap_system --auto-approve
                 return_code=$?
-                echo "Return code from remover.sh $return_code."
-                if [ 0 != $return_code ]; then
-                  echo "##vso[task.logissue type=error]Return code from remover.sh $return_code."
-                fi
+
               echo -e "$green--- Pull latest from DevOps Repository ---$reset"
                 git checkout -q $(Build.SourceBranchName)
                 git pull
@@ -277,6 +274,13 @@ stages:
                     fi
                   fi
                 fi
+
+              #stop the pipeline after you have reset the whitelisting on your resources
+              echo "Return code from remover.sh $return_code."
+              if [ 0 != $return_code ]; then
+                echo "##vso[task.logissue type=error]Return code from remover.sh $return_code."
+                exit $return_code
+              fi
 
               echo -e "$green--- Add & update files in the DevOps Repository ---$reset"
                 cd $(Build.Repository.LocalPath)
@@ -508,13 +512,6 @@ stages:
                 
                 $DEPLOYMENT_REPO_PATH/deploy/scripts/remover.sh --parameterfile $(workload_zone_configuration_file) --type sap_landscape --auto-approve --ado
                 return_code=$?
-                echo "Return code from remover.sh $return_code."
-                if [ 0 != $return_code ]; then
-                  echo "##vso[task.logissue type=error]Return code from remover.sh $return_code."
-                fi
-
-                echo -e "$green--- Pull latest ---$reset"
-                  git pull 
 
                 az account set --subscription ${STATE_SUBSCRIPTION}
                 if [[ ip_added_control_plane -eq 1 ]]; then
@@ -526,9 +523,17 @@ stages:
                   fi
                 fi
 
+                #stop the pipeline after you have reset the whitelisting on your resources
+                echo "Return code from remover.sh $return_code."
+                if [ 0 != $return_code ]; then
+                  echo "##vso[task.logissue type=error]Return code from remover.sh $return_code."
+                  exit $return_code
+                fi
+
               echo -e "$green--- Add & update files in the DevOps Repository ---$reset"
                 cd $(Build.Repository.LocalPath)
                 changed=0
+                git pull
 
                 if [ 0 == $return_code ]; then
 

--- a/deploy/scripts/remover.sh
+++ b/deploy/scripts/remover.sh
@@ -310,7 +310,11 @@ terraform -chdir="${terraform_module_directory}" init  -reconfigure \
 --backend-config "resource_group_name=${REMOTE_STATE_RG}"         \
 --backend-config "storage_account_name=${REMOTE_STATE_SA}"        \
 --backend-config "container_name=tfstate"                         \
---backend-config "key=${key}.terraform.tfstate"
+--backend-config "key=${key}.terraform.tfstate" || {
+    echo "Terraform init failed"
+    exit 1
+}
+
 
 
 created_resource_group_id=$(terraform -chdir="${terraform_module_directory}" output -no-color -raw created_resource_group_id | tr -d \")


### PR DESCRIPTION
## Problem
When using the pipeline 10-remover-terraform the situation could happen that something would go wrong during removal resulting in the scenario that your azure resources would still exist while the state file was removed.

## Solution
Stop with removal execution if the init of the terraform would fail.

## Tests
Remove system or workload using pipeline 10. this should succeed

## Notes
Move the stopping of the pipeline after removal of the whitelisting, this you want to do no matter what the result of the remove.sh 