### PR TITLE
SAP software provisioning manager (sapinst) should be run with umask 022

### DIFF
--- a/deploy/ansible/roles-db/4.2.0-db2-install/tasks/main.yml
+++ b/deploy/ansible/roles-db/4.2.0-db2-install/tasks/main.yml
@@ -106,6 +106,7 @@
 
     - name:                            "DB2 Install - SAPINST DB2 Install"
       ansible.builtin.shell: |
+                                       umask {{ custom_umask | default('022') }};
                                        ./sapinst SAPINST_INPUT_PARAMETERS_URL={{ dir_params }}/{{ sap_inifile }}     \
                                                  SAPINST_EXECUTE_PRODUCT_ID={{ bom.product_ids.dbl }}                \
                                                  SAPINST_SKIP_DIALOGS=true                                           \

--- a/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.0-db2_ha_install_primary.yml
+++ b/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.0-db2_ha_install_primary.yml
@@ -124,6 +124,7 @@
 
     - name:                            "SAP DB2 Install"
       ansible.builtin.shell: |
+                                       umask {{ custom_umask | default('022') }};
                                        ./sapinst SAPINST_INPUT_PARAMETERS_URL={{ dir_params }}/{{ sap_inifile }}     \
                                                  SAPINST_EXECUTE_PRODUCT_ID={{ bom.product_ids.dblha }}             \
                                                  SAPINST_SKIP_DIALOGS=true                                           \

--- a/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.2-db2_ha_install_secondary.yml
+++ b/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.2-db2_ha_install_secondary.yml
@@ -110,6 +110,7 @@
 
     - name:                            "SAP DB2 Install - Secondary DB"
       ansible.builtin.shell: |
+                                       umask {{ custom_umask | default('022') }};
                                        ./sapinst SAPINST_INPUT_PARAMETERS_URL={{ dir_params }}/{{ sap_inifile }}     \
                                                  SAPINST_EXECUTE_PRODUCT_ID={{ bom.product_ids.dblsby }}             \
                                                  SAPINST_SKIP_DIALOGS=true                                           \

--- a/deploy/ansible/roles-sap-os/2.5-sap-users/tasks/user_nw.yaml
+++ b/deploy/ansible/roles-sap-os/2.5-sap-users/tasks/user_nw.yaml
@@ -115,6 +115,7 @@
 
     - name:                            "User Creation: SAP OS USERS and Group Creation {{ sid_to_be_deployed }}"
       ansible.builtin.shell: |
+                                       umask {{ custom_umask | default('022') }};
                                        ./sapinst SAPINST_INPUT_PARAMETERS_URL={{ dir_params }}/{{ sap_inifile }} \
                                                  SAPINST_EXECUTE_PRODUCT_ID={{ bom.product_ids.generic }}                             \
                                                  SAPINST_SKIP_DIALOGS=true                                                            \

--- a/deploy/ansible/roles-sap/5.0.1-scs-ha-install/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.0.1-scs-ha-install/tasks/main.yaml
@@ -224,6 +224,7 @@
 
         - name:                        "RESCUE - SCS HA Install: SAPINST"
           ansible.builtin.command: |
+                                       umask {{ custom_umask | default('022') }};
                                        ./sapinst SAPINST_INPUT_PARAMETERS_URL={{ dir_params }}/{{ sap_inifile }}     \
                                                  SAPINST_EXECUTE_PRODUCT_ID={{ bom.product_ids.scs_ha }}             \
                                                  SAPINST_SKIP_DIALOGS=true                                           \

--- a/deploy/ansible/roles-sap/5.0.2-ers-ha-install/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.0.2-ers-ha-install/tasks/main.yaml
@@ -114,12 +114,6 @@
       loop:
         - { path: '/usr/sap/{{ sap_sid | upper }}/ERS{{ ers_instance_number }}' }
 
-    - name:                            "ERS Install: SAP ERS install command"
-      ansible.builtin.debug:
-        msg:                           ./sapinst SAPINST_INPUT_PARAMETERS_URL={{ dir_params }}/{{ sap_inifile }}
-                                        SAPINST_EXECUTE_PRODUCT_ID={{ bom.product_ids.ers_ha }} SAPINST_SKIP_DIALOGS=true SAPINST_START_GUISERVER=false SAPINST_USE_HOSTNAME={{ ers_virtual_hostname }}
-        verbosity:                     4
-
 # *====================================4=======================================8
 #   SAP ERS: Install
 # 2230669 - System Provisioning Using a Parameter Input File
@@ -186,6 +180,7 @@
 
         - name:                        "RESCUE - ERS Install: SAPInst"
           ansible.builtin.shell: |
+                                       umask {{ custom_umask | default('022') }};
                                        ./sapinst SAPINST_INPUT_PARAMETERS_URL={{ dir_params }}/{{ sap_inifile }}     \
                                                  SAPINST_EXECUTE_PRODUCT_ID={{ bom.product_ids.ers_ha }}             \
                                                  SAPINST_SKIP_DIALOGS=true                                           \

--- a/deploy/ansible/roles-sap/5.4-web-install/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.4-web-install/tasks/main.yaml
@@ -132,6 +132,7 @@
 
     - name:                            "SAP Web Dispatcher Install"
       ansible.builtin.command: |
+                                       umask {{ custom_umask | default('022') }};
                                        ./sapinst SAPINST_INPUT_PARAMETERS_URL={{ dir_params }}/{{ sap_inifile }} \
                                                  SAPINST_EXECUTE_PRODUCT_ID={{ bom.product_ids.web }}            \
                                                  SAPINST_SKIP_DIALOGS=true                                       \


### PR DESCRIPTION
## Problem
SAP software provision manager (sapinst) should be run with umask 022 when executing as the root user according to the documentation (see notes).

## Solution
Add umask command before every sapinst command with the possibility to override the default umask via the custom_umask  variable.

## Tests

## Notes
- https://help.sap.com/docs/SLTOOLSET/06f7611290ea4b8d9bc431a8d7bf05c3/1d4bd354b65ced05e10000000a4450e5.html?version=CURRENT_VERSION_SWPM20