### PR TITLE
Adding conditional execution for sap_library  "output" check when deploying for the first time. Installer.sh:635

### DIFF
--- a/deploy/scripts/installer.sh
+++ b/deploy/scripts/installer.sh
@@ -634,16 +634,17 @@ if [ 0 == $return_value ] ; then
 
     if [ "${deployment_system}" == sap_library ]
     then
+      if [ "$deployment_parameter" == " " ]
+        then  # This is not a new deployment. Reusing variable previously declared in the shell script above.
+          tfstate_resource_id=$(terraform -chdir="${terraform_module_directory}" output tfstate_resource_id| tr -d \")
+          STATE_SUBSCRIPTION=$(echo "$tfstate_resource_id" | cut -d/ -f3 | tr -d \" | xargs)
 
-        tfstate_resource_id=$(terraform -chdir="${terraform_module_directory}" output tfstate_resource_id| tr -d \")
-        STATE_SUBSCRIPTION=$(echo "$tfstate_resource_id" | cut -d/ -f3 | tr -d \" | xargs)
+          az account set --sub "${STATE_SUBSCRIPTION}"
 
-        az account set --sub "${STATE_SUBSCRIPTION}"
+          REMOTE_STATE_SA=$(terraform -chdir="${terraform_module_directory}" output -no-color -raw remote_state_storage_account_name| tr -d \")
 
-        REMOTE_STATE_SA=$(terraform -chdir="${terraform_module_directory}" output -no-color -raw remote_state_storage_account_name| tr -d \")
-
-        get_and_store_sa_details "${REMOTE_STATE_SA}" "${system_config_information}"
-
+          get_and_store_sa_details "${REMOTE_STATE_SA}" "${system_config_information}"
+      fi
     fi
 
     ok_to_proceed=true
@@ -956,13 +957,13 @@ if [ 1 == $ok_to_proceed ]; then
 
     if [ $rerun_apply == 1 ] ; then
         echo ""
-    echo ""
-    echo "#########################################################################################"
-    echo "#                                                                                       #"
-    echo -e "#                          $cyan Re running Terraform apply$resetformatting                                  #"
-    echo "#                                                                                       #"
-    echo "#########################################################################################"
-    echo ""
+        echo ""
+        echo "#########################################################################################"
+        echo "#                                                                                       #"
+        echo -e "#                          $cyan Re running Terraform apply$resetformatting                                  #"
+        echo "#                                                                                       #"
+        echo "#########################################################################################"
+        echo ""
         echo ""
         if [ 1 == $called_from_ado ] ; then
             terraform -chdir="${terraform_module_directory}" apply -parallelism="${parallelism}" -compact-warnings $allParams


### PR DESCRIPTION
Problem
When performing a deployment via scripts, sap_library deployment will fail with below message immediately after terraform plan. This happens when no previous sap_library state file exists locally or remotely.

<< EOF >>
╷
│ Warning: No outputs found
│
│ The state file either has no outputs defined, or all the defined outputs are empty. Please define an output in your configuration with the output keyword and run terraform refresh for it to become
│ available. If you are using interpolation, please verify the interpolated value is not empty. You can use the terraform console command to assist.
╵
╷ │ Warning: No outputs found │ │ The state file either has no outputs defined, or all the defined outputs are empty. Please define an output in your configuration with the output keyword and run terraform refresh for it to become │ available. If you are using interpolation, please verify the interpolated value is not empty. You can use the terraform console command to assist. ╵
The subscription of '╷ │ warning: no outputs found │ │ the state file either has no outputs defined, or all the defined outputs are empty. please define an output in your configuration with the output keyword and run terraform refresh for it to become │ available. if you are using interpolation, please verify the interpolated value is not empty. you can use the terraform console command to assist. ╵' doesn't exist in cloud 'AzureCloud'.
Trying to find the storage account
Warning: No outputs found

<>

This is due to lack of test condition in file installer.sh : 635. Script attempts to fetch 'terraform xxxx output' of a state file that either is not present or populated with actual output data block.
This will cause continuous failure unless Terraform is run manually with correct backend parameters.
Repeated execution of 'installer.sh' or 'prepare_region.sh' will continue to throw same error with no recovery possible without manual intervention.

Solution
Add a condition to the block in installer.sh: 630 to 642. Use the variable $deployment_parameter to check if this is a new deployment of not. In case of new deployment, do not execute this entire block.
$deployment_parameter is already being populated to identify if a given bootstrap is fresh deployment or existing.

Tests
Can successfully deploy sap_library on a fresh environment. Existing sap_library state file when present is being correctly looked up from Azure storage account.

Notes
Add fixes to various IF conditions, where due to usage of single square brackets is causing Bash to throw errors about expecting unary operator. This has been fixed by enclosing variables within the brackets in double quotations. This ensures POSIX standard compliance along with Bash on WSL as well as Ubuntu VM

example : IF [ $variable == "test" ] changed to IF [ "$variable" == "test" ] where ever script throws error during execution.