### PR TITLE
Fix disk appending in HA setup

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/variables_local.tf
@@ -292,7 +292,7 @@ locals {
         for idx, disk_count in range(storage_type.count) : {
           suffix = format("-%s%02d",
             storage_type.name,
-            storage_type.lun_start + disk_count + var.options.resource_offset
+            storage_type.name_offset + disk_count + var.options.resource_offset
           )
           storage_account_type      = storage_type.disk_type
           disk_size_gb              = storage_type.size_gb
@@ -309,15 +309,9 @@ locals {
     ]
   ) : []
 
-  all_data_disk_per_dbnode = distinct(
-    concat(
-      local.data_disk_per_dbnode, local.append_data_disk_per_dbnode
-    )
-  )
-
-  anydb_disks = flatten([
+  base_anydb_disks = flatten([
     for vm_counter in range(var.database_server_count) : [
-      for datadisk in local.all_data_disk_per_dbnode : {
+      for datadisk in local.data_disk_per_dbnode : {
         suffix                    = datadisk.suffix
         vm_index                  = vm_counter
         caching                   = datadisk.caching
@@ -331,6 +325,25 @@ locals {
       }
     ]
   ])
+
+  append_anydb_disks = flatten([
+    for vm_counter in range(var.database_server_count) : [
+      for datadisk in local.append_data_disk_per_dbnode : {
+        suffix                    = datadisk.suffix
+        vm_index                  = vm_counter
+        caching                   = datadisk.caching
+        storage_account_type      = datadisk.storage_account_type
+        disk_size_gb              = datadisk.disk_size_gb
+        write_accelerator_enabled = datadisk.write_accelerator_enabled
+        disk_iops_read_write      = datadisk.disk_iops_read_write
+        disk_mbps_read_write      = datadisk.disk_mbps_read_write
+        lun                       = datadisk.lun
+        type                      = datadisk.type
+      }
+    ]
+  ])
+
+  anydb_disks = distinct(concat(local.base_anydb_disks, local.append_anydb_disks))
 
   //Disks for Ansible
   // host: xxx, LUN: #, type: sapusr, size: #

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/disk_logic.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/disk_logic.tf
@@ -24,7 +24,10 @@ locals {
     [
       for storage_type in local.app_sizing.storage : [
         for idx, disk_count in range(storage_type.count) : {
-          suffix               = format("-%s%02d", storage_type.name, storage_type.lun_start + disk_count + var.options.resource_offset)
+          suffix = format("-%s%02d",
+            storage_type.name,
+            storage_type.name_offset + disk_count + var.options.resource_offset
+          )
           storage_account_type = storage_type.disk_type,
           disk_size_gb         = storage_type.size_gb,
           //The following two lines are for Ultradisks only
@@ -83,7 +86,10 @@ locals {
     [
       for storage_type in local.scs_sizing.storage : [
         for idx, disk_count in range(storage_type.count) : {
-          suffix               = format("-%s%02d", storage_type.name, disk_count + var.options.resource_offset)
+          suffix = format("-%s%02d",
+            storage_type.name,
+            storage_type.name_offset + disk_count + var.options.resource_offset
+          )
           storage_account_type = storage_type.disk_type,
           disk_size_gb         = storage_type.size_gb,
           //The following two lines are for Ultradisks only
@@ -144,7 +150,10 @@ locals {
     [
       for storage_type in local.web_sizing.storage : [
         for idx, disk_count in range(storage_type.count) : {
-          suffix               = format("-%s%02d", storage_type.name, disk_count + var.options.resource_offset)
+          suffix = format("-%s%02d",
+            storage_type.name,
+            storage_type.name_offset + disk_count + var.options.resource_offset
+          )
           storage_account_type = storage_type.disk_type,
           disk_size_gb         = storage_type.size_gb,
           //The following two lines are for Ultradisks only


### PR DESCRIPTION
## Problem
- When a stack is deployed high available, appending disks using the 'append' option in custom-sizes will redeploy all existing disk of the second node.
- When using the append option for disks, the "appended" disks gets the same name and number as the already existing disks

## Solution
- By changing the order of creating and concatenating the base and append disks list this problem is mitigated
- Introduced a new option named "name_offset" to use in the custom-sizes

## Tests
Part of the Terraform output when updating a high available stack with 2 extra log disks:
```terraform
# module.hdb_node.azurerm_managed_disk.data_disk[10] will be created
  + resource "azurerm_managed_disk" "data_disk" {
      + create_option                 = "Empty"
      + disk_iops_read_only           = (known after apply)
      + disk_iops_read_write          = (known after apply)
      + disk_mbps_read_only           = (known after apply)
      + disk_mbps_read_write          = (known after apply)
      + disk_size_gb                  = 1
      + id                            = (known after apply)
      + location                      = "westeurope"
      + logical_sector_size           = (known after apply)
      + max_shares                    = (known after apply)
      + name                          = "x00vm00-log01"
      + public_network_access_enabled = true
      + resource_group_name           = "x00"
      + source_uri                    = (known after apply)
      + storage_account_type          = "Premium_LRS"
      + tier                          = (known after apply)
      + zone                          = "2"
    }

  # module.hdb_node.azurerm_managed_disk.data_disk[11] will be created
  + resource "azurerm_managed_disk" "data_disk" {
      + create_option                 = "Empty"
      + disk_iops_read_only           = (known after apply)
      + disk_iops_read_write          = (known after apply)
      + disk_mbps_read_only           = (known after apply)
      + disk_mbps_read_write          = (known after apply)
      + disk_size_gb                  = 1
      + id                            = (known after apply)
      + location                      = "westeurope"
      + logical_sector_size           = (known after apply)
      + max_shares                    = (known after apply)
      + name                          = "x00vm00-log02"
      + public_network_access_enabled = true
      + resource_group_name           = "x00"
      + source_uri                    = (known after apply)
      + storage_account_type          = "Premium_LRS"
      + tier                          = (known after apply)
      + zone                          = "2"
    }

Changes to Outputs:
  ~ disks = [
        # (4 unchanged elements hidden)
        "{ host: 'x00vm00', LUN: 15, type: 'backup' }",
      + "{ host: 'x00vm00', LUN: 10, type: 'log' }",
      + "{ host: 'x00vm00', LUN: 11, type: 'log' }",
        "{ host: 'x00vm01', LUN: 0, type: 'data' }",
        # (3 unchanged elements hidden)
        "{ host: 'x00vm01', LUN: 15, type: 'backup' }",
      + "{ host: 'x00vm01', LUN: 10, type: 'log' }",
      + "{ host: 'x00vm01', LUN: 11, type: 'log' }",
        "{ host: 'x00vm30', LUN: 0, type: 'sap' }",
    ]
```

Part of the Terraform output when updating a single stack with 2 extra log disks:
```terraform
# module.hdb_node.azurerm_managed_disk.data_disk[5] will be created
  + resource "azurerm_managed_disk" "data_disk" {
      + create_option                 = "Empty"
      + disk_iops_read_only           = (known after apply)
      + disk_iops_read_write          = (known after apply)
      + disk_mbps_read_only           = (known after apply)
      + disk_mbps_read_write          = (known after apply)
      + disk_size_gb                  = 1
      + id                            = (known after apply)
      + location                      = "westeurope"
      + logical_sector_size           = (known after apply)
      + max_shares                    = (known after apply)
      + name                          = "x00vm00-log01"
      + public_network_access_enabled = true
      + resource_group_name           = "x00"
      + source_uri                    = (known after apply)
      + storage_account_type          = "Premium_LRS"
      + tier                          = (known after apply)
      + zone                          = "1"
    }

  # module.hdb_node.azurerm_managed_disk.data_disk[6] will be created
  + resource "azurerm_managed_disk" "data_disk" {
      + create_option                 = "Empty"
      + disk_iops_read_only           = (known after apply)
      + disk_iops_read_write          = (known after apply)
      + disk_mbps_read_only           = (known after apply)
      + disk_mbps_read_write          = (known after apply)
      + disk_size_gb                  = 1
      + id                            = (known after apply)
      + location                      = "westeurope"
      + logical_sector_size           = (known after apply)
      + max_shares                    = (known after apply)
      + name                          = "x00vm00-log02"
      + public_network_access_enabled = true
      + resource_group_name           = "x00"
      + source_uri                    = (known after apply)
      + storage_account_type          = "Premium_LRS"
      + tier                          = (known after apply)
      + zone                          = "1"
    }
	
Changes to Outputs:
  ~ disks = [
        # (4 unchanged elements hidden)
        "{ host: 'x00vm00', LUN: 15, type: 'backup' }",
      + "{ host: 'x00vm00', LUN: 10, type: 'log' }",
      + "{ host: 'x00vm00', LUN: 11, type: 'log' }",
        "{ host: 'x00vm30', LUN: 0, type: 'sap' }",
        # (1 unchanged element hidden)
    ]
```

Custom sizes block with the original log disk and the 2 extra disks:
```json
{
    "name": "log",
    "count": 1,
    "disk_type": "Premium_LRS",
    "size_gb": 1,
    "caching": "None",
    "write_accelerator": false,
    "lun_start": 9
},
{
    "name": "log",
    "count": 2,
    "name_offset": 1,
    "disk_type": "Premium_LRS",
    "size_gb": 1,
    "caching": "None",
    "write_accelerator": false,
    "append": true,
    "lun_start": 10
}
```
