### PR TITLE
Experimental

### DIFF
--- a/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.3-db2_restore_secondary.yml
+++ b/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.3-db2_restore_secondary.yml
@@ -51,7 +51,7 @@
 
       # ##################### Start of Restore without Encryption ##################################
     - name:                            "DB2 - Restore without encryption"
-      ansible.builtin.shell:           db2 restore database {{ db_sid }} from {{ db_sid_backup_dir }} on /db2/{{ db_sid }} no encrypt
+      ansible.builtin.shell:           db2 restore database {{ db_sid }} from {{ db_sid_backup_dir }} on /db2/{{ db_sid }} no encrypt without prompting
       args:
         executable:                    /bin/csh
       environment:

--- a/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.4-db2_haparameters.yaml
+++ b/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.4-db2_haparameters.yaml
@@ -5,8 +5,8 @@
   block:
     - name:                            " DB2 Primary DB - Set Fact for hadr local host and remote host "
       ansible.builtin.set_fact:
-        db_hadr_local_host:            "{{ primary_instance_name }}"
-        db_hadr_remote_host:           "{{ secondary_instance_name }}"
+        db_hadr_local_host:            "{{ primary_instance_name }}.{{ sap_fqdn }}"
+        db_hadr_remote_host:           "{{ secondary_instance_name }}.{{ sap_fqdn }}"
 
     - name:                            "DB2 Primary DB- Switch user to db2<db_sid>"
       ansible.builtin.shell:           whoami
@@ -52,7 +52,7 @@
             db2 update db cfg for {{ db_sid }} using HADR_LOCAL_SVC {{ db2hadr_port1 }} immediate
             db2 update db cfg for {{ db_sid }} using HADR_REMOTE_HOST {{ db_hadr_remote_host }} immediate
             db2 update db cfg for {{ db_sid }} using HADR_REMOTE_SVC {{ db2hadr_port2 }} immediate
-            db2 update db cfg for {{ db_sid }} using HADR_REMOTE_INST db2{{ db_sid }} immediate
+            db2 update db cfg for {{ db_sid }} using HADR_REMOTE_INST db2{{ db_sid | lower }} immediate
             db2 update db cfg for {{ db_sid }} using HADR_TIMEOUT 60 immediate
             db2 update db cfg for {{ db_sid }} using HADR_SYNCMODE NEARSYNC immediate
             db2 update db cfg for {{ db_sid }} using HADR_SPOOL_LIMIT 1000 immediate
@@ -81,10 +81,10 @@
             db2 update db cfg for {{ db_sid }} using HADR_REMOTE_HOST {{ db_hadr_remote_host }} immediate
             db2 update db cfg for {{ db_sid }} using HADR_REMOTE_SVC {{ db_sid }}_HADR_2 immediate
             db2 update db cfg for {{ db_sid }} using HADR_REMOTE_INST db2{{ db_sid }} immediate
-            db2 update db cfg for {{ db_sid }} using HADR_TIMEOUT 60 immediate
+            db2 update db cfg for {{ db_sid }} using HADR_TIMEOUT 45 immediate
             db2 update db cfg for {{ db_sid }} using HADR_SYNCMODE NEARSYNC immediate
             db2 update db cfg for {{ db_sid }} using HADR_SPOOL_LIMIT 1000 immediate
-            db2 update db cfg for {{ db_sid }} using HADR_PEER_WINDOW 900 immediate
+            db2 update db cfg for {{ db_sid }} using HADR_PEER_WINDOW 240 immediate
             db2 update db cfg for {{ db_sid }} using indexrec RESTART logindexbuild ON immediate
             db2 disconnect {{ db_sid }}
           register:                db2_update

--- a/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.5-db2_enable_hadr.yaml
+++ b/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.5-db2_enable_hadr.yaml
@@ -8,8 +8,8 @@
     insertafter:                  "{{ item.insafter }}"
     line:                         "{{ item.line }}"
   loop:
-    - { path: '/etc/services',       insafter: '^sapdb2{{ db_sid }}',    line: '{{ db_sid }}_HADR_1 =  {{ db2hadr_port1 }}/tcp' }
-    - { path: '/etc/services',       insafter: '^sapdb2{{ db_sid }}',    line: '{{ db_sid }}_HADR_2 =  {{ db2hadr_port2 }}/tcp' }
+    - { path: '/etc/services',       insafter: '^sapdb2{{ db_sid }}',    line: '{{ db_sid }}_HADR_1  {{ db2hadr_port1 }}/tcp' }
+    - { path: '/etc/services',       insafter: '^sapdb2{{ db_sid }}',    line: '{{ db_sid }}_HADR_2  {{ db2hadr_port2 }}/tcp' }
 
 - name:                                "DB2 - Activate HADR on Secondary DB "
   block:

--- a/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.6-db2_post_install_checks.yaml
+++ b/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.6-db2_post_install_checks.yaml
@@ -1,18 +1,41 @@
-# TBC -
-# Execute command as db2<sid> db2pd -hadr -db <SID>
-# and check the following values
-#
-#                        HADR_ROLE = PRIMARY
-#                           REPLAY_TYPE = PHYSICAL
-#                         HADR_SYNCMODE = NEARSYNC
-#                            STANDBY_ID = 1
-#                         LOG_STREAM_ID = 0
-#                            HADR_STATE = PEER
-#                            HADR_FLAGS = TCP_PROTOCOL
-#                   PRIMARY_MEMBER_HOST = azibmdb02
-#                      PRIMARY_INSTANCE = db2ptr
-#                        PRIMARY_MEMBER = 0
-#                   STANDBY_MEMBER_HOST = azibmdb01
-#                      STANDBY_INSTANCE = db2ptr
-#                        STANDBY_MEMBER = 0
-#                   HADR_CONNECT_STATUS = CONNECTED
+
+---
+########################### the playbook checks the status of replication in both primary and secondary instance#####
+
+- name:                                "DB2 Primary Instance: - Ensure replication status is active"
+  become_user:                         db2{{ db_sid | lower }}
+  ansible.builtin.shell:               db2pd -hadr -db {{ db_sid | upper }} | grep -e 'HADR_STATE = PEER' -e 'HADR_CONNECT_STATUS = CONNECTED'
+  register:                            grep_result
+  until:                               grep_result.rc == 0 or grep_result.rc == 1
+  failed_when:                         grep_result.rc != 0 and grep_result.rc != 1
+  changed_when:                        false
+  retries:                             5
+  delay:                               5
+  when:                                ansible_hostname == primary_instance_name
+  tags:
+    - skip_ansible_lint
+
+- name:                                "DB2 Primary Instance  Replication - Status"
+  ansible.builtin.debug:
+    var:                               grep_result
+    verbosity:                         2
+
+- name:                                "DB2 Secondary Instance: - Ensure replication status is active"
+  become_user:                         db2{{ db_sid | lower }}
+  ansible.builtin.shell:               db2pd -hadr -db {{ db_sid | upper }} | grep -e 'HADR_STATE = PEER' -e 'HADR_CONNECT_STATUS = CONNECTED'
+  register:                            grep_result
+  until:                               grep_result.rc == 0 or grep_result.rc == 1
+  failed_when:                         grep_result.rc != 0 and grep_result.rc != 1
+  changed_when:                        false
+  retries:                             5
+  delay:                               5
+  when:                                ansible_hostname == secondary_instance_name
+  tags:
+    - skip_ansible_lint
+
+- name:                                "DB2 Secondary Instance Replication - Status"
+  ansible.builtin.debug:
+    var:                               grep_result
+    verbosity:                         2
+
+...

--- a/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.7-sap-pofile-changes
+++ b/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.7-sap-pofile-changes
@@ -1,0 +1,63 @@
+--- 
+
+#################################################################################################################
+# Profile changes for DB2 Installations                                                                         #
+# To connect to the primary instance of the HADR configuration, the SAP application layer needs to use the      #
+# virtual IP address that you defined and configured for the Azure Load Balancer                                #
+#################################################################################################################
+
+
+- name:                                " 4.2.1.7 - SAP Profile changes - DB2 Installations"
+  block:
+
+     
+    - name:                            "4.2.1.7 - SAP DEFAULT.PFL changes "
+      ansible.builtin.replace:
+        path:                          /sapmnt/{{ sap_sid }}/profile/DEFAULT.PFL
+        backup:                        true
+        regexp:                        '^SAPDBHOST'
+        replace:                       '#SAPDBHOST'
+      tags:
+        - dbhostcomment
+
+    - name:                            "4.2.1.7 - SAP DEFAULT.PFL changes - add db virtual hostname "
+      ansible.builtin.lineinfile:
+        path:                          /sapmnt/{{ sap_sid }}/profile/DEFAULT.PFL
+        line:                          SAPDBHOST = {{ db_virtual_hostname }}
+        insertafter:                   '#SAPDBHOST'
+      tags:
+        - dbhostpara
+    
+    - name:                            "4.2.1.7 - SAP DEFAULT.PFL changes - add db virtual hostname "
+      ansible.builtin.lineinfile:
+        path:                          /sapmnt/{{ sap_sid }}/profile/DEFAULT.PFL
+        line:                          j2ee/dbhost = {{ db_virtual_hostname }}
+        insertafter:                   'SAPDBHOST'
+      tags:
+        - j2eedbhostpara
+     
+    - name:                            "4.2.1.7 - SAP db2cli.ini profile changes "
+      ansible.builtin.replace:
+        path:                          /sapmnt/{{ sap_sid }}/global/db6/db2cli.ini
+        backup:                        true
+        regexp:                        '^Hostname'
+        replace:                       '#Hostname'
+      tags:
+        - hostnamecomment
+
+    - name:                            "4.2.1.7 - SAP db2cli.ini profile changes "
+      ansible.builtin.lineinfile:
+        path:                          /sapmnt/{{ sap_sid }}/global/db6/db2cli.ini
+        line:                          Hostname = {{ db_virtual_hostname }}
+        insertafter:                   '#Hostname'
+      tags:
+        - virtdbhostpara
+    
+
+  when:
+    - inventory_hostname == primary_instance_name
+    - platform == 'DB2'
+    - db_high_availability
+
+    
+...

--- a/deploy/ansible/roles-sap-os/2.4-hosts-file/tasks/main.yaml
+++ b/deploy/ansible/roles-sap-os/2.4-hosts-file/tasks/main.yaml
@@ -76,4 +76,17 @@
     - db_high_availability
     - platform == 'HANA'
 
+- name:                                "2.4 Hosts: - Setup Virtual host name resolution - DB"
+  ansible.builtin.blockinfile:
+    path:                              /etc/hosts
+    mode:                              0644
+    create:                            true
+    state:                             present
+    block: |
+      {{ '%-19s' | format(db_lb_ip) }} {{ '%-50s' | format(db_virtual_hostname + '.' + sap_fqdn) }} {{ '%-21s' | format(db_virtual_hostname) }}
+    marker:                            "# {mark} DB Entries {{ db_virtual_hostname }}"
+  when:
+    - db_high_availability
+    - platform == 'DB2'
+
 ...

--- a/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.4-db2-mounts.yaml
+++ b/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.4-db2-mounts.yaml
@@ -96,7 +96,7 @@
     group:                             "{{ item.group }}"
     recurse:                           true
   loop:
-    - { path: '/db2',       group: 'db2install',   owner: 'db2{{ db_sid | lower }}'}
+    - { path: '/db2',       group: 'db{{ db_sid | lower }}adm',   owner: 'db2{{ db_sid | lower }}'}
   when:
     - not db2_permissions_set.stat.exists
 

--- a/deploy/ansible/roles-sap/5.6-scsers-pacemaker/tasks/5.6.4.1-scsersprofile.yaml
+++ b/deploy/ansible/roles-sap/5.6-scsers-pacemaker/tasks/5.6.4.1-scsersprofile.yaml
@@ -198,4 +198,73 @@
     - ensa1 is defined
     - ensa1
 
+
+#################################################################################################################
+# Profile changes for DB2 Installations                                                                         #
+# To connect to the primary instance of the HADR configuration, the SAP application layer needs to use the      #
+# virtual IP address that you defined and configured for the Azure Load Balancer                                #
+#################################################################################################################
+
+
+- name:                                "5.6 - SCS / ASCS profile changes - DB2 Installations"
+  block:
+
+     # execute the following tasks only when using ENSA1
+     # SAP introduced support for enqueue server 2, including replication, as of SAP NW 7.52.
+     # Starting with ABAP Platform 1809, enqueue server 2 is installed by default
+    - name:                            "5.6 SCSERS - ASCS Profile - Comment Restart_Program_01 If Using ENSA1"
+      ansible.builtin.replace:
+        path:                          /sapmnt/{{ sap_sid }}/profile/{{ sap_sid }}_ASCS{{ scs_instance_number }}_{{ scs_virtual_hostname }}
+        backup:                        true
+        regexp:                        '^Restart_Program_01'
+        replace:                       '#Restart_Program_01'
+      tags:
+        - ascscomment
+
+    - name:                            "5.6 SCSERS - ASCS Profile- Add the right Start command to ASCS profile If Using ENSA1"
+      ansible.builtin.lineinfile:
+        path:                          /sapmnt/{{ sap_sid }}/profile/{{ sap_sid }}_ASCS{{ scs_instance_number }}_{{ scs_virtual_hostname }}
+        line:                          Start_Program_01 = local $(_EN) pf=$(_PF)
+        insertafter:                   Restart_Program_01
+      tags:
+        - ascspara
+
+    - name:                            "5.6 SCSERS - ERS Profile - Comment Restart_Program_00 in ERS Profile if using ENSA1"
+      ansible.builtin.replace:
+        path:                          /sapmnt/{{ sap_sid }}/profile/{{ sap_sid }}_ERS{{ ers_instance_number }}_{{ ers_virtual_hostname }}
+        backup:                        true
+        regexp:                        '^Restart_Program_00'
+        replace:                       '#Restart_Program_00'
+      tags:
+        - erscomment
+
+    - name:                            "5.6 SCSERS - ERS Profile - Change the restart command to a start command if using ENSA1"
+      ansible.builtin.lineinfile:
+        path:                          /sapmnt/{{ sap_sid }}/profile/{{ sap_sid }}_ERS{{ ers_instance_number }}_{{ ers_virtual_hostname }}
+        line:                          Start_Program_00 = local $(_ER) pf=$(_PFL) NR=$(SCSID)
+        insertafter:                   Restart_Program_01
+      tags:
+        - erspara
+
+    - name:                            "5.6 SCSERS - ERS Profile - Remove Autostart from ERS profile if using ENSA1"
+      ansible.builtin.replace:
+        path:                          /sapmnt/{{ sap_sid }}/profile/{{ sap_sid }}_ERS{{ ers_instance_number }}_{{ ers_virtual_hostname }}
+        regexp:                        '^Autostart = 1'
+        replace:                       '#Autostart = 1'
+      tags:
+        - ersautostart
+
+    - name:                            "5.6 SCSERS - Add the keep alive parameter, if using ENSA1"
+      ansible.builtin.lineinfile:
+        path:                          /sapmnt/{{ sap_sid }}/profile/{{ sap_sid }}_ASCS{{ scs_instance_number }}_{{ scs_virtual_hostname }}
+        line:                          enque/encni/set_so_keepalive = true
+      tags:
+        - keepalive
+
+  when:
+    - inventory_hostname == primary_instance_name
+    - platform == 'DB2'
+    - db_high_availability
+
+
 ...


### PR DESCRIPTION
## Problem
DB2 HADR replication check 
DB Virtual hostname definition
SAP profile changes 

## Solution
DB2 HADR replication check - added playbook to check HADR_STATE & HADR_CONNECTED_STATUS
DB Virtual hostname definition -modified roles-sap-os -> 2.4.hosts-file to have vitual hostname definition for DB
SAP profile changes -  To connect to the primary instance of the HADR configuration, the SAP application layer needs to use the virtual IP address that you defined and configured for the Azure Load Balancer. The following changes are required:
/sapmnt/<SID>/profile/DEFAULT.PFL
SAPDBHOST = db-virt-hostname
j2ee/dbhost = db-virt-hostname

/sapmnt/<SID>/global/db6/db2cli.ini
Hostname=db-virt-hostname


## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>