### PR TITLE
Update main.yaml

### DIFF
--- a/deploy/ansible/roles-misc/0.3.sap-installation-media-storage-details/tasks/main.yaml
+++ b/deploy/ansible/roles-misc/0.3.sap-installation-media-storage-details/tasks/main.yaml
@@ -129,7 +129,7 @@
                                        az storage account generate-sas \
                                          --services b \
                                          --resource-types sco \
-                                         --permissions rl \
+                                         --permissions crwl \
                                          --account-name {{ sapbits_location_base_path.rpartition('//')[2].split('.')[0] }} \
                                          --account-key {{ sapbits_access_key }} \
                                          --expiry {{ expiry.stdout }} \


### PR DESCRIPTION
Summary: Changing SAS token generation permissions from "rl" to "crwl", BOM upload to storage accounts fails due to sas token set to read only based on steps in documented step-by-step guide: https://learn.microsoft.com/en-us/azure/virtual-machines/workloads/sap/automation-software

## Problem
When running BOM download task, ansible will fail with error at "sap-automation\deploy\ansible\roles-sap\0.1-bom-validator\tasks\main.yaml:66"

You do not have the required permissions needed to perform this operation.
Depending on your operation, you may need to be assigned one of the following roles:
    "Storage Blob Data Owner"
    "Storage Blob Data Contributor"
    "Storage Blob Data Reader"
    "Storage Queue Data Contributor"
    "Storage Queue Data Reader"
    "Storage Table Data Contributor"
    "Storage Table Data Reader"

If you want to use the old authentication method and allow querying for the right account key, please use the "--auth-mode" parameter and "key" value.

## Solution
change SAS token generation in file "sap-automation\deploy\ansible\roles-misc\0.3.sap-installation-media-storage-details\tasks\main.yaml:132" from "rl" to "crwl"

## Tests
Download an existing Microsoft provided BOM based on steps in guide : https://learn.microsoft.com/en-us/azure/virtual-machines/workloads/sap/automation-software and attempt to upload to an existing storage account.

## Notes
<Additional comments for the PR>