### PR TITLE
Fix BOM target file name parameter from 'override_target_filename' to 'filename'

### DIFF
--- a/deploy/ansible/BOM-catalog/SWPM10SP35_win_latest/SWPM10SP35_win_latest.yaml
+++ b/deploy/ansible/BOM-catalog/SWPM10SP35_win_latest/SWPM10SP35_win_latest.yaml
@@ -10,7 +10,7 @@ materials:
     - name:                     "SWPM 1.0 SP35 for NW higher than 7.0x"
       archive:                  SWPM10SP35_7-20009707.SAR
       checksum:                 b673c3e395900d34038256d9075ae0c5d2b96c721fd5b870e2301a8a754bd8a6
-      override_target_filename: "SWPM.SAR"
+      filename:                 "SWPM.SAR"
       extract:                  true
       extractDir:               SWPM
       url:                      https://softwaredownloads.sap.com/file/0020000001261312022

--- a/deploy/ansible/BOM-catalog/SWPM10SP36_win_latest/SWPM10SP36_win_latest.yaml
+++ b/deploy/ansible/BOM-catalog/SWPM10SP36_win_latest/SWPM10SP36_win_latest.yaml
@@ -10,7 +10,7 @@ materials:
     - name:                     "SWPM 1.0 SP36 for NW higher than 7.0x ; OS: Windows 64bit"
       archive:                  SWPM10SP36_1-20009707.SAR
       checksum:                 91c9d0e4dd805988beacad2e4c28578021ba33ffdf27e944ff03e755682e174d
-      override_target_filename: "SWPM.SAR"
+      filename:                 "SWPM.SAR"
       extract:                  true
       extractDir:               SWPM
       url:                      https://softwaredownloads.sap.com/file/0020000001382702022


### PR DESCRIPTION
## Problem
When processing BOM for SWPM windows, ansible skips rename of downloaded file to SWPM.SAR as BOM contains 'override_target_filename' property which is not used by "roles-sap/windows/3.3-bom-processing"

## Solution
replaced property 'override_target_filename' with 'filename'

## Tests
run play_bom_downloader , then playbook_03_bom_processing to validate that the archive is unpacked correctly.

## Notes
minor fix to BOM