### PR TITLE
Remove async job wait db_load

### DIFF
--- a/deploy/ansible/roles-sap/5.1-dbload/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.1-dbload/tasks/main.yaml
@@ -144,30 +144,18 @@
       register:                        dbload_results
       tags:
         - skip_ansible_lint
-      async:                           7200
-      poll:                            0
-
-    - name:                            "DBLoad Install -Wait for asynchronous job to end"
-      ansible.builtin.async_status:
-        jid:                           "{{ dbload_results.ansible_job_id }}"
-      register:                        job_result
-      until:                           job_result.finished
-      retries:                         120
-      delay:                           60
-      when:                            dbload_results.ansible_job_id is defined
 
     - name:                            "DBLoad: Installation results"
       ansible.builtin.debug:
         msg:
           - "DBLoad : {{ dbload_results }}"
-          - "Job result: {{ job_result }}"
 
     - name:                            "DBLoad: Installation results"
       ansible.builtin.debug:
         var:                           dbload_results
       when:
-        - job_result is defined
-        - job_result.rc > 0
+        - dbload_results is defined
+        - dbload_results.rc > 0
 
     - name:                            "DBLoad Install: Cleanup ini file {{ ansible_hostname }}"
       ansible.builtin.file:
@@ -180,8 +168,8 @@
         state:                         touch
         mode:                          0755
       when:
-        - job_result.rc is defined
-        - job_result.rc == 0
+        - dbload_results is defined
+        - dbload_results.rc > 0
 
     - name:                            "DBLoad Install: Installation results"
       ansible.builtin.debug:


### PR DESCRIPTION
## Problem
During the wait of the async db load job, anywhere between 3-15 minutes it would result with the error

```
TASK [roles-sap/5.1-dbload : DBLoad Install -Wait for asynchronous job to end] *** 
task path: /agent/_work/1/s/deploy/ansible/roles-sap/5.1-dbload/tasks/main.yaml:150 
fatal: [x01app00le41]: FAILED! => { 
"ansible_job_id": "397969119419.703904", 
"attempts": 12, 
"changed": false, 
"finished": 1, 
"invocation": { 
"module_args": { 
"_async_dir": "/home/azureadm", 
"jid": "397969119419.703904", 
"mode": "status" 
} 
}, 
"msg": "could not find job", 
"results_file": "/home/azureadm/397969119419.703904", 
"started": 1, 
"stderr": "", 
"stderr_lines": [], 
"stdout": "", 
"stdout_lines": [] 
} 

```

## Solution
Removing the async wait resolved the entire issue. Dont know why it was there in the first place case it is a pretty much synchronous operation

## Tests
Run the db_load in pipeline 5

## Notes
<Additional comments for the PR>