### PR TITLE
Bugfix : HSR setup failing when OS name is in upper case

### DIFF
--- a/deploy/ansible/roles-db/4.0.1-hdb-hsr/tasks/4.0.1.5-provision_hana_replication.yml
+++ b/deploy/ansible/roles-db/4.0.1-hdb-hsr/tasks/4.0.1.5-provision_hana_replication.yml
@@ -29,14 +29,14 @@
     HOME:                              "/usr/sap/{{ db_sid | upper }}/home"
     PYTHONHOME:                        "/usr/sap/{{ DB }}/exe/Python3"
     DIR_EXECUTABLE:                    "/usr/sap/{{ DB }}/exe"
-    SAP_RETRIEVAL_PATH:                "/usr/sap/{{ DB }}/{{ ansible_hostname }}"
+    SAP_RETRIEVAL_PATH:                "/usr/sap/{{ DB }}/{{ ansible_hostname | lower}}"
     DIR_SYSEXE:                        "/usr/sap/{{ db_sid | upper }}/SYS/exe/hdb"
     SAPSYSTEMNAME:                     "{{ db_sid | upper }}"
-    SECUDIR:                           "/usr/sap/{{ DB }}/{{ ansible_hostname }}/sec"
+    SECUDIR:                           "/usr/sap/{{ DB }}/{{ ansible_hostname | lower }}/sec"
     DAT_BIN_DIR:                       "/usr/sap/{{ DB }}/exe/dat_bin_dir"
     DIR_INSTANCE:                      "/usr/sap/{{ DB }}"
-    PYTHONPATH:                        "/usr/sap/{{ DB }}/exe/Py3:/usr/sap/HDB/SYS/global/hdb/custom/python_support:/usr/sap/{{ DB }}/exe/python_support:/usr/sap/{{ DB }}/{{ ansible_hostname }}:/usr/sap/{{ DB }}/exe:/usr/sap/{{ DB }}/exe/testscripts:/usr/sap/{{ DB }}/exe/Python3/lib/python3.7"
-    PATH:                              "/usr/sap/{{ DB }}/exe/krb5/bin:/usr/sap/{{ DB }}/exe/krb5/sbin:/usr/sap/{{ DB }}/{{ ansible_hostname }}:/usr/sap/{{ DB }}:/usr/sap/{{ DB }}/exe:/usr/sap/{{ DB }}/exe/mdc:/usr/sap/{{ DB }}/exe/Python3/bin:/usr/sap/{{ DB }}/exe/dat_bin_dir:/usr/sap/HDB/home:/usr/sap/HDB/home/bin:/usr/local/bin:/usr/bin:/bin:/usr/games:/usr/lib/mit/bin"
+    PYTHONPATH:                        "/usr/sap/{{ DB }}/exe/Py3:/usr/sap/HDB/SYS/global/hdb/custom/python_support:/usr/sap/{{ DB }}/exe/python_support:/usr/sap/{{ DB }}/{{ ansible_hostname | lower }}:/usr/sap/{{ DB }}/exe:/usr/sap/{{ DB }}/exe/testscripts:/usr/sap/{{ DB }}/exe/Python3/lib/python3.7"
+    PATH:                              "/usr/sap/{{ DB }}/exe/krb5/bin:/usr/sap/{{ DB }}/exe/krb5/sbin:/usr/sap/{{ DB }}/{{ ansible_hostname | lower }}:/usr/sap/{{ DB }}:/usr/sap/{{ DB }}/exe:/usr/sap/{{ DB }}/exe/mdc:/usr/sap/{{ DB }}/exe/Python3/bin:/usr/sap/{{ DB }}/exe/dat_bin_dir:/usr/sap/HDB/home:/usr/sap/HDB/home/bin:/usr/local/bin:/usr/bin:/bin:/usr/games:/usr/lib/mit/bin"
     LD_LIBRARY_PATH:                   "/usr/sap/{{ DB }}/exe/krb5/lib/krb5/plugins/preauth:/usr/sap/{{ DB }}/exe/krb5/lib:/usr/sap/{{ DB }}/exe:/usr/sap/{{ DB }}/exe/Python3/lib:/usr/sap/{{ DB }}/exe/Py3:/usr/sap/{{ DB }}/exe/filter:/usr/sap/{{ DB }}/exe/dat_bin_dir:/usr/sap/{{ DB }}/exe/plugins/afl:/usr/sap/{{ DB }}/exe/plugins/lcapps:/usr/sap/{{ DB }}/exe/plugins/repository:/usr/sap/{{ DB }}/exe/plugins/epmmds:/usr/sap/HDB/SYS/global/hdb/federation:/usr/sap/HDB/SYS/global/hdb/plugins/3rd_party_libs:/usr/sap/HDB/SYS/global/hdb/plugins/1st_party_libs"
   when:
     - ansible_hostname == primary_instance_name
@@ -106,14 +106,14 @@
     HOME:                              "/usr/sap/{{ db_sid | upper }}/home"
     PYTHONHOME:                        "/usr/sap/{{ DB }}/exe/Python3"
     DIR_EXECUTABLE:                    "/usr/sap/{{ DB }}/exe"
-    SAP_RETRIEVAL_PATH:                "/usr/sap/{{ DB }}/{{ ansible_hostname }}"
+    SAP_RETRIEVAL_PATH:                "/usr/sap/{{ DB }}/{{ ansible_hostname | lower }}"
     DIR_SYSEXE:                        "/usr/sap/{{ db_sid | upper }}/SYS/exe/hdb"
     SAPSYSTEMNAME:                     "{{ db_sid | upper }}"
-    SECUDIR:                           "/usr/sap/{{ DB }}/{{ ansible_hostname }}/sec"
+    SECUDIR:                           "/usr/sap/{{ DB }}/{{ ansible_hostname | lower }}/sec"
     DAT_BIN_DIR:                       "/usr/sap/{{ DB }}/exe/dat_bin_dir"
     DIR_INSTANCE:                      "/usr/sap/{{ DB }}"
-    PYTHONPATH:                        "/usr/sap/{{ DB }}/exe/Py3:/usr/sap/HDB/SYS/global/hdb/custom/python_support:/usr/sap/{{ DB }}/exe/python_support:/usr/sap/{{ DB }}/{{ ansible_hostname }}:/usr/sap/{{ DB }}/exe:/usr/sap/{{ DB }}/exe/testscripts:/usr/sap/{{ DB }}/exe/Python3/lib/python3.7"
-    PATH:                              "/usr/sap/{{ DB }}/exe/krb5/bin:/usr/sap/{{ DB }}/exe/krb5/sbin:/usr/sap/{{ DB }}/{{ ansible_hostname }}:/usr/sap/{{ DB }}:/usr/sap/{{ DB }}/exe:/usr/sap/{{ DB }}/exe/mdc:/usr/sap/{{ DB }}/exe/Python3/bin:/usr/sap/{{ DB }}/exe/dat_bin_dir:/usr/sap/HDB/home:/usr/sap/HDB/home/bin:/usr/local/bin:/usr/bin:/bin:/usr/games:/usr/lib/mit/bin"
+    PYTHONPATH:                        "/usr/sap/{{ DB }}/exe/Py3:/usr/sap/HDB/SYS/global/hdb/custom/python_support:/usr/sap/{{ DB }}/exe/python_support:/usr/sap/{{ DB }}/{{ ansible_hostname | lower }}:/usr/sap/{{ DB }}/exe:/usr/sap/{{ DB }}/exe/testscripts:/usr/sap/{{ DB }}/exe/Python3/lib/python3.7"
+    PATH:                              "/usr/sap/{{ DB }}/exe/krb5/bin:/usr/sap/{{ DB }}/exe/krb5/sbin:/usr/sap/{{ DB }}/{{ ansible_hostname | lower }}:/usr/sap/{{ DB }}:/usr/sap/{{ DB }}/exe:/usr/sap/{{ DB }}/exe/mdc:/usr/sap/{{ DB }}/exe/Python3/bin:/usr/sap/{{ DB }}/exe/dat_bin_dir:/usr/sap/HDB/home:/usr/sap/HDB/home/bin:/usr/local/bin:/usr/bin:/bin:/usr/games:/usr/lib/mit/bin"
     LD_LIBRARY_PATH:                   "/usr/sap/{{ DB }}/exe/krb5/lib/krb5/plugins/preauth:/usr/sap/{{ DB }}/exe/krb5/lib:/usr/sap/{{ DB }}/exe:/usr/sap/{{ DB }}/exe/Python3/lib:/usr/sap/{{ DB }}/exe/Py3:/usr/sap/{{ DB }}/exe/filter:/usr/sap/{{ DB }}/exe/dat_bin_dir:/usr/sap/{{ DB }}/exe/plugins/afl:/usr/sap/{{ DB }}/exe/plugins/lcapps:/usr/sap/{{ DB }}/exe/plugins/repository:/usr/sap/{{ DB }}/exe/plugins/epmmds:/usr/sap/HDB/SYS/global/hdb/federation:/usr/sap/HDB/SYS/global/hdb/plugins/3rd_party_libs:/usr/sap/HDB/SYS/global/hdb/plugins/1st_party_libs"
   when:                                ansible_hostname == primary_instance_name
 
@@ -123,10 +123,10 @@
 - name:                                "HANA HSR: - Restart HANA"
   become_user:                         "{{ db_sid_admin_user }}"
   block:
-    - name:                            "HANA HSR: - Stop HANA on {{ ansible_hostname }}"
+    - name:                            "HANA HSR: - Stop HANA on {{ ansible_hostname | lower }}"
       ansible.builtin.import_tasks:                   ../../../roles-misc/0.4-helpers/tasks/04.02-stop_hana.yml
 
-    - name:                            "HANA HSR: - Start HANA on {{ ansible_hostname }}"
+    - name:                            "HANA HSR: - Start HANA on {{ ansible_hostname | lower }}"
       ansible.builtin.import_tasks:                    ../../../roles-misc/0.4-helpers/tasks/04.01-start_hana.yml
   vars:
     ansible_python_interpreter:        python3
@@ -134,14 +134,14 @@
     HOME:                              "/usr/sap/{{ db_sid | upper }}/home"
     PYTHONHOME:                        "/usr/sap/{{ DB }}/exe/Python3"
     DIR_EXECUTABLE:                    "/usr/sap/{{ DB }}/exe"
-    SAP_RETRIEVAL_PATH:                "/usr/sap/{{ DB }}/{{ ansible_hostname }}"
+    SAP_RETRIEVAL_PATH:                "/usr/sap/{{ DB }}/{{ ansible_hostname | lower }}"
     DIR_SYSEXE:                        "/usr/sap/{{ db_sid | upper }}/SYS/exe/hdb"
     SAPSYSTEMNAME:                     "{{ db_sid | upper }}"
-    SECUDIR:                           "/usr/sap/{{ DB }}/{{ ansible_hostname }}/sec"
+    SECUDIR:                           "/usr/sap/{{ DB }}/{{ ansible_hostname | lower }}/sec"
     DAT_BIN_DIR:                       "/usr/sap/{{ DB }}/exe/dat_bin_dir"
     DIR_INSTANCE:                      "/usr/sap/{{ DB }}"
-    PYTHONPATH:                        "/usr/sap/{{ DB }}/exe/Py3:/usr/sap/HDB/SYS/global/hdb/custom/python_support:/usr/sap/{{ DB }}/exe/python_support:/usr/sap/{{ DB }}/{{ ansible_hostname }}:/usr/sap/{{ DB }}/exe:/usr/sap/{{ DB }}/exe/testscripts:/usr/sap/{{ DB }}/exe/Python3/lib/python3.7"
-    PATH:                              "/usr/sap/{{ DB }}/exe/krb5/bin:/usr/sap/{{ DB }}/exe/krb5/sbin:/usr/sap/{{ DB }}/{{ ansible_hostname }}:/usr/sap/{{ DB }}:/usr/sap/{{ DB }}/exe:/usr/sap/{{ DB }}/exe/mdc:/usr/sap/{{ DB }}/exe/Python3/bin:/usr/sap/{{ DB }}/exe/dat_bin_dir:/usr/sap/HDB/home:/usr/sap/HDB/home/bin:/usr/local/bin:/usr/bin:/bin:/usr/games:/usr/lib/mit/bin"
+    PYTHONPATH:                        "/usr/sap/{{ DB }}/exe/Py3:/usr/sap/HDB/SYS/global/hdb/custom/python_support:/usr/sap/{{ DB }}/exe/python_support:/usr/sap/{{ DB }}/{{ ansible_hostname | lower }}:/usr/sap/{{ DB }}/exe:/usr/sap/{{ DB }}/exe/testscripts:/usr/sap/{{ DB }}/exe/Python3/lib/python3.7"
+    PATH:                              "/usr/sap/{{ DB }}/exe/krb5/bin:/usr/sap/{{ DB }}/exe/krb5/sbin:/usr/sap/{{ DB }}/{{ ansible_hostname | lower }}:/usr/sap/{{ DB }}:/usr/sap/{{ DB }}/exe:/usr/sap/{{ DB }}/exe/mdc:/usr/sap/{{ DB }}/exe/Python3/bin:/usr/sap/{{ DB }}/exe/dat_bin_dir:/usr/sap/HDB/home:/usr/sap/HDB/home/bin:/usr/local/bin:/usr/bin:/bin:/usr/games:/usr/lib/mit/bin"
     LD_LIBRARY_PATH:                   "/usr/sap/{{ DB }}/exe/krb5/lib/krb5/plugins/preauth:/usr/sap/{{ DB }}/exe/krb5/lib:/usr/sap/{{ DB }}/exe:/usr/sap/{{ DB }}/exe/Python3/lib:/usr/sap/{{ DB }}/exe/Py3:/usr/sap/{{ DB }}/exe/filter:/usr/sap/{{ DB }}/exe/dat_bin_dir:/usr/sap/{{ DB }}/exe/plugins/afl:/usr/sap/{{ DB }}/exe/plugins/lcapps:/usr/sap/{{ DB }}/exe/plugins/repository:/usr/sap/{{ DB }}/exe/plugins/epmmds:/usr/sap/HDB/SYS/global/hdb/federation:/usr/sap/HDB/SYS/global/hdb/plugins/3rd_party_libs:/usr/sap/HDB/SYS/global/hdb/plugins/1st_party_libs"
   when:                                ansible_hostname == primary_instance_name
 
@@ -154,7 +154,7 @@
 - name:                                "HANA HSR: - Ensure System Replication is configured on secondary"
   block:
 
-    - name:                            "HANA HSR: - Stop HANA on {{ ansible_hostname }}"
+    - name:                            "HANA HSR: - Stop HANA on {{ ansible_hostname | lower }}"
       ansible.builtin.import_tasks:                   ../../../roles-misc/0.4-helpers/tasks/04.02-stop_hana.yml
 
     - name:                            "HANA HSR: - Ensure Secondary node is registered as secondary in replication"
@@ -171,7 +171,7 @@
       args:
         executable: /bin/bash
 
-    - name:                            "HANA HSR: - Start HANA on {{ ansible_hostname }}"
+    - name:                            "HANA HSR: - Start HANA on {{ ansible_hostname | lower }}"
       ansible.builtin.import_tasks:                    ../../../roles-misc/0.4-helpers/tasks/04.01-start_hana.yml
   vars:
     ansible_python_interpreter:        python3
@@ -179,14 +179,14 @@
     HOME:                              "/usr/sap/{{ db_sid | upper }}/home"
     PYTHONHOME:                        "/usr/sap/{{ DB }}/exe/Python3"
     DIR_EXECUTABLE:                    "/usr/sap/{{ DB }}/exe"
-    SAP_RETRIEVAL_PATH:                "/usr/sap/{{ DB }}/{{ ansible_hostname }}"
+    SAP_RETRIEVAL_PATH:                "/usr/sap/{{ DB }}/{{ ansible_hostname | lower }}"
     DIR_SYSEXE:                        "/usr/sap/{{ db_sid | upper }}/SYS/exe/hdb"
     SAPSYSTEMNAME:                     "{{ db_sid | upper }}"
-    SECUDIR:                           "/usr/sap/{{ DB }}/{{ ansible_hostname }}/sec"
+    SECUDIR:                           "/usr/sap/{{ DB }}/{{ ansible_hostname | lower }}/sec"
     DAT_BIN_DIR:                       "/usr/sap/{{ DB }}/exe/dat_bin_dir"
     DIR_INSTANCE:                      "/usr/sap/{{ DB }}"
-    PYTHONPATH:                        "/usr/sap/{{ DB }}/exe/Py3:/usr/sap/HDB/SYS/global/hdb/custom/python_support:/usr/sap/{{ DB }}/exe/python_support:/usr/sap/{{ DB }}/{{ ansible_hostname }}:/usr/sap/{{ DB }}/exe:/usr/sap/{{ DB }}/exe/testscripts:/usr/sap/{{ DB }}/exe/Python3/lib/python3.7"
-    PATH:                              "/usr/sap/{{ DB }}/exe/krb5/bin:/usr/sap/{{ DB }}/exe/krb5/sbin:/usr/sap/{{ DB }}/{{ ansible_hostname }}:/usr/sap/{{ DB }}:/usr/sap/{{ DB }}/exe:/usr/sap/{{ DB }}/exe/mdc:/usr/sap/{{ DB }}/exe/Python3/bin:/usr/sap/{{ DB }}/exe/dat_bin_dir:/usr/sap/HDB/home:/usr/sap/HDB/home/bin:/usr/local/bin:/usr/bin:/bin:/usr/games:/usr/lib/mit/bin"
+    PYTHONPATH:                        "/usr/sap/{{ DB }}/exe/Py3:/usr/sap/HDB/SYS/global/hdb/custom/python_support:/usr/sap/{{ DB }}/exe/python_support:/usr/sap/{{ DB }}/{{ ansible_hostname | lower }}:/usr/sap/{{ DB }}/exe:/usr/sap/{{ DB }}/exe/testscripts:/usr/sap/{{ DB }}/exe/Python3/lib/python3.7"
+    PATH:                              "/usr/sap/{{ DB }}/exe/krb5/bin:/usr/sap/{{ DB }}/exe/krb5/sbin:/usr/sap/{{ DB }}/{{ ansible_hostname | lower }}:/usr/sap/{{ DB }}:/usr/sap/{{ DB }}/exe:/usr/sap/{{ DB }}/exe/mdc:/usr/sap/{{ DB }}/exe/Python3/bin:/usr/sap/{{ DB }}/exe/dat_bin_dir:/usr/sap/HDB/home:/usr/sap/HDB/home/bin:/usr/local/bin:/usr/bin:/bin:/usr/games:/usr/lib/mit/bin"
     LD_LIBRARY_PATH:                   "/usr/sap/{{ DB }}/exe/krb5/lib/krb5/plugins/preauth:/usr/sap/{{ DB }}/exe/krb5/lib:/usr/sap/{{ DB }}/exe:/usr/sap/{{ DB }}/exe/Python3/lib:/usr/sap/{{ DB }}/exe/Py3:/usr/sap/{{ DB }}/exe/filter:/usr/sap/{{ DB }}/exe/dat_bin_dir:/usr/sap/{{ DB }}/exe/plugins/afl:/usr/sap/{{ DB }}/exe/plugins/lcapps:/usr/sap/{{ DB }}/exe/plugins/repository:/usr/sap/{{ DB }}/exe/plugins/epmmds:/usr/sap/HDB/SYS/global/hdb/federation:/usr/sap/HDB/SYS/global/hdb/plugins/3rd_party_libs:/usr/sap/HDB/SYS/global/hdb/plugins/1st_party_libs"
   when:
     - ansible_hostname == secondary_instance_name


### PR DESCRIPTION
## Problem
When HANA VM is provisioned with OS name in upper case, HSR setup will fail with messages "SAPSYSTEMNAME not in profile".
On detailed examination, users are able to run "hdbnsutil" from shell running as <sid>adm but not when triggered from ansible.

Reason : Irrespective of OS name, HANA setup will create and populate the profile directory under /usr/sap/<SID>/HDB<instanceID>/ as lower case OS name. More so, sapprofile.ini under the same folder has SAPSYSTEMNAME also populated in lower case. 
When running commands via Ansible task : 4.0.1.5, the environment variables are generated using Ansible variables that denote actual hostnames coming from <SID>_hosts,yaml which are in upper case.
This results in "hdbnsutil" executions to fail as it points to a directory that does not exists and does not have the sapprofile.ini file in it with correct params.

## Solution
In file "4.0.1.5-provision_hana_replication.yaml", ensure SAP HANA profile directories are correctly populated by correcting the case of hostname , denoted by {{ ansible_hostname }}

## Tests
Provision VM with upper case hostnames matching the same upper case OS Names. HANA HSR setup will fail.
Apply fix and HANA HSR setup will proceed without errors.

## Notes
SAP documentation link for paths to profile directory and configuration file ( https://help.sap.com/docs/SAP_HANA_PLATFORM/eb3777d5495d46c5b2fa773206bbfb46/aa7e697ccf214852a283a75126c34370.html?version=1.0.12) 