### PR TITLE
Syntax errors fixed in JAVA stack templates ( ers and app) for NW750_SPS25

### DIFF
--- a/deploy/ansible/BOM-catalog/NW750SPS25_JAVA_v0001ms/templates/NW750SPS25_JAVA_v0001ms-app-inifile-param.j2
+++ b/deploy/ansible/BOM-catalog/NW750SPS25_JAVA_v0001ms/templates/NW750SPS25_JAVA_v0001ms-app-inifile-param.j2
@@ -3,160 +3,168 @@
 # Installation service 'SAP NetWeaver 7.5 > SAP HANA Database > Installation > Application Server Java > High-Availability System > Additional Application Server Instance', product id 'NW_DI:NW750.HDB.HA' #
 #                                                                                                                                                                                                            #
 ##############################################################################################################################################################################################################
-# IMPORTANT DO NOT DELETE!!! SAPInstDes25Hash=$h20IpZrGdfYX$hxFAkaJAAGEok0gobUbi10f7BjScjl4JG+kXiq1GxzebqKt+ML3iZ5yoQDda3snRdKeOaGP1SC+kkod6blX3d4qmIGkidwVU
+
+# Location of Export CD
+SAPINST.CD.PACKAGE.HDBCLIENT                                          = {{ sap_cd_package_hdbclient }}
+SAPINST.CD.PACKAGE.CD1                                                = {{ sap_cd_package_cd1 }}
+SAPINST.CD.PACKAGE.CD2                                                = {{ sap_cd_package_cd2 }}
+SAPINST.CD.PACKAGE.CD3                                                = {{ sap_cd_package_cd3 }}
+SAPINST.CD.PACKAGE.CD4                                                = {{ sap_cd_package_cd4 }}
+SAPINST.CD.PACKAGE.CD5                                                = {{ sap_cd_package_cd5 }}
+
 
 # Password for the Diagnostics Agent specific <dasid>adm user. Provided value may be encoded.
-# DiagnosticsAgent.dasidAdmPassword =
+# DiagnosticsAgent.dasidAdmPassword                                   =
 
 # Windows domain in which the Diagnostics Agent users must be created. This is an optional property (Windows only).
-# DiagnosticsAgent.domain =
+# DiagnosticsAgent.domain                                             =
 
 # Windows only: Password for the Diagnostics Agent specific 'SAPService<DASID>' user.
-# DiagnosticsAgent.sapServiceDASIDPassword =
+# DiagnosticsAgent.sapServiceDASIDPassword                            =
 
 # Specify whether Software Provisioning Manager is to drop the schema if it exists.
-# HDB_Schema_Check_Dialogs.dropSchema = false
+# HDB_Schema_Check_Dialogs.dropSchema                                 = false
 
 # The name of the database schema.
-HDB_Schema_Check_Dialogs.schemaName = SAPJAVA1
+HDB_Schema_Check_Dialogs.schemaName                                   = SAPJAVA1
 
 # The password of the database schema.
-HDB_Schema_Check_Dialogs.schemaPassword = des25(kZXlpkaaxRxEiBQza+I5AtxEnK7q)
+HDB_Schema_Check_Dialogs.schemaPassword                               = {{ main_password }}
 
 # Specify whether Software Provisioning Manager is to validate the schema name. The schema name must only contain numbers and capital letters. It  must not start with '_' . It cannot be 'SYS' or 'SYSTEM'.
-# HDB_Schema_Check_Dialogs.validateSchemaName = true
+# HDB_Schema_Check_Dialogs.validateSchemaName                         = true
+
 
 # If set to 'true', an 'ms_acl_info' file is created. It manages the hosts from which the Message Server accepts connections.
-# MessageServer.configureAclInfo = false
+# MessageServer.configureAclInfo                                      = false
 
 # The  instance number of the application server. Leave empty for default.
-NW_AS.instanceNumber = 02
+NW_AS.instanceNumber                                                    =  {{ aas_instance_number }}
 
 # Skip unpacking any archive, for example SAPEXE.SAR. Do not set it to 'true' if the database client archives or the SAP kernel must be unpacked, for example if you want to add an application server on a another operating system.
-# NW_AS.skipUnpacking = false
+# NW_AS.skipUnpacking                                                   = false
 
 # Start the application server at the end of the installation. Default is 'true'.
-# NW_AS.start = true
+# NW_AS.start                                                           = true
 
 # User-defined number of Java server nodes. Depends on NW_DI_Instance.nodesNumber.
-# NW_DI_Instance.nodesNum =
+# NW_DI_Instance.nodesNum                                               =
 
 # Number of Java server nodes. Possible values: 'defNodes' - default number; 'userNodes' - user-defined number. Default is 'defNodes'
-# NW_DI_Instance.nodesNumber = defNodes
+# NW_DI_Instance.nodesNumber                                            = defNodes
 
 # You can specify a virtual host name for the application server instance. Leave empty if you want to use the default physical host name. The virtual host name must already be bound to a local network interface.
-NW_DI_Instance.virtualHostname = app-01
+NW_DI_Instance.virtualHostname                                          = 
 
 # Specify whether the all operating system users are to be removed from group 'sapinst' after the execution of Software Provisioning Manager has completed.
-NW_Delete_Sapinst_Users.removeUsers = true
+NW_Delete_Sapinst_Users.removeUsers                                   = true
 
 # Master password
-NW_GetMasterPassword.masterPwd = des25(B/B8+BAt5dnXyDQZIpixe3pOld6T)
+NW_GetMasterPassword.masterPwd                                        = {{ main_password }}
 
 # Skip checking if creating a HANA user store is needed. Default value is 'true'. If set to 'false', a valid HANA userstore must exists.
-# NW_HDB_DBClient.checkCreateUserstore = true
+# NW_HDB_DBClient.checkCreateUserstore                                = true
 
 # Install the SAP HANA database client in a central or local directory. Possible values are: 'SAPCPE', 'LOCAL'
-# NW_HDB_DBClient.clientPathStrategy = LOCAL
+# NW_HDB_DBClient.clientPathStrategy                                  = LOCAL
 
 # The DB admin user for SAP HANA tenant database. Default value: SYSTEM
-# NW_HDB_getDBInfo.dbadmin = SYSTEM
+# NW_HDB_getDBInfo.dbadmin                                            = SYSTEM
 
 # The instance number of the SAP HANA database server
-NW_HDB_getDBInfo.instanceNumber = 00
+NW_HDB_getDBInfo.instanceNumber                                       = {{ db_instance_number }}
 
 # The SQL port for SAP HANA tenant database
-# NW_HDB_getDBInfo.tenantPort =
+# NW_HDB_getDBInfo.tenantPort                                         =
 
 # DEPRECATED, DO NOT USE!
-# NW_SAPCrypto.SAPCryptoFile =
+# NW_SAPCrypto.SAPCryptoFile                                          =
 
 # SAP INTERNAL USE ONLY
-# NW_System.installSAPHostAgent = true
+# NW_System.installSAPHostAgent                                       = true
 
 # DEPRECATED, DO NOT USE!
-# NW_Unpack.dbaToolsSar =
+# NW_Unpack.dbaToolsSar                                               =
+
+# DEPRECATED, DO NOT USE!                                             
+NW_Unpack.igsExeSar                                                   = {{ target_media_location }}/download_basket/igsexe_13-80003187.sar
 
 # DEPRECATED, DO NOT USE!
-# NW_Unpack.igsExeSar =
+NW_Unpack.igsHelperSar                                                = {{ target_media_location }}/download_basket/igshelper_17-10010245.sar
 
 # DEPRECATED, DO NOT USE!
-# NW_Unpack.igsHelperSar =
+NW_Unpack.sapExeDbSar                                                 = {{ target_media_location }}/download_basket/SAPEXEDB_1100-80002572.SAR
 
 # DEPRECATED, DO NOT USE!
-# NW_Unpack.sapExeDbSar =
+# NW_Unpack.sapExeSar                                                 =
 
 # DEPRECATED, DO NOT USE!
-# NW_Unpack.sapExeSar =
+NW_Unpack.sapJvmSar                                                   = {{ target_media_location }}/download_basket/SAPJVM8_91-80000202.SAR
 
 # DEPRECATED, DO NOT USE!
-# NW_Unpack.sapJvmSar =
-
-# DEPRECATED, DO NOT USE!
-# NW_Unpack.xs2Sar =
+# NW_Unpack.xs2Sar                                                    =
 
 # SAP INTERNAL USE ONLY
-# NW_adaptProfile.templateFiles =
+# NW_adaptProfile.templateFiles                                       =
 
 # ABAP message server port for connecting to the message server, leave empty for default
-# NW_checkMsgServer.abapMSPort =
+# NW_checkMsgServer.abapMSPort                                        =
 
 # The FQDN of the system
-# NW_getFQDN.FQDN =
+# NW_getFQDN.FQDN                                                     =
 
 # SAP INTERNAL USE ONLY
-# NW_getFQDN.resolve = true
+# NW_getFQDN.resolve                                                  = true
 
 # Specify whether you want to set FQDN for the system.
-# NW_getFQDN.setFQDN = true
+# NW_getFQDN.setFQDN                                                  = true
 
 # Manual configuration and execution of Migration Monitor or manual native database copy method.
-# NW_getLoadType.importManuallyExecuted = false
+# NW_getLoadType.importManuallyExecuted                               = false
 
 # The load type chosen by the user. Valid values are: 'SAP', 'STD', 'OBR', 'HCP', 'FLASHCOPY', 'MDA', 'HBR', 'SBR'
-NW_getLoadType.loadType = SAP
+NW_getLoadType.loadType                                               = SAP
 
 # ABAP system is Unicode (true|false), only needed if it cannot be determined from the system.
-# NW_getUnicode.isUnicode =
+# NW_getUnicode.isUnicode                                             =
 
 # Provide  'profile' directory of SAP Netweaver-based system.
-NW_readProfileDir.profileDir = /usr/sap/X01/SYS/profile
+NW_readProfileDir.profileDir                                          = {{ sap_profile_dir }}
 
 # Windows only: The drive to use
-# NW_readProfileDir.sapdrive =
+# NW_readProfileDir.sapdrive                                          =
 
-# The folder containing all archives that have been downloaded from http://support.sap.com/swdc and are supposed to be used in this procedure
-archives.downloadBasket = /usr/sap/install/download_basket
+
 
 # DBACOCKPIT user is to be created. Default value is 'false'.
-# hdb.create.dbacockpit.user = false
+# hdb.create.dbacockpit.user                                          = false
 
 # Windows only: The domain of the SAP Host Agent user
-# hostAgent.domain =
+# hostAgent.domain                                                    =
 
 # Password for the 'sapadm' user of the SAP Host Agent
-# hostAgent.sapAdmPassword =
+# hostAgent.sapAdmPassword                                            =
 
 # Windows only: The domain of all users of this SAP system. Leave empty for default.
-# nwUsers.sapDomain =
+# nwUsers.sapDomain                                                   =
 
 # Windows only: The password of the 'SAPServiceSID' user
-# nwUsers.sapServiceSIDPassword =
+# nwUsers.sapServiceSIDPassword                                       =
 
 # UNIX only: The user ID of the 'sapadm' user, leave empty for default. The ID is ignored if the user already exists.
-# nwUsers.sapadmUID =
+# nwUsers.sapadmUID                                                   =
 
 # UNIX only: The group id of the 'sapsys' group, leave empty for default. The ID is ignored if the group already exists.
-nwUsers.sapsysGID = 2000
+nwUsers.sapsysGID                                                     = {{ sapsys_gid }}
 
 # UNIX only: The user id of the <sapsid>adm user, leave empty for default. The ID is ignored if the user already exists.
-nwUsers.sidAdmUID = 2200
+nwUsers.sidAdmUID                                                     = {{ sidadm_uid }}
 
 # The password of the '<sapsid>adm' user
-# nwUsers.sidadmPassword =
+# nwUsers.sidadmPassword                                              = 
 
 # ABAP schema password
-# storageBasedCopy.abapSchemaPassword =
+# storageBasedCopy.abapSchemaPassword                                 =
 
 # Sets the SAP<SAPSID>DB schema password using a  parameter file.
-# storageBasedCopy.javaSchemaPassword =
+# storageBasedCopy.javaSchemaPassword                                 =

--- a/deploy/ansible/BOM-catalog/NW750SPS25_JAVA_v0001ms/templates/NW750SPS25_JAVA_v0001ms-ers-inifile-param.j2
+++ b/deploy/ansible/BOM-catalog/NW750SPS25_JAVA_v0001ms/templates/NW750SPS25_JAVA_v0001ms-ers-inifile-param.j2
@@ -3,7 +3,16 @@
 # Installation service 'SAP NetWeaver 7.5 > SAP HANA Database > Installation > Application Server Java > High-Availability System > Enqueue Replication Server Instance', product id 'NW_ERS:NW750.HDB.HA' #
 #                                                                                                                                                                                                          #
 ############################################################################################################################################################################################################
-# IMPORTANT DO NOT DELETE!!! SAPInstDes25Hash=$epackL+yJON1$L0+zdBnX8NwCWxv/cged05Bv5HIGNY/Juz0NdljkwiRH9KonnwMeFS6t684mJHdb/lN9PUisHH4N5tjruTsSf8Mn1PUdrQIh
+
+
+# Location of Export CD
+SAPINST.CD.PACKAGE.HDBCLIENT                                          = {{ sap_cd_package_hdbclient }}
+SAPINST.CD.PACKAGE.CD1                                                = {{ sap_cd_package_cd1 }}
+SAPINST.CD.PACKAGE.CD2                                                = {{ sap_cd_package_cd2 }}
+SAPINST.CD.PACKAGE.CD3                                                = {{ sap_cd_package_cd3 }}
+SAPINST.CD.PACKAGE.CD4                                                = {{ sap_cd_package_cd4 }}
+SAPINST.CD.PACKAGE.CD5                                                = {{ sap_cd_package_cd5 }}
+
 
 # Password for the Diagnostics Agent specific <dasid>adm user. Provided value may be encoded.
 # DiagnosticsAgent.dasidAdmPassword =
@@ -40,9 +49,6 @@ NW_readProfileDir.profileDir = /usr/sap/{{ app_sid | upper }}/SYS/profile
 
 # Windows only: The drive to use
 # NW_readProfileDir.sapdrive =
-
-# The folder containing all archives that have been downloaded from http://support.sap.com/swdc and are supposed to be used in this procedure
-archives.downloadBasket = {{ download_basket_dir }}
 
 # Windows only: The domain of the SAP Host Agent user
 # hostAgent.domain =


### PR DESCRIPTION
## Problem
malformed templates caused errors when deploying app and ers in distributed setups.

## Solution
fixed the syntax errors in the param templates.
