### PR TITLE
Update S4HANA_2021_FP01_v0001ms BOM / BOM validator

### DIFF
--- a/deploy/ansible/BOM-catalog/S42021SPS00_v0001ms/S42021SPS00_v0001ms.yaml
+++ b/deploy/ansible/BOM-catalog/S42021SPS00_v0001ms/S42021SPS00_v0001ms.yaml
@@ -22,7 +22,7 @@ product_ids:
 materials:
   dependencies:
     - name:                            "HANA_2_00_066_v0001ms"
-    - name:                            "SWPM20SP11_latest"
+    - name:                            "SWPM20SP13_latest"
 
   media:
 

--- a/deploy/ansible/BOM-catalog/S4HANA_2021_FP01_v0001ms/S4HANA_2021_FP01_v0001ms.yaml
+++ b/deploy/ansible/BOM-catalog/S4HANA_2021_FP01_v0001ms/S4HANA_2021_FP01_v0001ms.yaml
@@ -24,8 +24,8 @@ product_ids:
 materials:
   dependencies:
     - name:         "HANA_2_00_066_v0001ms"
-    - name:         "SWPM20SP11_latest"
-    - name:         "SUM20SP13_latest"
+    - name:         "SWPM20SP13_latest"
+    - name:         "SUM20SP15_latest"
   media:
 
     # SAPCAR 7.22

--- a/deploy/ansible/roles-sap/0.1-bom-validator/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/0.1-bom-validator/tasks/main.yaml
@@ -132,7 +132,7 @@
     new_bom:                           "{{ lookup('template', 'bom.j2') }}"
 
 - name:                                "0.1 BOM Validator: - remove BoM"
-  become:                              true
+  become:                              "{{ bom_processing_become }}"
   become_user:                         root
   delegate_to:                         localhost
   ansible.builtin.file:
@@ -140,7 +140,7 @@
     state:                             absent
 
 - name:                                "0.1 BOM Validator: - write combined BoM"
-  become:                              true
+  become:                              "{{ bom_processing_become }}"
   become_user:                         root
   delegate_to:                         localhost
   ansible.builtin.copy:


### PR DESCRIPTION
## Problem
- In the S/4 HANA 2021 FP 01 BOM the SWPM 2.0 SP11 and SUM 2.0 SP13 aren't available anymore
- In the BOM validator the become value has been hard coded to true

## Solution
- Replace dependencies by SWPM 2.0 SP13 and SUM 2.0 SP15
- Replace hard coded true to bom_processing_become variable

## Tests
- BOM was downloaded and processed successfully