### PR TITLE
removing failOnStderr

### DIFF
--- a/deploy/pipelines/05-DB-and-SAP-installation.yaml
+++ b/deploy/pipelines/05-DB-and-SAP-installation.yaml
@@ -276,7 +276,6 @@ stages:
               CONFIG_REPO_PATH:              ${{ parameters.config_repo_path }}
               BOM_BASE_NAME:                 ${{ parameters.bom_base_name }}
               SAP_SYSTEM_CONFIGURATION_NAME: ${{ parameters.sap_system_configuration_name }}
-            failOnStderr:                    true
           - template:                        templates\run-ansible.yaml
             parameters:
               displayName:                   "Parameter validation"


### PR DESCRIPTION
## Problem
A Warnings is written in the Error Stream and Azure DevOps breaks due to the same.

## Solution
Azure DevOps should not break on warnings. Hence the removal of the below line won't stop the pipeline from execution.
**failOnStderr: true**

## Tests
Tested it with or without settings.