### PR TITLE
make sure folder settings apply

### DIFF
--- a/deploy/ansible/roles-db/4.0.0-hdb-install/tasks/main.yaml
+++ b/deploy/ansible/roles-db/4.0.0-hdb-install/tasks/main.yaml
@@ -81,6 +81,7 @@
     - name:                            "SAP HANA: Execute hdblcm on {{ (hana_host) }}"
       ansible.builtin.shell: |
                                        umask {{ custom_umask | default('022') }};
+                                       chmod 755 /usr/sap;
                                        ./hdblcm --batch --action=install --hostname {{ hana_host }} --configfile='{{ dir_params }}/{{ sap_inifile }}'
       args:
         chdir:                         "{{ target_media_location }}/CD_HDBSERVER/SAP_HANA_DATABASE"


### PR DESCRIPTION
## Problem
During execution the process did not have access to the /usr/sap folders. 

## Solution
Tried to figure out where the original settings where applied to change it but this was quicker, just chmod before execution

## Tests
Run the db-install from the 05 pipeline

## Notes
If you know where these folders are setup in the first place it might me better to fix it there instead of doing it my way.