### PR TITLE
Make sure directories exists before execution

### DIFF
--- a/deploy/ansible/playbook_04_00_00_db_install.yaml
+++ b/deploy/ansible/playbook_04_00_00_db_install.yaml
@@ -12,7 +12,20 @@
     - vars/ansible-input-api.yaml                               # API Input template with defaults
 
   tasks:
-
+    - name:                                "refresh BoM Processing: - Create BOM download directories"
+      ansible.builtin.file:
+        path:                              "{{ item.path }}"
+        state:                             directory
+        mode:                              0755
+      become:                              true
+      become_user:                         root
+      delegate_to:                         localhost
+      loop:
+        - path: "{{ download_directory }}"
+        - path: "{{ download_directory }}/tmp"
+        - path: "{{ download_directory }}/bom"
+        - path: "{{ download_directory }}/files"
+        
     - name:                            "Database Installation Playbook: - Create Progress folder"
       ansible.builtin.file:
         path:                          "{{ _workspace_directory }}/.progress"


### PR DESCRIPTION
## Problem
During testing the bom folder structure did not exist while executing DB_install. 

## Solution
Added the bom download directories task from the roles setup.

## Tests
Run the 05 pipeline

## Notes
Don't remember if this happened in the distributed or in the single server configuration, sorry