### PR TITLE
db_platform changed  default value

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_namegenerator/variables_global.tf
+++ b/deploy/terraform/terraform-units/modules/sap_namegenerator/variables_global.tf
@@ -64,7 +64,7 @@ variable "app_ostype" {
 
 variable "db_platform" {
   description = "AnyDB platform type (Oracle, DB2, SQLServer, ASE)"
-  default     = "LINUX"
+  default     = "HANA"
 }
 
 variable "anchor_ostype" {


### PR DESCRIPTION
## Problem
The Default value was LINUX for db_platform in https://github.com/Azure/sap-automation/blob/main/deploy/terraform/terraform-units/modules/sap_namegenerator/variables_global.tf

## Solution
changed the value from LINUX to HANA

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>

Closes #144