### PR TITLE
add dns configration to ha resources

### DIFF
--- a/deploy/terraform/run/sap_system/module.tf
+++ b/deploy/terraform/run/sap_system/module.tf
@@ -72,12 +72,12 @@ module "common_infrastructure" {
     local.database.high_availability ? 1 : 0,
     var.NFS_provider
   )
-  Agent_IP                           = var.Agent_IP
-  use_private_endpoint               = var.use_private_endpoint
+  Agent_IP             = var.Agent_IP
+  use_private_endpoint = var.use_private_endpoint
 
-  use_custom_dns_a_registration      = data.terraform_remote_state.landscape.outputs.use_custom_dns_a_registration
-  management_dns_subscription_id     = try(data.terraform_remote_state.landscape.outputs.management_dns_subscription_id, null)
-  management_dns_resourcegroup_name  = data.terraform_remote_state.landscape.outputs.management_dns_resourcegroup_name
+  use_custom_dns_a_registration     = data.terraform_remote_state.landscape.outputs.use_custom_dns_a_registration
+  management_dns_subscription_id    = try(data.terraform_remote_state.landscape.outputs.management_dns_subscription_id, null)
+  management_dns_resourcegroup_name = data.terraform_remote_state.landscape.outputs.management_dns_resourcegroup_name
 
   database_dual_nics                 = var.database_dual_nics
   azure_files_sapmnt_id              = var.azure_files_sapmnt_id
@@ -247,7 +247,6 @@ module "anydb_node" {
     local.database.high_availability ? 2 * var.database_server_count : var.database_server_count
   )
   use_observer                       = var.use_observer
-  landscape_tfstate                  = data.terraform_remote_state.landscape.outputs
   use_secondary_ips                  = var.use_secondary_ips
   deploy_application_security_groups = var.deploy_application_security_groups
   use_msi_for_clusters               = var.use_msi_for_clusters

--- a/deploy/terraform/run/sap_system/tfvar_variables.tf
+++ b/deploy/terraform/run/sap_system/tfvar_variables.tf
@@ -761,6 +761,23 @@ variable "use_private_endpoint" {
   type        = bool
 }
 
+variable "use_custom_dns_a_registration" {
+  description = "Boolean value indicating if a custom dns a record should be created when using private endpoints"
+  default     = false
+  type        = bool
+}
+
+variable "management_dns_subscription_id" {
+  description = "String value giving the possibility to register custom dns a records in a separate subscription"
+  default     = null
+  type        = string
+}
+
+variable "management_dns_resourcegroup_name" {
+  description = "String value giving the possibility to register custom dns a records in a separate resourcegroup"
+  default     = null
+  type        = string
+}
 #########################################################################################
 #                                                                                       #
 #  NFS and Shared Filed settings                                                        #

--- a/deploy/terraform/terraform-units/modules/sap_landscape/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/infrastructure.tf
@@ -153,7 +153,7 @@ resource "azurerm_route" "admin" {
 
 resource "azurerm_private_dns_zone_virtual_network_link" "vnet_sap" {
   provider = azurerm.deployer
-  count    = length(var.dns_label) > 0 ? 1 : 0
+  count    = length(var.dns_label) > 0 && !var.use_custom_dns_a_registration ? 1 : 0
   name = format("%s%s%s%s",
     var.naming.resource_prefixes.dns_link,
     local.prefix,

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/infrastructure.tf
@@ -137,10 +137,10 @@ data "azurerm_availability_set" "anydb" {
 }
 
 resource "azurerm_private_dns_a_record" "db" {
-  provider            = azurerm.deployer
+  provider            = azurerm.dnsmanagement
   count               = local.enable_db_lb_deployment && length(local.dns_label) > 0 ? 1 : 0
   name                = lower(format("%s%sdb%scl", var.sap_sid, local.anydb_sid, "00"))
-  resource_group_name = local.dns_resource_group_name
+  resource_group_name = try(var.management_dns_resourcegroup_name, local.dns_resource_group_name)
   zone_name           = local.dns_label
   ttl                 = 300
   records             = [azurerm_lb.anydb[0].frontend_ip_configuration[0].private_ip_address]

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/providers.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source                = "hashicorp/azurerm"
-      configuration_aliases = [azurerm.main, azurerm.deployer]
+      configuration_aliases = [azurerm.main, azurerm.deployer, azurerm.dnsmanagement]
       version               = "~> 3.0"
     }
   }

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/variables_global.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/variables_global.tf
@@ -128,3 +128,21 @@ variable "use_msi_for_clusters" {
 variable "fencing_role_name" {
   description = "If specified the role name to use for the fencing"
 }
+
+variable "use_custom_dns_a_registration" {
+  description = "Boolean value indicating if a custom dns a record should be created when using private endpoints"
+  default     = false
+  type        = bool
+}
+
+variable "management_dns_subscription_id" {
+  description = "String value giving the possibility to register custom dns a records in a separate subscription"
+  default     = null
+  type        = string
+}
+
+variable "management_dns_resourcegroup_name" {
+  description = "String value giving the possibility to register custom dns a records in a separate resourcegroup"
+  default     = null
+  type        = string
+}

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/infrastructure.tf
@@ -104,6 +104,9 @@ resource "azurerm_lb" "scs" {
       zones                         = ["1", "2", "3"]
     }
   }
+  lifecycle {
+    ignore_changes = [tags]
+  }
 }
 
 resource "azurerm_lb_backend_address_pool" "scs" {
@@ -291,6 +294,9 @@ resource "azurerm_availability_set" "scs" {
     var.ppg[0].id
   )
   managed = true
+  lifecycle {
+    ignore_changes = [tags]
+  }
 }
 
 ##############################################################################################
@@ -318,6 +324,9 @@ resource "azurerm_availability_set" "app" {
     var.ppg[0].id
   )
   managed = true
+  lifecycle {
+    ignore_changes = [tags]
+  }
 }
 
 /*
@@ -360,7 +369,9 @@ resource "azurerm_lb" "web" {
     private_ip_address_allocation = var.application.use_DHCP ? "Dynamic" : "Static"
     zones                         = ["1", "2", "3"]
   }
-
+  lifecycle {
+    ignore_changes = [tags]
+  }
 }
 
 resource "azurerm_lb_backend_address_pool" "web" {
@@ -438,6 +449,10 @@ resource "azurerm_availability_set" "web" {
   platform_fault_domain_count  = local.faultdomain_count
   proximity_placement_group_id = local.web_zonal_deployment ? var.ppg[count.index % length(local.web_zones)].id : var.ppg[0].id
   managed                      = true
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
 }
 
 
@@ -467,6 +482,9 @@ resource "azurerm_application_security_group" "app" {
     var.network_location) : (
     var.resource_group[0].location
   )
+  lifecycle {
+    ignore_changes = [tags]
+  }
 }
 
 resource "azurerm_application_security_group" "web" {
@@ -490,6 +508,9 @@ resource "azurerm_application_security_group" "web" {
     var.network_location) : (
     var.resource_group[0].location
   )
+  lifecycle {
+    ignore_changes = [tags]
+  }
 }
 
 resource "azurerm_subnet_route_table_association" "subnet_sap_app" {
@@ -513,26 +534,26 @@ resource "azurerm_subnet_route_table_association" "subnet_sap_web" {
 }
 
 resource "azurerm_private_dns_a_record" "scs" {
-  provider = azurerm.deployer
+  provider = azurerm.dnsmanagement
   count    = local.enable_scs_lb_deployment && length(local.dns_label) > 0 ? 1 : 0
   name = lower(format("%sscs%scl1",
     local.sid,
     var.application.scs_instance_number
   ))
-  resource_group_name = local.dns_resource_group_name
+  resource_group_name = try(var.management_dns_resourcegroup_name, local.dns_resource_group_name)
   zone_name           = local.dns_label
   ttl                 = 300
   records             = [azurerm_lb.scs[0].frontend_ip_configuration[0].private_ip_address]
 }
 
 resource "azurerm_private_dns_a_record" "ers" {
-  provider = azurerm.deployer
+  provider = azurerm.dnsmanagement
   count    = local.enable_scs_lb_deployment && length(local.dns_label) > 0 ? 1 : 0
   name = lower(format("%sers%scl2",
     local.sid,
     local.ers_instance_number
   ))
-  resource_group_name = local.dns_resource_group_name
+  resource_group_name = try(var.management_dns_resourcegroup_name, local.dns_resource_group_name)
   zone_name           = local.dns_label
   ttl                 = 300
   records             = [azurerm_lb.scs[0].frontend_ip_configuration[1].private_ip_address]

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/providers.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source                = "hashicorp/azurerm"
-      configuration_aliases = [azurerm.main, azurerm.deployer]
+      configuration_aliases = [azurerm.main, azurerm.deployer, azure.dnsmanagement]
       version               = "~> 3.0"
     }
   }

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_global.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_global.tf
@@ -123,3 +123,20 @@ variable "fencing_role_name" {
   description = "If specified the role name to use for the fencing"
 }
 
+variable "use_custom_dns_a_registration" {
+  description = "Boolean value indicating if a custom dns a record should be created when using private endpoints"
+  default     = false
+  type        = bool
+}
+
+variable "management_dns_subscription_id" {
+  description = "String value giving the possibility to register custom dns a records in a separate subscription"
+  default     = null
+  type        = string
+}
+
+variable "management_dns_resourcegroup_name" {
+  description = "String value giving the possibility to register custom dns a records in a separate resourcegroup"
+  default     = null
+  type        = string
+}

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-app.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-app.tf
@@ -43,6 +43,9 @@ resource "azurerm_network_interface" "app" {
 
     }
   }
+  lifecycle {
+    ignore_changes = [tags]
+  }
 }
 
 resource "azurerm_network_interface_application_security_group_association" "app" {
@@ -336,6 +339,9 @@ resource "azurerm_windows_virtual_machine" "app" {
 
   tags = try(var.application.app_tags, {})
 
+  lifecycle {
+    ignore_changes = [tags]
+  }
 }
 
 # Creates managed data disk
@@ -362,8 +368,9 @@ resource "azurerm_managed_disk" "app" {
       azurerm_windows_virtual_machine.app[local.app_data_disks[count.index].vm_index].zone
     )
   )
-
-
+  lifecycle {
+    ignore_changes = [tags]
+  }
 }
 
 resource "azurerm_virtual_machine_data_disk_attachment" "app" {

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-scs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-scs.tf
@@ -41,6 +41,10 @@ resource "azurerm_network_interface" "scs" {
       primary = pub.value.primary
     }
   }
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
 }
 
 resource "azurerm_network_interface_application_security_group_association" "scs" {
@@ -236,6 +240,9 @@ resource "azurerm_linux_virtual_machine" "scs" {
     }
   }
 
+  lifecycle {
+    ignore_changes = [tags]
+  }
 }
 
 resource "azurerm_role_assignment" "scs" {
@@ -404,6 +411,10 @@ resource "azurerm_managed_disk" "scs" {
     )) : (
     null
   )
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
 }
 
 resource "azurerm_virtual_machine_data_disk_attachment" "scs" {

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-webdisp.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-webdisp.tf
@@ -46,6 +46,10 @@ resource "azurerm_network_interface" "web" {
       primary = pub.value.primary
     }
   }
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
 }
 
 resource "azurerm_network_interface_application_security_group_association" "web" {
@@ -229,6 +233,10 @@ resource "azurerm_linux_virtual_machine" "web" {
   license_type = length(var.license_type) > 0 ? var.license_type : null
 
   tags = try(var.application.web_tags, {})
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
 }
 
 # Create the Windows Web dispatcher VM(s)
@@ -378,6 +386,10 @@ resource "azurerm_managed_disk" "web" {
     )) : (
     null
   )
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
 }
 
 resource "azurerm_virtual_machine_data_disk_attachment" "web" {

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/infrastructure.tf
@@ -145,10 +145,10 @@ resource "azurerm_lb_rule" "hdb" {
   idle_timeout_in_minutes  = 30
 }
 resource "azurerm_private_dns_a_record" "db" {
-  provider            = azurerm.deployer
+  provider            = azurerm.dnsmanagement
   count               = local.enable_db_lb_deployment && length(local.dns_label) > 0 ? 1 : 0
   name                = lower(format("%s%sdb%scl", var.sap_sid, local.hdb_sid, local.hdb_nr))
-  resource_group_name = local.dns_resource_group_name
+  resource_group_name = try(var.management_dns_resourcegroup_name, local.dns_resource_group_name)
   zone_name           = local.dns_label
   ttl                 = 300
   records             = [try(azurerm_lb.hdb[0].frontend_ip_configuration[0].private_ip_address, "")]

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/providers.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source                = "hashicorp/azurerm"
-      configuration_aliases = [azurerm.main, azurerm.deployer]
+      configuration_aliases = [azurerm.main, azurerm.deployer, azurerm.dnsmanagement]
       version               = "~> 3.0"
     }
   }

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_global.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_global.tf
@@ -147,3 +147,21 @@ variable "use_msi_for_clusters" {
 variable "fencing_role_name" {
   description = "If specified the role name to use for the fencing"
 }
+
+variable "use_custom_dns_a_registration" {
+  description = "Boolean value indicating if a custom dns a record should be created when using private endpoints"
+  default     = false
+  type        = bool
+}
+
+variable "management_dns_subscription_id" {
+  description = "String value giving the possibility to register custom dns a records in a separate subscription"
+  default     = null
+  type        = string
+}
+
+variable "management_dns_resourcegroup_name" {
+  description = "String value giving the possibility to register custom dns a records in a separate resourcegroup"
+  default     = null
+  type        = string
+}

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/vm-hdb.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/vm-hdb.tf
@@ -95,6 +95,9 @@ resource "azurerm_network_interface" "nics_dbnodes_db" {
       primary = pub.value.primary
     }
   }
+  lifecycle {
+    ignore_changes = [tags]
+  }
 }
 
 resource "azurerm_network_interface_application_security_group_association" "db" {


### PR DESCRIPTION
## Problem
While testing HA setup there was a misconfiguration for the HA resources DNS setup

## Solution
- Added the same DNS configuration as for the normal resources
- Added additional lifecycle instructions
- Remove a duplicate variable setting from sap-system
- Pass on the DNS label to the sap-parameters file upon systemdeployment

## Tests
Deploy a systemdeploy for HA 

## Notes
<Additional comments for the PR>