### PR TITLE
Updating Checksum to correct values

### DIFF
--- a/deploy/ansible/BOM-catalog/S42020SPS03_v0003ms/S42020SPS03_v0003ms.yaml
+++ b/deploy/ansible/BOM-catalog/S42020SPS03_v0003ms/S42020SPS03_v0003ms.yaml
@@ -237,7 +237,7 @@
 
         - name: "Attribute Change Package 26 for GBX01HR5 605"
           archive: GBX01HR5605.SAR
-          checksum: 2e0fb0fa90bca1c152edf6669f7d7118886acffb782506aa45c5a63b6a04fd34
+          checksum: 19d06ed87c3fc1b9390fafa94d9a2d25ddabd3c0e61777a693e6155f113fa167
           url: https://softwaredownloads.sap.com/file/0010000000033172015
           download: false
 
@@ -993,7 +993,7 @@
 
         - name: "Attribute Change Package 45 for ST-PI 740"
           archive: ST-PI740.SAR
-          checksum: 8406c3d057afd459406b3d2fa500a1050eb8ac3c81be165d19af6e5834725328
+          checksum: 2b87eb02fa26dd8279a37eaa4c1ee64adab8bccbaca668f1e32ff421bdfbf9c8
           url: https://softwaredownloads.sap.com/file/0010000000297212015
           download: false
 


### PR DESCRIPTION
Updating Checksum to correct values based on the bom validator  test results: 2022-12-08 08:46:40 info: E2ECloudTests--WaaS-ValidateBomLinksAsync-08-12-22-08-35-50-AM-88969b37-202212080835[0]
      For BOM S42020SPS03_v0003ms, media link https://softwaredownloads.sap.com/file/0010000000033172015 is has invalid checksum 2e0fb0fa90bca1c152edf6669f7d7118886acffb782506aa45c5a63b6a04fd34.
2022-12-08 08:46:40 info: E2ECloudTests--WaaS-ValidateBomLinksAsync-08-12-22-08-35-50-AM-88969b37-202212080835[0]
      For BOM S42020SPS03_v0003ms, media link https://softwaredownloads.sap.com/file/0010000000297212015 is has invalid checksum 8406c3d057afd459406b3d2fa500a1050eb8ac3c81be165d19af6e5834725328.

## Problem
<Please describe what problem this PR is trying to resolve>

## Solution
<Please elaborate the solution for the problem>

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>