### PR TITLE
Set CLOUD_NETCONFIG_MANAGE to yes

### DIFF
--- a/deploy/ansible/roles-os/1.10-networking/tasks/main.yaml
+++ b/deploy/ansible/roles-os/1.10-networking/tasks/main.yaml
@@ -64,6 +64,7 @@
       ONBOOT=yes
       IPADDR="{{ secondary_ip }}"
       NETMASK=255.255.255.0
+      CLOUD_NETCONFIG_MANAGE='yes'
     mode:                              755
   register:                            definition_made
   when:


### PR DESCRIPTION
## Problem
<Please describe what problem this PR is trying to resolve>
[Problem is described in this issue](https://github.com/Azure/sap-automation/issues/352#issue-1465887124)

## Solution
Hi @hdamecharla @phaniteluguti ,

I was able to identify the issue to 3 possible files:

1. [deploy\ansible\roles-os\1.17-generic-pacemaker\tasks\1.17.2-provision.yml](deploy\ansible\roles-os\1.17-generic-pacemaker\tasks\1.17.2-provision.yml)
2. [deploy\ansible\roles-os\1.17-generic-pacemaker\tasks\1.17.2.0-cluster-Suse.yml](deploy\ansible\roles-os\1.17-generic-pacemaker\tasks\1.17.2.0-cluster-Suse.yml)

The above 2 files :point_up_2: are setting CLOUD_NETCONFIG_MANAGE to no.
Not fully sure if this can be removed [I think not].

But perhaps here it can be added in this file :point_down:

3. [deploy\ansible\roles-os\1.10-networking\tasks.yml](deploy\ansible\roles-os\1.10-networking\tasks.yml)

```
64      ONBOOT=yes
65     IPADDR="{{ secondary_ip }}"
66      NETMASK=255.255.255.0
67+      CLOUD_NETCONFIG_MANAGE='yes'
68    mode:                              755
69  register:                            definition_made
70  when:
```
## Tests
[TODO]<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>