### PR TITLE
Minor bug fix: DB Load fails for No-HA setups with separate PAS

### DIFF
--- a/deploy/ansible/playbook_05_01_sap_dbload.yaml
+++ b/deploy/ansible/playbook_05_01_sap_dbload.yaml
@@ -154,7 +154,7 @@
 
       when:
         - platform == 'HANA'
-        - "'pas' in supported_tiers"
+        - "'scs' in supported_tiers"
 
 # /*----------------------------------------------------------------------------8
 # |                                                                            |


### PR DESCRIPTION
changing line 157 condition from *pas to *scs. DBLoad must always run on SCS hosting VM if running a distributed setup ( HA or non HA )

## Problem
DB load runs on PAS node which is not yet configured and does not have the /usr/sap/<SID>/SYS/profile directory available. DB load will fail in this case where PAS is being hosted on a separate VM.

## Solution
DBLoad must always run before PAS and AAS setup, hence it must be triggered from A/SCS node only ( or any node running the messaging service ). Playbook is modified slightly to run this from the first SCS server. Post DB Load, PAS and AAS installation instances of SAPINST are un on their respective VM's and succeed without errors.

