### PR TITLE
Only manage the tmp_dir when it doens't exist

### DIFF
--- a/deploy/ansible/roles-os/1.5-disk-setup/tasks/main.yml
+++ b/deploy/ansible/roles-os/1.5-disk-setup/tasks/main.yml
@@ -27,12 +27,17 @@
 # -------------------------------------+---------------------------------------8
 #
 
-- name:                                "1.5 Disk setup - Ensure installation directory exists"
+- name:                                "1.5 Disk setup - Check if installation root directory exists"
+  ansible.builtin.stat:
+    path:                              "{{ tmp_directory }}"
+  register:                            tmp_dir
+
+- name:                                "1.5 Disk setup - Ensure installation root directory exists"
   ansible.builtin.file:
     path:                              "{{ tmp_directory }}"
     state:                             directory
     mode:                              0775
-
+  when: not tmp_dir.stat.isdir
 
 - name:                                "1.5 Disk setup - Load the disk configuration settings"
   ansible.builtin.include_vars:        disks_config.yml


### PR DESCRIPTION
## Problem
 /var/tmp already has enough permission by default for RHEL8

## Solution
Only manage the tmp_dir when it doesn't exist.