### PR TITLE
Fix enabling/disabling of maintenance mode for scsers/hanadb clustering

### DIFF
--- a/deploy/ansible/roles-sap/5.5-hanadb-pacemaker/tasks/5.5.4.0-cluster-Suse.yml
+++ b/deploy/ansible/roles-sap/5.5-hanadb-pacemaker/tasks/5.5.4.0-cluster-Suse.yml
@@ -7,7 +7,7 @@
 - name:                                Ensure the Cluster STONITH is configured
   block:
     - name:                            Ensure maintenance mode is enabled
-      ansible.builtin.command:         "crm configure property maintenance-mode=true"
+      ansible.builtin.command:         crm configure property maintenance-mode=true
 
     - name:                            Ensure CIB Bootstrap Options are set
       ansible.builtin.command: >

--- a/deploy/ansible/roles-sap/5.5-hanadb-pacemaker/tasks/cluster-Suse-large-instance.yml
+++ b/deploy/ansible/roles-sap/5.5-hanadb-pacemaker/tasks/cluster-Suse-large-instance.yml
@@ -88,7 +88,7 @@
         msg: "{{ sbd_report.stdout }}"
 
     - name: Ensure maintenance mode is enabled
-      ansible.builtin.command: "crm configure property maintenance-mode=true"
+      ansible.builtin.command: crm configure property maintenance-mode=true
 
     - name: Ensure CIB Bootstrap Options are set
       ansible.builtin.shell: >
@@ -189,4 +189,4 @@
       ansible.builtin.command: "crm resource cleanup rsc_SAPHana_{{ sid | upper }}_HDB{{ instance_number }}"
 
     - name: Ensure maintenance mode is disabled
-      ansible.builtin.command: "crm configure property maintenance-mode=false"
+      ansible.builtin.command: crm configure property maintenance-mode=false

--- a/deploy/ansible/roles-sap/5.6-scsers-pacemaker/tasks/5.6.4.2-sap-resources-RedHat.yml
+++ b/deploy/ansible/roles-sap/5.6-scsers-pacemaker/tasks/5.6.4.2-sap-resources-RedHat.yml
@@ -8,6 +8,9 @@
 
 - name:                                "5.6 SCSERS - RHEL - ENSA1 - SAP Resources - Cluster Configuration after Install"
   block:
+    - name:                            "5.6 SCSERS - RHEL - ENSA1 - Enable Maintenance mode for the cluster"
+      ansible.builtin.command:         pcs property set maintenance-mode=true
+
     - name:                            "5.6 SCSERS - RHEL - ENSA1 - Configure SAP ASCS/SCS resources"
       ansible.builtin.command: >
                                        pcs resource create rsc_sap_{{ sap_sid }}_ASCS{{ scs_instance_number }} SAPInstance \
@@ -58,6 +61,9 @@
 # Use the following if using ENSA2
 - name:                                "5.6 SCSERS - RHEL - SAP Resources - Cluster Configuration after Install"
   block:
+    - name:                            "5.6 SCSERS - RHEL - ENSA2 - Enable Maintenance mode for the cluster"
+      ansible.builtin.command:         pcs property set maintenance-mode=true
+
     - name:                            "5.6 SCSERS - RHEL - ENSA2 - Configure SAP ASCS/SCS resources"
       ansible.builtin.command: >
                                        pcs resource create rsc_sap_{{ sap_sid }}_ASCS{{ scs_instance_number }} SAPInstance \

--- a/deploy/ansible/roles-sap/5.6-scsers-pacemaker/tasks/5.6.4.2-sap-resources-Suse.yml
+++ b/deploy/ansible/roles-sap/5.6-scsers-pacemaker/tasks/5.6.4.2-sap-resources-Suse.yml
@@ -8,6 +8,8 @@
 
 - name:                                "5.6 SCSERS - SUSE - ENSA1 - SAP Resources - Cluster Configuration after Install "
   block:
+    - name:                            "5.6 SCSERS - SUSE - ENSA1 - Set the cluster on maintenance mode"
+      ansible.builtin.command:         crm configure property maintenance-mode=true
 
     - name:                            "5.6 SCSERS - SUSE - ENSA1 - Configure SAP ASCS/SCS resources"
       ansible.builtin.command: >
@@ -53,7 +55,7 @@
     #   ansible.builtin.command:        crm node online {{ primary_instance_name }}
 
     - name:                           "5.6 SCSERS - SUSE - ENSA1 - Set the Cluster out of maintenance mode"
-      ansible.builtin.command:        crm configure property maintenance-mode="false"
+      ansible.builtin.command:        crm configure property maintenance-mode=false
 
   when:
     - inventory_hostname == primary_instance_name
@@ -66,7 +68,7 @@
 - name:                               "5.6 SCSERS - SUSE - ENSA2 - SAP Resources - Cluster Configuration after Install"
   block:
     - name:                            "5.6 SCSERS - SUSE - ENSA2 - Set the cluster on maintenance mode"
-      ansible.builtin.command:         crm configure property maintenance-mode="true"
+      ansible.builtin.command:         crm configure property maintenance-mode=true
 
     - name:                            "5.6 SCSERS - SUSE - ENSA2 - Configure SAP ASCS/SCS resources"
       ansible.builtin.shell: >
@@ -110,8 +112,8 @@
     - name:                            "5.6 SCSERS - SUSE - ENSA2 - Bring primary node online "
       ansible.builtin.command:         crm node online {{ primary_instance_name }}
 
-    - name:                            "Set the Cluster out of maintenance mode"
-      ansible.builtin.command:         crm configure property maintenance-mode="false"
+    - name:                            "5.6 SCSERS - SUSE - ENSA2 - Set the Cluster out of maintenance mode"
+      ansible.builtin.command:         crm configure property maintenance-mode=false
 
   when:
     - inventory_hostname == primary_instance_name

--- a/deploy/ansible/roles-sap/5.7-db2-pacemaker/tasks/5.7.3.0-cluster-Suse.yml
+++ b/deploy/ansible/roles-sap/5.7-db2-pacemaker/tasks/5.7.3.0-cluster-Suse.yml
@@ -32,7 +32,7 @@
 - name:                                "Configure DB2 Cluster Resources"
   block:
     - name:                            "DB2 HA - SUSE - Ensure maintenance mode is enabled"
-      ansible.builtin.command:         "crm configure property maintenance-mode=true"
+      ansible.builtin.command:         crm configure property maintenance-mode=true
 
     - name:                            "DB2 HA - SUSE - Configure resource defaults - resource stickiness"
       ansible.builtin.command:         "crm configure rsc_defaults resource-stickiness=1000"


### PR DESCRIPTION
## Problem
For Red Hat the cluster was only taken out of the maintenance mode but it was never in maintenance.

## Solution
Set the cluster in maintenance first.

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>