### PR TITLE
Update HANA_2_00_install.rsp.j2

### DIFF
--- a/deploy/ansible/BOM-catalog/HANA_2_00_065_v0001ms/templates/HANA_2_00_install.rsp.j2
+++ b/deploy/ansible/BOM-catalog/HANA_2_00_065_v0001ms/templates/HANA_2_00_install.rsp.j2
@@ -63,10 +63,10 @@ install_ssh_key=y
 root_user=root
 
 # Root User Password For Remote Hosts
-root_password= {{ main_password }}
+root_password=
 
 # SAP Host Agent User (sapadm) Password
-sapadm_password= {{ main_password }}
+sapadm_password=
 
 # Directory containing a storage configuration
 storage_cfg=


### PR DESCRIPTION
## Problem
HANA installation fails with errors:

    Master Password cannot be used in combination with other initial passwords

## Solution
remove reference of {{ main_password }} for all other initial passwords and
keep only the Master Password
master_password={{ main_password }}

## Tests
done on SLES 15 SP3 command line and via devops pipeline run

## Notes
reason is unclear why hdblcm changed the behavior 