### PR TITLE
Changing the output variable name as per the last commit

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_deployer/key_vault.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/key_vault.tf
@@ -80,7 +80,7 @@ data "azurerm_key_vault" "kv_user" {
 }
 
 resource "azurerm_key_vault_access_policy" "kv_user_msi" {
-
+  count        = var.key_vault.kv_exists ? 1 : 0
   key_vault_id = var.key_vault.kv_exists ? data.azurerm_key_vault.kv_user[0].id : azurerm_key_vault.kv_user[0].id
 
   tenant_id = azurerm_user_assigned_identity.deployer.tenant_id

--- a/deploy/terraform/terraform-units/modules/sap_deployer/output.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/output.tf
@@ -120,7 +120,7 @@ output "deployer_user" {
 */
 
 output "deployer_keyvault_user_arm_id" {
-  value = local.user_keyvault_exist ? data.azurerm_key_vault.kv_user[0].id : azurerm_key_vault.kv_user[0].id
+  value = var.key_vault.kv_exists ? data.azurerm_key_vault.kv_user[0].id : azurerm_key_vault.kv_user[0].id
 }
 
 


### PR DESCRIPTION
## Problem
The Control plane deployment pipeline was failing due to wrong declaration of variable in output file of sap_deployer

## Solution
Changed the output file variable name from local.user_keyvault_exist) to var.key_vault.kv_exists
Also added the below line in kv.tf
count        = var.key_vault.kv_exists ? 1 : 0

## Tests
tested and is working fine now

## Notes
<Additional comments for the PR>