### PR TITLE
Added the changes for fixing DB Discovery issue in HA scenarios.

### DIFF
--- a/deploy/ansible/roles-db/4.0.1-hdb-hsr/tasks/4.0.1.7-sap-profile-changes.yml
+++ b/deploy/ansible/roles-db/4.0.1-hdb-hsr/tasks/4.0.1.7-sap-profile-changes.yml
@@ -1,0 +1,66 @@
+---
+
+##############################################################################################################
+# Profile changes for HANA Installations                                                                     #
+# To connect to the primary instance of the HSR configuration, the SAP application layer needs to use the    #
+# virtual IP address that you defined and configured for the Azure Load Balancer                             #
+##############################################################################################################
+
+- name:                                " 4.0.1.7 - SAP Profile changes - HANA Installations"
+  block:
+
+    - name:                            "HSR: Set the DB Server name list"
+      ansible.builtin.set_fact:
+        db_server_temp:                "{{ db_server_temp | default([]) + [item] }}"
+      with_items:
+        - "{{ query('inventory_hostnames', '{{ sap_sid | upper }}_DB') }}"
+      when:
+        - db_high_availability
+
+    - name:                            "HSR Install: Set the DB virtual_host name"
+      ansible.builtin.set_fact:
+        db_lb_virtual_host:            "{% if db_high_availability %}{{ sap_sid | lower }}{{ db_sid | lower }}db{{ hdb_instance_number }}cl{% else %}{{ hostvars[db_server_temp | first]['virtual_host'] }}{% endif %}"
+      when:
+        - db_high_availability
+        - db_server_temp is defined
+        - db_server_temp | length > 0
+
+    - name:                            "HSR: 4.0.1.7 - Check if SAP DEFAULT.PFL changes are needed"
+      ansible.builtin.lineinfile:
+        path:                          "/sapmnt/{{ sap_sid | upper }}/profile/DEFAULT.PFL"
+        regexp:                        "^SAPDBHOST = {{ db_lb_virtual_host }}"
+        line:                          "SAPDBHOST = {{ db_lb_virtual_host }}"
+        state:                         present
+      check_mode:                      true
+      register:                        check_default_pfl
+      when:
+        - db_high_availability
+
+    - name:                            "HSR: 4.0.1.7 - SAP DEFAULT.PFL changes "
+      ansible.builtin.replace:
+        path:                          /sapmnt/{{ sap_sid | upper }}/profile/DEFAULT.PFL
+        backup:                        true
+        regexp:                        '^SAPDBHOST'
+        replace:                       '#SAPDBHOST'
+      when:
+        - check_default_pfl is changed
+        - db_high_availability
+      tags:
+        - dbhostcomment
+
+    - name:                            "HSR: 4.0.1.7 - SAP DEFAULT.PFL changes - add db virtual hostname "
+      ansible.builtin.lineinfile:
+        path:                          /sapmnt/{{ sap_sid | upper }}/profile/DEFAULT.PFL
+        line:                          SAPDBHOST = {{ db_lb_virtual_host }}
+        insertafter:                   '#SAPDBHOST'
+      when:
+        - check_default_pfl is changed
+        - db_high_availability
+      tags:
+        - dbhostpara
+
+  when:
+    - platform == 'HANA'
+    - db_high_availability
+
+...

--- a/deploy/ansible/roles-sap/5.2-pas-install/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.2-pas-install/tasks/main.yaml
@@ -133,6 +133,12 @@
 # |                                                                            |
 # *====================================4=======================================8
 
+    - name:                            "PAS Install: HANA HSR - Update Profile"
+      ansible.builtin.import_tasks:    ../../../roles-db/4.0.1-hdb-hsr/tasks/4.0.1.7-sap-profile-changes.yml
+      when:
+        - db_high_availability
+        - platform == "HANA"
+
     - name:                            "PAS Install: progress"
       ansible.builtin.debug:
         msg:                           "Starting PAS installation ({{ sid_to_be_deployed.sid | upper }})"


### PR DESCRIPTION
## Problem
The sap profile parameters were not being set correctly after the DB Load installation. The SAPDBHOST param in particular was being set to the primary DB VM instead of it being the DB LB. This was preventing all the DB VMs backing a DB instance from being discovered. The SAPDBHOST is set to the primary DB VM so as to ensure reliable installation of the DB Load. After the installation succeeds, the SAPDBHOST value should be set to point to the DB LB. This was not being done.

## Solution
A new file 4.0.1.7-sap-profile-changes.yml is added which contains tasks for setting the sap profile parameters correctly after the DB Load installation. These tasks are executed at the beginning of PAS install.

## Tests
Manually tested and E2Es refined in the service code to test whether all DB VMs are being discovered in the post installation discovery.
