### PR TITLE
Add support for DB2 deployments on RHEL8.7

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -3,8 +3,6 @@ exclude_paths:
   - deploy/ansible/BOM-catalog
   - deploy/terraform
   - .github
-  # added ansible_skip_lint tag to exclude the task rather than the whole file.
-  # - deploy/ansible/roles-sap-os/2.10-sap-notes/tasks/2.10.1.1.yaml # Has to be excluded as there is a pipe sign in the regex that Ansible sees as filter
 
 warn_list:
   # FIXME: Experimental violations should be fixed in separate PR

--- a/.github/workflows/github-actions-ansible-lint.yml
+++ b/.github/workflows/github-actions-ansible-lint.yml
@@ -7,3 +7,5 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ansible/ansible-lint-action@v6.11.0
+        with:
+          path: deploy/ansible

--- a/.github/workflows/requirements.yml
+++ b/.github/workflows/requirements.yml
@@ -1,7 +1,0 @@
-collections:
-- name: ansible.windows
-- name: ansible.posix
-- name: ansible.utils
-- name: ansible.netcommon
-- name: community.windows
-- name: community.general

--- a/deploy/ansible/playbook_00_validate_parameters.yaml
+++ b/deploy/ansible/playbook_00_validate_parameters.yaml
@@ -286,11 +286,12 @@
       when:
         - deployer_free_temp_disk_space is not defined
 
-    - name:                            "0.0 Validations - Check for free disk space on deployer "
+    - name:                            "0.0 Validations - Check for free disk space on deployer"
       ansible.builtin.assert:
-        that:
-          - "{{ (mnt_free_diskspace | first | int / (1024 * 1024 * 1024) | int) > (deployer_free_temp_disk_space | int) }}"
+        that: "{{ (mnt_free_diskspace | first | int / (1024 * 1024 * 1024) | int) > (deployer_free_temp_disk_space | int) }}"
         fail_msg: "The deployer needs at least {{ deployer_free_temp_disk_space }} GB of free disk space in /mnt"
+      when:
+        - mnt_free_diskspace | length > 0
       tags:
         - 0.0-agent-diskspace
 

--- a/deploy/ansible/playbook_01_os_base_config.yaml
+++ b/deploy/ansible/playbook_01_os_base_config.yaml
@@ -234,7 +234,6 @@
 
   tasks:
     - name:                            "OS configuration playbook: - Create os-configuration-done flag"
-      become: true
       ansible.builtin.file:
         path: "{{ _workspace_directory }}/.progress/os-configuration-done"
         state: touch

--- a/deploy/ansible/playbook_bom_downloader.yaml
+++ b/deploy/ansible/playbook_bom_downloader.yaml
@@ -14,14 +14,8 @@
   connection:                           local
   environment:
     ANSIBLE_COLLECTIONS_PATHS:         "/opt/ansible/collections"
-
-# -------------------------------------+
-# 20230117 MKD (DynBOM) - BEGIN
-# Mitigate root requirement
-  become:                               true
+  become:                               "{{ bom_processing_become  }}"
   become_user:                          "{{ orchestration_ansible_user }}"
-# 20230117 MKD (DynBOM) - END
-# -------------------------------------+
   vars_files:
     - vars/ansible-input-api.yaml                                               # API Input template with defaults
 

--- a/deploy/ansible/requirements.yml
+++ b/deploy/ansible/requirements.yml
@@ -1,7 +1,10 @@
+---
 collections:
   - name: ansible.windows
   - name: ansible.posix
-  - name: ansible.netcommon
   - name: ansible.utils
+  - name: ansible.netcommon
   - name: community.windows
   - name: community.general
+
+roles: []

--- a/deploy/ansible/roles-db/4.0.1-hdb-hsr/tasks/4.0.1.0-pre_checks.yml
+++ b/deploy/ansible/roles-db/4.0.1-hdb-hsr/tasks/4.0.1.0-pre_checks.yml
@@ -36,8 +36,6 @@
   failed_when:                         hana_replication_status.rc != 0
   vars:
     allow_world_readable_tmpfiles:     true
-  tags:
-    - skip_ansible_lint
   environment:
     ANSIBLE_REMOTE_TEMP:               "{{ tmp_directory }}/{{ db_sid | upper }}"
     TEMPDIR:                           "{{ tmp_directory }}/{{ db_sid | upper }}"

--- a/deploy/ansible/roles-db/4.0.1-hdb-hsr/tasks/4.0.1.2-set_trust_relationship.yml
+++ b/deploy/ansible/roles-db/4.0.1-hdb-hsr/tasks/4.0.1.2-set_trust_relationship.yml
@@ -12,8 +12,6 @@
 #     user:                              "root"
 #     key:                                "{{ lookup('file','/tmp/{{ primary_instance_name }}-id_rsa.pub') }} "
 #   when: ansible_hostname == secondary_instance_name
-#   tags:
-#     - skip_ansible_lint
 
 # - name:                                HSR - Ensure the secondary node public key is on the primary node
 #   become:                              true
@@ -21,8 +19,6 @@
 #     user:                              "root"
 #     key:                                "{{ lookup('file','/tmp/{{ secondary_instance_name }}-id_rsa.pub') }} "
 #   when: ansible_hostname == primary_instance_name
-#   tags:
-#     - skip_ansible_lint
 
 # - name:                                HSR - Ensure trust relationship is working from primary to secondary
 #   ansible.builtin.command:             ssh -oStrictHostKeyChecking=no {{ secondary_instance_name }} "hostname -s"

--- a/deploy/ansible/roles-db/4.0.1-hdb-hsr/tasks/4.0.1.5-provision_hana_replication.yml
+++ b/deploy/ansible/roles-db/4.0.1-hdb-hsr/tasks/4.0.1.5-provision_hana_replication.yml
@@ -166,8 +166,6 @@
         --operationMode={{ hana_operation_mode }} --name=SITEB
       register:                        hsr_secondary_registration
       changed_when:                    "'adding site' in hsr_secondary_registration.stdout"
-      tags:
-        - skip_ansible_lint
       args:
         executable: /bin/bash
 

--- a/deploy/ansible/roles-db/4.0.1-hdb-hsr/tasks/4.0.1.6-post_checks.yml
+++ b/deploy/ansible/roles-db/4.0.1-hdb-hsr/tasks/4.0.1.6-post_checks.yml
@@ -16,8 +16,6 @@
   retries:                             10
   delay:                               5
   when:                                ansible_hostname == primary_instance_name
-  tags:
-    - skip_ansible_lint
 
 - name:                                "HANA HSR: - Debug replication"
   ansible.builtin.debug:

--- a/deploy/ansible/roles-db/4.1.0-ora-install/tasks/main.yaml
+++ b/deploy/ansible/roles-db/4.1.0-ora-install/tasks/main.yaml
@@ -48,8 +48,6 @@
     group:                             oinstall
     recurse:                           true
   when:                                not oracle_permissions.stat.exists
-  tags:
-    - skip_ansible_lint
 
 - name:                                Create oracleowner.txt
   become:                              true
@@ -105,8 +103,6 @@
         chdir:                         "{{ target_media_location }}/oraserver/LINUX_X86_64/db_home/SAP"
         creates:                       "/etc/sap_deployment_automation/{{ sap_sid | upper }}/oracle_pre_check_install.txt"
         executable:                    /bin/csh
-      tags:
-        - skip_ansible_lint
 
     # Debug for testing
     - name:                            "ORACLE: Debug: installer prechecks output"
@@ -154,8 +150,6 @@
         executable:                    /bin/csh
         chdir:                         "{{ target_media_location }}/oraserver/LINUX_X86_64/db_home/SAP"
         creates:                       "/etc/sap_deployment_automation/{{ sap_sid | upper }}/oracle_installed.txt"
-      tags:
-        - skip_ansible_lint
 
     - name:                            "ORACLE: Debug: installer output"
       ansible.builtin.debug:
@@ -196,8 +190,6 @@
         DB_SID:                        "{{ db_sid }}"
         CV_ASSUME_DISTID:              OL7
         TMPDIR:                        "{{ tmp_directory }}/{{ sap_sid | upper }}"
-      tags:
-        - skip_ansible_lint
 
     - name:                            "ORACLE: Debug: orainstRoot output"
       ansible.builtin.debug:
@@ -229,8 +221,6 @@
         DB_SID:                        "{{ db_sid }}"
         CV_ASSUME_DISTID:              OL7
         TMPDIR:                        "{{ tmp_directory }}/{{ sap_sid | upper }}"
-      tags:
-        - skip_ansible_lint
 
     - name:                            "ORACLE: Debug: rootscript output"
       ansible.builtin.debug:
@@ -256,8 +246,6 @@
         state:                         file
         owner:                         oracle
         mode:                          06751
-      tags:
-        - skip_ansible_lint
 
 # /*---------------------------------------------------------------------------8
 # |                                                                            |

--- a/deploy/ansible/roles-db/4.1.2-ora-asm-db-install/tasks/main.yaml
+++ b/deploy/ansible/roles-db/4.1.2-ora-asm-db-install/tasks/main.yaml
@@ -51,8 +51,6 @@
     group:                             oinstall
     recurse:                           true
   when:                                not oracle_permissions.stat.exists
-  tags:
-    - skip_ansible_lint
 
 - name:                                Create oracleowner.txt
   become:                              true
@@ -93,8 +91,6 @@
         chdir:                         "{{ target_media_location }}/oraserver/LINUX_X86_64/db_home/SAP"
         creates:                       "/etc/sap_deployment_automation/{{ sap_sid | upper }}/oracle_pre_check_install.txt"
         executable:                    /bin/csh
-      tags:
-        - skip_ansible_lint
 
     # Debug for testing
     - name:                            "ORACLE: Debug: installer prechecks output"
@@ -137,8 +133,6 @@
         executable:                    /bin/csh
         chdir:                         "{{ target_media_location }}/oraserver/LINUX_X86_64/db_home/SAP"
         creates:                       "/etc/sap_deployment_automation/{{ sap_sid | upper }}/oracle_installed.txt"
-      tags:
-        - skip_ansible_lint
 
     - name:                            "ORACLE: Debug: installer output"
       ansible.builtin.debug:
@@ -175,8 +169,6 @@
       args:
         creates:                       "/etc/sap_deployment_automation/{{ sap_sid | upper }}/orainstRoot_executed.txt"
         executable:                    /bin/csh
-      tags:
-        - skip_ansible_lint
 
     - name:                            "ORACLE: Debug: orainstRoot output"
       ansible.builtin.debug:
@@ -204,8 +196,6 @@
       args:
         creates:                       "/etc/sap_deployment_automation/{{ sap_sid | upper }}/rootscripts_executed.txt"
         executable:                    /bin/csh
-      tags:
-        - skip_ansible_lint
 
     - name:                            "ORACLE: Debug: rootscript output"
       ansible.builtin.debug:
@@ -231,8 +221,6 @@
         state:                         file
         owner:                         oracle
         mode:                          '6751'
-      tags:
-        - skip_ansible_lint
 
 # /*---------------------------------------------------------------------------8
 # |                                                                            |
@@ -397,12 +385,12 @@
 
     - name:                            "ORACLE: backup MOPatch"
       ansible.builtin.copy:
-            src:                           /oracle/GRID/{{ ora_version }}/MOPatch
-            dest:                          /oracle/GRID/{{ ora_version }}/MOPatch.bck
-            remote_src:                    true
-            mode:                          '0755'
-            owner:                         oracle
-            group:                         oinstall
+        src:                           /oracle/GRID/{{ ora_version }}/MOPatch
+        dest:                          /oracle/GRID/{{ ora_version }}/MOPatch.bck
+        remote_src:                    true
+        mode:                          '0755'
+        owner:                         oracle
+        group:                         oinstall
       when:
         - mopatchgrid_stat.stat.exists
 
@@ -426,7 +414,7 @@
         owner:                         oracle
         group:                         oinstall
 
-    #Backup the existing Opatch and then copy the new Opatch from the downloads folder
+    # Backup the existing Opatch and then copy the new Opatch from the downloads folder
 
     - name:                            "ORACLE: Check if 'OPatch.bck' exists for GRID"
       ansible.builtin.stat:
@@ -435,12 +423,12 @@
 
     - name:                            "ORACLE: backup OPatch"
       ansible.builtin.copy:
-            src:                           /oracle/GRID/{{ ora_version }}/OPatch
-            dest:                          /oracle/GRID/{{ ora_version }}/OPatch.bck
-            remote_src:                    true
-            mode:                          '0755'
-            owner:                         oracle
-            group:                         oinstall
+        src:                           /oracle/GRID/{{ ora_version }}/OPatch
+        dest:                          /oracle/GRID/{{ ora_version }}/OPatch.bck
+        remote_src:                    true
+        mode:                          '0755'
+        owner:                         oracle
+        group:                         oinstall
       when:
         - not opatchgrid_stat.stat.exists
 
@@ -479,18 +467,17 @@
         mode:                              '0755'
       when:                                gridpreinstall.rc == 0
 
-
-    #STEP 4.2.2 SBP Patching for Oracle GRID.
+    # STEP 4.2.2 SBP Patching for Oracle GRID.
     - name:                            "ORACLE: Post Processing - GRID SBP Patching"
       become:                          true
       become_user:                     "oracle"
       ansible.builtin.shell:            $OHGRID/MOPatch/mopatch.sh -v -s {{ oraclegrid_sbp_patch }}
       environment:
         OHGRID:                         /oracle/GRID/{{ ora_version }}
-        #ORACLE_BASE:                    /oracle/GRID/
+        # ORACLE_BASE:                    /oracle/GRID/
         ORACLE_HOME:                    /oracle/GRID/{{ ora_version }}
-        #IHRDBMS:                        /oracle/{{ db_sid | upper}}/{{ ora_release }}
-        #ORACLE_SID:                     "{{ db_sid | upper}}"
+        # IHRDBMS:                        /oracle/{{ db_sid | upper}}/{{ ora_release }}
+        # ORACLE_SID:                     "{{ db_sid | upper}}"
       register:                         gridsbpscript_results
       failed_when:                      gridsbpscript_results.rc >= 2
       args:
@@ -516,8 +503,8 @@
         state:                             touch
         mode:                               '0755'
 
-    #STEP 4.2.3 Post-Processing SBP Patching for Oracle GRID.
-    #SAP Note 2893317 - ORA-12547:  TNS:lost contact during SWPM system copy import -NetWeaver
+    # STEP 4.2.3 Post-Processing SBP Patching for Oracle GRID.
+    # SAP Note 2893317 - ORA-12547:  TNS:lost contact during SWPM system copy import -NetWeaver
     # Run the post install script for GRID SBP patching to start the Oracle Cluster service manager, ASMCA and relevant toolset.
 
     - name:                                "SAP Oracle DB ASM: Oracle Post Processing - GRID SBP GRID Patching Post-Processing"
@@ -538,7 +525,7 @@
         path:                             /etc/sap_deployment_automation/{{ sap_sid | upper }}/sbp-grid-postprocess.txt
         state:                            touch
         mode:                             '0755'
-      #when:                               sbppostpro_results.rc >= 2
+      # when:                               sbppostpro_results.rc >= 2
 
     - name:                            "ORACLE: Create sbp_installed.txt"
       ansible.builtin.file:
@@ -554,8 +541,6 @@
         owner:                         oracle
         group:                         oinstall
         mode:                          '6751'
-      tags:
-        - skip_ansible_lint
 
     - name:                            "ORACLE: environment variables to the Bash profile"
       become:                          true
@@ -592,9 +577,6 @@
             setenv  DB_SID {{ db_sid }}
             set path = ($path $ORACLE_HOME/bin)
         mode:                              '0755'
-
-
-
 
   when:
     - not oracle_installed.stat.exists

--- a/deploy/ansible/roles-db/4.1.3-ora-dg/tasks/ora-dg-observer-setup.yaml
+++ b/deploy/ansible/roles-db/4.1.3-ora-dg/tasks/ora-dg-observer-setup.yaml
@@ -80,8 +80,6 @@
     executable:                        /bin/csh
     chdir:                             "{{ target_media_location }}/oraserver/LINUX_X86_64/db_home/SAP"
     creates:                           /etc/sap_deployment_automation/oracle_installed.txt
-  tags:
-    - skip_ansible_lint
 
 - name:                                "Oracle Data Guard - Observer: installer output"
   ansible.builtin.debug:
@@ -110,27 +108,23 @@
   become:                              true
   become_user:                         "root"
   ansible.builtin.copy:
-    src:                               "{{ target_media_location }}/downloads/{{ db_sid| upper }}/sqlnet.ora"
+    src:                               "{{ target_media_location }}/downloads/{{ db_sid | upper }}/sqlnet.ora"
     dest:                              /oracle/{{ db_sid | upper }}/{{ ora_version }}/network/admin/sqlnet.ora
     remote_src:                        true
     owner:                             oracle
     group:                             oinstall
     mode:                              "{{ '0777' | int - (custom_umask | default('022') | int) }}"
-  tags:
-    - skip_ansible_lint
 
 - name:                                "Oracle Data Guard - Observer: Copy tnsnames.ora TO Observer"
   become:                              true
   become_user:                         "root"
   ansible.builtin.copy:
-    src:                               "{{ target_media_location }}/downloads/{{ db_sid| upper }}/tnsnames.ora"
+    src:                               "{{ target_media_location }}/downloads/{{ db_sid | upper }}/tnsnames.ora"
     dest:                              /oracle/{{ db_sid | upper }}/{{ ora_version }}/network/admin/tnsnames.ora
     remote_src:                        true
     owner:                             oracle
     group:                             oinstall
     mode:                              "{{ '0777' | int - (custom_umask | default('022') | int) }}"
-  tags:
-    - skip_ansible_lint
 
 - name:                                "Oracle Data Guard - Observer: Add environment variables to the Bash profile"
   become:                              true
@@ -201,8 +195,6 @@
   args:
     chdir:                             /oracle/{{ db_sid | upper }}/{{ ora_release }}/bin
     executable:                        /bin/csh
-  tags:
-    - skip_ansible_lint
 
 - name:                                "Oracle Data Guard - Observer: tnsping Secondary output"
   ansible.builtin.debug:

--- a/deploy/ansible/roles-db/4.1.3-ora-dg/tasks/ora-dg-secondary-preparation.yaml
+++ b/deploy/ansible/roles-db/4.1.3-ora-dg/tasks/ora-dg-secondary-preparation.yaml
@@ -61,8 +61,6 @@
     creates:                           /etc/sap_deployment_automation/dgscripts/createpfile.txt
     chdir:                             /etc/sap_deployment_automation/dgscripts
     executable:                        /bin/csh
-  tags:
-    - skip_ansible_lint
   # when:  current_host == ora_primary
 
 - name:                                "Oracle Data Guard - Preparation (Secondary): Create createpfile.txt"
@@ -90,8 +88,6 @@
     force:                             true
     mode:                              "{{ '0777' | int - (custom_umask | default('022') | int) }}"
   # when: current_host == ora_primary
-  tags:
-    - skip_ansible_lint
 
 - name:                                "Oracle Data Guard - Preparation (Secondary): Copy orapwSID to templocation"
   become:                              true
@@ -105,8 +101,6 @@
     group:                             dba
     mode:                              "{{ '0777' | int - (custom_umask | default('022') | int) }}"
   # when: current_host == ora_primary
-  tags:
-    - skip_ansible_lint
 
 # - name:                                "Oracle Data Guard - Preparation (Secondary)Copy dbs folder to templocation"
 #   become:                              true
@@ -118,8 +112,6 @@
 #     creates:                           /etc/sap_deployment_automation/dgscripts/dbscopied.txt
 #     chdir:                             /oracle/{{ db_sid | upper }}/{{ ora_release }}/dbs
 #     executable:                        /bin/csh
-#   tags:
-#     - skip_ansible_lint
 
 - name:                                "Oracle Data Guard - Preparation (Secondary)Copy dbs folder to templocation"
   become:                              true
@@ -132,8 +124,6 @@
     group:                             oinstall
     force:                             true
     mode:                              "{{ '0777' | int - (custom_umask | default('022') | int) }}"
-
-
 
 - name:                                "Oracle Data Guard - Preparation (Secondary): Create dbscopied.txt"
   become:                              true

--- a/deploy/ansible/roles-db/4.1.3-ora-dg/tasks/ora-dg-setup-primary.yaml
+++ b/deploy/ansible/roles-db/4.1.3-ora-dg/tasks/ora-dg-setup-primary.yaml
@@ -36,8 +36,6 @@
   when:
   #  - not archive_primary_stat.stat.exists
     - current_host == ora_primary
-  tags:
-    - skip_ansible_lint
 
 - name:                                "Oracle Data Guard - Setup Primary: Enable Archive log on Primary (debug)"
   ansible.builtin.debug:
@@ -83,8 +81,6 @@
   when:
   #  - not forcelogin_stat.stat.exists
     - current_host == ora_primary
-  tags:
-    - skip_ansible_lint
 
 - name:                                "Oracle Data Guard - Setup Primary: Enable enable_force_login on Primary (debug)"
   ansible.builtin.debug:
@@ -129,8 +125,6 @@
     chdir:                             /etc/sap_deployment_automation/dgscripts
     executable:                        /bin/csh
   when:  current_host == ora_primary
-  tags:
-    - skip_ansible_lint
 
 - name:                                "Oracle Data Guard - Setup Primary: Create standby logs for Oracle DG (debug)"
   ansible.builtin.debug:
@@ -166,8 +160,6 @@
     chdir:                             /etc/sap_deployment_automation/dgscripts
     executable:                        /bin/csh
   when:  current_host == ora_primary
-  tags:
-    - skip_ansible_lint
 
 - name:                                "Oracle Data Guard - Setup Primary: Enable Flashback on Oracle Primary DB (debug)"
   ansible.builtin.debug:

--- a/deploy/ansible/roles-db/4.1.3-ora-dg/tasks/ora-dg-setup-secondary.yaml
+++ b/deploy/ansible/roles-db/4.1.3-ora-dg/tasks/ora-dg-setup-secondary.yaml
@@ -27,8 +27,6 @@
     group:                             oinstall
     mode:                              "{{ '0777' | int - (custom_umask | default('022') | int) }}"
   when: current_host == ora_secondary
-  tags:
-    - skip_ansible_lint
 
 - name:                                "Oracle Data Guard - Setup Secondary: Copy orapwSID to Secondary"
   become:                              true
@@ -41,8 +39,6 @@
     group:                             dba
     mode:                              "{{ '0777' | int - (custom_umask | default('022') | int) }}"
   when: current_host == ora_secondary
-  tags:
-    - skip_ansible_lint
 
 # Restart the Listener on Secondary node.
 
@@ -57,8 +53,6 @@
     chdir:                             /etc/sap_deployment_automation/dgscripts
     executable:                        /bin/csh
   when:                                current_host == ora_secondary
-  tags:
-    - skip_ansible_lint
 
 - name:                                "Oracle Data Guard - Setup Secondary: restart lsnrctl on Secondary (Debug)"
   ansible.builtin.debug:
@@ -96,8 +90,6 @@
     chdir:                             /etc/sap_deployment_automation/dgscripts
     executable:                        /bin/csh
   when: current_host == ora_secondary
-  tags:
-    - skip_ansible_lint
 
 - name:                                "Oracle Data Guard - Setup Secondary: startup DG Broker on Secondary (Debug)"
   ansible.builtin.debug:
@@ -170,8 +162,6 @@
         - { directory_to_empty: '/oracle/{{ db_sid | upper }}/origlogB' }
         - { directory_to_empty: '/oracle/{{ db_sid | upper }}/mirrlogA' }
         - { directory_to_empty: '/oracle/{{ db_sid | upper }}/mirrlogB' }
-      tags:
-        - skip_ansible_lint
 
     - name:                            "Oracle Data Guard - Setup Secondary: Startup secondary DB"
       become:                          true
@@ -252,8 +242,6 @@
     chdir:                             /etc/sap_deployment_automation/dgscripts
     executable:                        /bin/csh
   when:                                current_host == ora_secondary
-  tags:
-    - skip_ansible_lint
 
 - name:                                "Oracle Data Guard - Setup Secondary: startup DG Broker on Secondary (Debug)"
   ansible.builtin.debug:

--- a/deploy/ansible/roles-db/4.1.3-ora-multi-sid/tasks/main.yaml
+++ b/deploy/ansible/roles-db/4.1.3-ora-multi-sid/tasks/main.yaml
@@ -86,8 +86,6 @@
     executable:                         /bin/csh
     chdir:                             "{{ target_media_location }}/oraserver/LINUX_X86_64/db_home/SAP"
     creates:                           /etc/sap_deployment_automation/shared_db_installed.txt
-  tags:
-    - skip_ansible_lint
 
 - name:                                 "ORACLE (sharedHome): Debug: installer output"
   ansible.builtin.debug:
@@ -131,8 +129,6 @@
     executable:                         /bin/csh
     chdir:                             "{{ target_media_location }}/oraserver/LINUX_X86_64/db_home/SAP"
     creates:                           /etc/sap_deployment_automation/oracle_installed.txt
-  tags:
-    - skip_ansible_lint
 
 - name:                                 "ORACLE (sharedHome): create after a successful install"
   ansible.builtin.file:
@@ -156,8 +152,6 @@
   args:
     creates:                           /etc/sap_deployment_automation/orainstRoot_executed.txt
     executable:                         /bin/csh
-  tags:
-    - skip_ansible_lint
 
 - name:                                 "ORACLE (sharedHome): Debug: orainstRoot output"
   ansible.builtin.debug:
@@ -185,8 +179,6 @@
   args:
     creates:                          /etc/sap_deployment_automation/root_scripts_executed.txt
     executable:                        /bin/csh
-  tags:
-    - skip_ansible_lint
 
 - name:                                 "ORACLE (sharedHome): Debug: rootscript output"
   ansible.builtin.debug:
@@ -221,9 +213,6 @@
     owner:                             oracle
     group:                             oinstall
     mode:                              06751
-  tags:
-    - skip_ansible_lint
-
 
 # /*---------------------------------------------------------------------------8
 # |                                                                            |
@@ -239,9 +228,6 @@
     owner:                             oracle
     group:                             oinstall
     mode:                              06751
-  tags:
-    - skip_ansible_lint
-
 
 # /*---------------------------------------------------------------------------8
 # |                                                                            |
@@ -313,17 +299,15 @@
   environment:
     DB_SID:                             "{{ db_sid }}"
     CV_ASSUME_DISTID:                   OL7
-    IHRDBMS:                           /oracle/RDBMS/{{ ora_version }}
-    ORACLE_HOME:                       /oracle/RDBMS/{{ ora_version }}
-    RDBMS:                             /oracle/RDBMS/{{ ora_version }}
+    IHRDBMS:                            /oracle/RDBMS/{{ ora_version }}
+    ORACLE_HOME:                        /oracle/RDBMS/{{ ora_version }}
+    RDBMS:                              /oracle/RDBMS/{{ ora_version }}
   register:                             sbpscript_results
-  failed_when:                         sbpscript_results.rc >= 2
+  failed_when:                          sbpscript_results.rc >= 2
   args:
-    creates:                           /etc/sap_deployment_automation/sbpinstalled.txt
-    chdir:                             "{{ target_media_location }}/SBP"
+    creates:                            /etc/sap_deployment_automation/sbpinstalled.txt
+    chdir:                              "{{ target_media_location }}/SBP"
     executable:                         /bin/csh
-  tags:
-    - skip_ansible_lint
 
 - name:                                 "ORACLE (sharedHome): Post processing installer output"
   ansible.builtin.debug:

--- a/deploy/ansible/roles-db/4.2.0-db2-install/tasks/main.yml
+++ b/deploy/ansible/roles-db/4.2.0-db2-install/tasks/main.yml
@@ -76,8 +76,6 @@
         tier:                          "db2S"
         db2_memory:                    "{{ mem_size | int }}"
         param_directory:               "{{ dir_params }}"
-      tags:
-        - skip_ansible_lint
     # +--------------------------------4--------------------------------------*/
     #
     # - name:                            "SAP DB2 install: variables"
@@ -119,8 +117,6 @@
         DB2TMPDIR:                     "{{ tmp_directory }}"
       register:                        db2_installation
       failed_when:                     db2_installation.rc > 0
-      tags:
-        - skip_ansible_lint
       # 2570458 - DB6: Depooling report RUTPOADAPT fails with SQL -912
 
     - name:                            "DB2 Install - Set LOCK variable for PAS"

--- a/deploy/ansible/roles-db/4.2.0-db2-install/tasks/main.yml
+++ b/deploy/ansible/roles-db/4.2.0-db2-install/tasks/main.yml
@@ -116,6 +116,7 @@
         creates:                       "/etc/sap_deployment_automation/{{ sap_sid | upper }}/sap_deployment_db2.txt"
       environment:
         TMPDIR:                        "{{ tmp_directory }}/{{ sap_sid | upper }}"
+        DB2TMPDIR:                     "{{ tmp_directory }}"
       register:                        db2_installation
       failed_when:                     db2_installation.rc > 0
       tags:

--- a/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.0-db2_ha_install_primary.yml
+++ b/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.0-db2_ha_install_primary.yml
@@ -135,6 +135,7 @@
         creates:                       "/etc/sap_deployment_automation/{{ sap_sid | upper }}/sap_deployment_db2.txt"
       environment:
         TMPDIR:                        "{{ tmp_directory }}/{{ sap_sid | upper }}"
+        DB2TMPDIR:                     "{{ tmp_directory }}"
       register:                        db2_installation
       failed_when:                     db2_installation.rc > 0
       tags:

--- a/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.0-db2_ha_install_primary.yml
+++ b/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.0-db2_ha_install_primary.yml
@@ -97,13 +97,10 @@
         db2_encryption_keystore_dir:   /db2/db2{{ db_sid }}/keystore
         db2_sslencryption_label:       "sap_db2{{ db_sid }}_{{ sap_db_hostname }}_ssl_comm_000"
         sap_scs_hostname:              "{{ query('inventory_hostnames', '{{ sap_sid | upper }}_SCS') | first }}"
-        tier:                          "{{ tier }}"
         sap_profile_dir:               "/sapmnt/{{ sap_sid | upper }}/profile"
         param_directory:               "{{ dir_params }}"
         db2_memory:                    "{{ mem_size | int }}"
         always_upload_jinja_templates: false
-      tags:
-        - skip_ansible_lint
 
     - name:                            "SAP DB2 install: variables"
       ansible.builtin.debug:
@@ -138,8 +135,6 @@
         DB2TMPDIR:                     "{{ tmp_directory }}"
       register:                        db2_installation
       failed_when:                     db2_installation.rc > 0
-      tags:
-        - skip_ansible_lint
 
     - name:                            "SAP DB2 Install: progress"
       ansible.builtin.debug:

--- a/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.2-db2_ha_install_secondary.yml
+++ b/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.2-db2_ha_install_secondary.yml
@@ -121,6 +121,7 @@
         creates:                       "/etc/sap_deployment_automation/{{ sap_sid | upper }}/sap_deployment_db2.txt"
       environment:
         TMPDIR:                        "{{ tmp_directory }}/{{ sap_sid | upper }}"
+        DB2TMPDIR:                     "{{ tmp_directory }}"
       register:                        db2_installation
       failed_when:                     db2_installation.rc > 0
       tags:

--- a/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.2-db2_ha_install_secondary.yml
+++ b/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.2-db2_ha_install_secondary.yml
@@ -84,13 +84,10 @@
         db2_sslencryption_label:       "sap_db2{{ db_sid }}_{{ sap_db_hostname }}_ssl_comm_000"
         sap_scs_hostname:               "{{ query('inventory_hostnames', '{{ sap_sid | upper }}_SCS') | first }}"
         sap_profile_dir:               "/sapmnt/{{ sap_sid | upper }}/profile"
-        tier:                          "{{ tier }}"
         param_directory:               "{{ dir_params }}"
         db2_memory:                    "{{ mem_size | int }}"
         always_upload_jinja_templates: false
 
-      tags:
-        - skip_ansible_lint
 # +------------------------------------4--------------------------------------*/
 
     - name:                            "SAP DB2 install Secondary: variables"
@@ -124,8 +121,6 @@
         DB2TMPDIR:                     "{{ tmp_directory }}"
       register:                        db2_installation
       failed_when:                     db2_installation.rc > 0
-      tags:
-        - skip_ansible_lint
 
     - name:                            "SAP DB2 Install: progress"
       ansible.builtin.debug:

--- a/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.6-db2_post_install_checks.yaml
+++ b/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.6-db2_post_install_checks.yaml
@@ -3,7 +3,7 @@
 
 - name:                                "DB2 Primary Instance: - Ensure replication status is active"
   become_user:                         db2{{ db_sid | lower }}
-  ansible.builtin.shell:               db2pd -hadr -db {{ db_sid | upper }} | grep -e 'HADR_STATE = PEER' -e 'HADR_CONNECT_STATUS = CONNECTED'
+  ansible.builtin.shell:               set -o pipefail && db2pd -hadr -db {{ db_sid | upper }} | grep -e 'HADR_STATE = PEER' -e 'HADR_CONNECT_STATUS = CONNECTED'
   register:                            grep_result
   until:                               grep_result.rc == 0 or grep_result.rc == 1
   failed_when:                         grep_result.rc != 0 and grep_result.rc != 1
@@ -11,8 +11,6 @@
   retries:                             5
   delay:                               5
   when:                                ansible_hostname == primary_instance_name
-  tags:
-    - skip_ansible_lint
 
 - name:                                "DB2 Primary Instance  Replication - Status"
   ansible.builtin.debug:
@@ -21,7 +19,7 @@
 
 - name:                                "DB2 Secondary Instance: - Ensure replication status is active"
   become_user:                         db2{{ db_sid | lower }}
-  ansible.builtin.shell:               db2pd -hadr -db {{ db_sid | upper }} | grep -e 'HADR_STATE = PEER' -e 'HADR_CONNECT_STATUS = CONNECTED'
+  ansible.builtin.shell:               set -o pipefail && db2pd -hadr -db {{ db_sid | upper }} | grep -e 'HADR_STATE = PEER' -e 'HADR_CONNECT_STATUS = CONNECTED'
   register:                            grep_result
   until:                               grep_result.rc == 0 or grep_result.rc == 1
   failed_when:                         grep_result.rc != 0 and grep_result.rc != 1
@@ -29,8 +27,6 @@
   retries:                             5
   delay:                               5
   when:                                ansible_hostname == secondary_instance_name
-  tags:
-    - skip_ansible_lint
 
 - name:                                "DB2 Secondary Instance Replication - Status"
   ansible.builtin.debug:

--- a/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.2.0-cluster-RedHat.yml
+++ b/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.2.0-cluster-RedHat.yml
@@ -79,8 +79,7 @@
       delay:                           10
       until:                           "(primary_instance_name + ' ' + secondary_instance_name) in cluster_stable_check.stdout or (secondary_instance_name + ' ' + primary_instance_name) in cluster_stable_check.stdout"
       when:                            ansible_distribution_major_version != "8"
-      tags:
-        - skip_ansible_lint
+
     # '*' is a special character in regexp and needs to be escaped for literal matching
     # if we are worried about character spacing across distros we can match for '\* Online:'
     - name:                            "1.17 Generic Pacemaker - Wait until cluster has stabilized"
@@ -90,8 +89,6 @@
       delay:                           10
       until:                           "(primary_instance_name + ' ' + secondary_instance_name) in cluster_stable_check.stdout or (secondary_instance_name + ' ' + primary_instance_name) in cluster_stable_check.stdout"
       when:                            ansible_distribution_major_version == "8"
-      tags:
-        - skip_ansible_lint
 
     - name:                            "1.17 Generic Pacemaker - Ensure the expected quorum votes is set for the cluster"
       ansible.builtin.command:         pcs quorum expected-votes "{{ cluster_quorum.expected_votes }}"

--- a/deploy/ansible/roles-os/1.3-repository/vars/repos.yaml
+++ b/deploy/ansible/roles-os/1.3-repository/vars/repos.yaml
@@ -20,6 +20,7 @@ repos:
   #  - { tier:   'os', repo: 'epel', url: 'https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm', state: 'absent' }
   redhat8.4:
   redhat8.6:
+  redhat8.7:
   # do not have any repos that are needed for RedHat at the moment.
   sles_sap12.3:
   sles_sap12.4:

--- a/deploy/ansible/roles-os/1.4-packages/tasks/main.yaml
+++ b/deploy/ansible/roles-os/1.4-packages/tasks/main.yaml
@@ -106,8 +106,6 @@
 #    name:                              'python-xml'
 #    state:                             latest
 #  when:                                distribution_id in ['suse15', 'sles_sap15']
-#  tags:
-#    - skip_ansible_lint
 
 # Analyse the package list for this distribution selecting only those
 # packages assigned to the active tier or 'all'.
@@ -292,8 +290,6 @@
     - ansible_os_family == 'Suse'
     - upgrade_packages is defined
     - upgrade_packages
-  tags:
-    - skip_ansible_lint
 
 - name:                                "1.4 Packages: - Upgrade all: {{ distribution_full_id }}"  # noqa package-latest
   become:                              true
@@ -305,9 +301,6 @@
     - ansible_os_family == 'Redhat'
     - upgrade_packages is defined
     - upgrade_packages
-  tags:
-    - skip_ansible_lint
-
 
 # /*----------------------------------------------------------------------------8
 # |                                    END                                      |

--- a/deploy/ansible/roles-os/1.4-packages/vars/os-packages.yaml
+++ b/deploy/ansible/roles-os/1.4-packages/vars/os-packages.yaml
@@ -160,6 +160,8 @@ packages:
     - { tier: 'ha',    package: 'fence-agents-azure-arm',                       node_tier: 'all',     state: 'present' }
   redhat8.6:
     - { tier: 'ha',    package: 'fence-agents-azure-arm',                       node_tier: 'all',     state: 'present' }
+  redhat8.7:
+    - { tier: 'ha',    package: 'fence-agents-azure-arm',                       node_tier: 'all',     state: 'present' }
   sles_sap12:
     - { tier: 'os',    package: 'chrony',                                       node_tier: 'all',     state: 'present' }
     - { tier: 'os',    package: 'glibc',                                        node_tier: 'all',     state: 'present' }

--- a/deploy/ansible/roles-os/1.5.1-disk-setup-asm/tasks/main.yml
+++ b/deploy/ansible/roles-os/1.5.1-disk-setup-asm/tasks/main.yml
@@ -401,8 +401,6 @@
       register:                            datadiskcreated
       args:
         creates:      "/etc/sap_deployment_automation/asmdatadisks.txt"
-      tags:
-        - skip_ansible_lint
 
     - name:                            Print datadiskcreated
       ansible.builtin.debug:
@@ -469,15 +467,13 @@
       register:                        archdiskcreated
       args:
         creates:                       "/etc/sap_deployment_automation/asmarchdisks.txt"
-      tags:
-        - skip_ansible_lint
 
     - name:                            "ORACLE ASM: Initialize ASM DISKS ARCH File"
       ansible.builtin.file:
         path:                          "/etc/sap_deployment_automation/asmarchdisks.txt"
         state:                         touch
         mode:                          0755
-      #when:                                archdiskcreated == 0
+      # when:                                archdiskcreated == 0
 
     - name:                            "ORACLE ASM: Print archdiskcreated"
       ansible.builtin.debug:
@@ -529,15 +525,13 @@
       register:                        recodiskcreated
       args:
         creates:                       "/etc/sap_deployment_automation/asmrecodisks.txt"
-      tags:
-        - skip_ansible_lint
 
     - name:                            "ORACLE ASM: Initialize ASM DISKS RECO File"
       ansible.builtin.file:
         path:                          "/etc/sap_deployment_automation/asmrecodisks.txt"
         state:                         touch
         mode:                          0755
-      #when:                                recodiskcreated == 0
+      # when:                                recodiskcreated == 0
 
     - name:                            "ORACLE ASM: Print recodiskcreated"
       ansible.builtin.debug:
@@ -582,5 +576,4 @@
         mode:                          '755'
       loop:                            '{{ recodisklist }}'
 
-
-  #when: not oracleasm_initialised.stat.exists
+  # when: not oracleasm_initialised.stat.exists

--- a/deploy/ansible/roles-sap-os/2.10-sap-notes/tasks/grub_editor.yaml
+++ b/deploy/ansible/roles-sap-os/2.10-sap-notes/tasks/grub_editor.yaml
@@ -12,7 +12,6 @@
     line:                              'GRUB_CMDLINE_LINUX="\1{{ item.key }}={{ item.value }}\2'
     backrefs:                          true
   when: item.key in grub_config_file_content
-  tags: skip_ansible_lint
 
 - name:                                "2.10 sap-notes: - Add the argument if it does not exist"
   ansible.builtin.lineinfile:

--- a/deploy/ansible/roles-sap-os/2.5-sap-users/tasks/user_nw.yaml
+++ b/deploy/ansible/roles-sap-os/2.5-sap-users/tasks/user_nw.yaml
@@ -89,8 +89,6 @@
     sap_appVirtualHostname:
     param_directory:                   "{{ dir_params }}"
     sidadm_uid:                        "{{ sid_to_be_deployed.sidadm_uid }}"
-  tags:
-    - skip_ansible_lint
 
 - name:                                "User Creation: install variables"
   ansible.builtin.debug:
@@ -141,8 +139,6 @@
         TMPDIR:                        "{{ tmp_directory }}/{{ sid_to_be_deployed.sid | upper }}"
       register:                        generic_user_creation
       failed_when:                     generic_user_creation.rc > 0
-      tags:
-        - skip_ansible_lint
 
     - name:                            "User Creation: Installation results"
       ansible.builtin.debug:

--- a/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.0-afs-mounts.yaml
+++ b/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.0-afs-mounts.yaml
@@ -141,8 +141,6 @@
             state:                     absent
       when:
         - sap_mnt is defined
-      tags:
-        - skip_ansible_lint
   when:
     - tier == 'sapos'
     - "'scs' in supported_tiers"
@@ -151,21 +149,21 @@
   ansible.builtin.include_tasks:       2.6.0.1-afs-mount.yaml
   loop:
     - {
-      'type':              'install',
-      'temppath':          'sapinstall',
-      'folder':            '{{ bom_base_name }}',
-      'mount':             '{{ usr_sap_install_mountpoint }}',
-      'opts':              'rw,hard,rsize=65536,wsize=65536,sec=sys,vers=4.1,tcp',
-      'path':              '/usr/sap/install',
-      'permissions':       '0775',
-      'set_chattr_on_dir': false,
-      'target_nodes':      ['all'],
-      'create_temp_folders': true 
+      'type':               'install',
+      'temppath':           'sapinstall',
+      'folder':             '{{ bom_base_name }}',
+      'mount':              '{{ usr_sap_install_mountpoint }}',
+      'opts':               'rw,hard,rsize=65536,wsize=65536,sec=sys,vers=4.1,tcp',
+      'path':               '/usr/sap/install',
+      'permissions':        '0775',
+      'set_chattr_on_dir':  false,
+      'target_nodes':       ['all'],
+      'create_temp_folders': true
     }
   vars:
     primary_host:                     "{{ first_server_temp | first }}"
   when:
-    - tier == 'sapos' 
+    - tier == 'sapos'
     - usr_sap_install_mountpoint is defined
 
 - name:                                "AFS Mount: sap_mnt"
@@ -180,8 +178,6 @@
         state:                         directory
       register:                        is_created_now
       loop:                            "{{ all_sap_mounts }}"
-      tags:
-        - skip_ansible_lint
 
     - name:                            "AFS Mount: Change attribute only when we create SAP Directories (sapmnt)"
       ansible.builtin.file:
@@ -193,8 +189,6 @@
       when:
         - item.item is changed
       register: set_immutable_attribute
-      tags:
-        - skip_ansible_lint
   when:
     - tier == 'sapos'
     - node_tier != 'hana'
@@ -233,8 +227,6 @@
       when:
         - item.item is changed
       register: set_immutable_attribute
-      tags:
-        - skip_ansible_lint
   when:
     - tier == 'sapos'
     - "'scs' in supported_tiers or 'ers' in supported_tiers "

--- a/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.0.1-afs-mount.yaml
+++ b/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.0.1-afs-mount.yaml
@@ -97,9 +97,6 @@
     state:                             directory
     recurse:                           true
   register:                            is_created_now
-
-  tags:
-    - skip_ansible_lint
   when:
     - node_tier in item.target_nodes or item.target_nodes == ['all']
 
@@ -119,8 +116,6 @@
     - node_tier in item.target_nodes or item.target_nodes == "all"
     - is_created_now.changed
     - item.set_chattr_on_dir
-  tags:
-    - skip_ansible_lint
 
 - name:                                "AFS Mount"
   when:
@@ -144,4 +139,3 @@
         fstype:                        "nfs4"
         opts:                          "{{ item.opts }}"
         state:                         mounted
-

--- a/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.1-anf-mounts.yaml
+++ b/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.1-anf-mounts.yaml
@@ -174,8 +174,6 @@
         state:                         directory
         mode:                          0755
         group:                         sapsys
-      tags:
-        - skip_ansible_lint
 
     - name:                            "ANF Mount: (sapmnt)"
       block:
@@ -269,8 +267,6 @@
     state:                             directory
   register: is_created_now
   loop:                                "{{ all_sap_mounts }}"
-  tags:
-    - skip_ansible_lint
   when:
     - tier == 'sapos'
     - node_tier in ['app','scs','ers', 'pas'] or 'scs' in supported_tiers
@@ -287,8 +283,6 @@
     - tier == 'sapos'
     - item.item is changed
   register: set_immutable_attribute
-  tags:
-    - skip_ansible_lint
 
 - name:                                "ANF Mount: Create SAP Directories (scs & ers)"
   ansible.builtin.file:
@@ -320,8 +314,6 @@
     - tier == 'sapos'
     - item.item is changed
   register: set_immutable_attribute
-  tags:
-    - skip_ansible_lint
 
 - name:                                "ANF Mount: sapmnt/{{ sap_sid | upper }} - Standalone"
   ansible.posix.mount:

--- a/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.1.1-anf-mount.yaml
+++ b/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.1.1-anf-mount.yaml
@@ -87,9 +87,6 @@
     state:                             directory
     recurse:                           true
   register:                            is_created_now
-
-  tags:
-    - skip_ansible_lint
   when:
     - node_tier in item.target_nodes or item.target_nodes == ['all']
 
@@ -109,8 +106,6 @@
     - node_tier in item.target_nodes or item.target_nodes == "all"
     - is_created_now.changed
     - item.set_chattr_on_dir
-  tags:
-    - skip_ansible_lint
 
 - name:                                "ANF Mount: ({{ item.path }} on {% if item.create_temp_folders %}{{ item.mount }}/{{ item.folder }}{% else %}{{ item.mount }}{% endif %})"
   ansible.posix.mount:

--- a/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/main.yaml
+++ b/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/main.yaml
@@ -323,7 +323,7 @@
   ansible.builtin.import_tasks:        2.6.0-afs-mounts.yaml
   when:
     - sap_mnt is defined or sap_trans is defined or usr_sap_install_mountpoint is defined
-    - NFS_provider != 'ANF'
+    - NFS_provider == 'AFS'
 
 
 # Import this task only if the sap_mnt is defined, i.e. ANF is used
@@ -343,8 +343,7 @@
 - name:                                "2.6 SAP Mounts: - Set permissions"
   become:                               true
   become_user:                          root
-  when:
-    - node_tier == "hana"
+  when:                                 node_tier == "hana"
   block:
     - name:                            "2.6 SAP Mounts: - Set permissions on hana folders"
       ansible.builtin.file:

--- a/deploy/ansible/roles-sap/0.1-bom-validator/tasks/bom_download.yaml
+++ b/deploy/ansible/roles-sap/0.1-bom-validator/tasks/bom_download.yaml
@@ -283,7 +283,6 @@
             - name:                        "BOM: Line"
               ansible.builtin.blockinfile:
                 path:                      "{{ bom_file }}"
-                regexp:                    '      archive:      {{ bom_media_entry.archive }}'
                 insertafter:               '      archive:      {{ bom_media_entry.archive }}'
                 block:                     "      checksum:     {{ fs_check.stat.checksum }}"
                 marker:                    "# {mark} ANSIBLE MANAGED BLOCK {{ bom_media_entry.archive }}"
@@ -291,8 +290,6 @@
                 - fs_check is defined
                 - create_checksums is defined
                 - bom_file is defined
-              tags:
-              - skip_ansible_lint
 # Step: 05-03-02-01 - END
 # -------------------------------------+---------------------------------------8
 
@@ -335,8 +332,6 @@
                 bom:                                "{{ bom_update }}"
               vars:
                 bom_update:                         "{#- -#}{% set _ = bom.materials.media[bom_media_index].update({'checksum': fs_check.stat.checksum}) -%} {{ bom }}"
-              tags:
-               - skip_ansible_lint
         # Step: 05-03-03-01 - END
 
 # -------------------------------------+---------------------------------------8

--- a/deploy/ansible/roles-sap/0.1-bom-validator/tasks/dynamic_bom_processing.yaml
+++ b/deploy/ansible/roles-sap/0.1-bom-validator/tasks/dynamic_bom_processing.yaml
@@ -68,7 +68,7 @@
 
 # -------------------------------------+---------------------------------------8
 # Step: 03-01
-    - name:                                 "Dynamic processing - Show media entry"
+    - name:                                 "Dynamic processing - Show media entry"  # noqa jinja[spacing]
       ansible.builtin.debug:
         msg: |-
                                             Name:     {{ bom_media_entry.name }}
@@ -99,7 +99,7 @@
 # Step: 03-03
 # Description:
 #
-    - name:                                 "Dynamic processing - Update BOM"
+    - name:                                 "Dynamic processing - Update BOM"  # noqa jinja[spacing]
       ansible.builtin.set_fact:
         bom:                                "{{ bom_update }}"
       vars:
@@ -116,14 +116,7 @@
                                                 | join
                                                 | parse_xml(role_path + '/templates/sap_search.yaml')
                                             }}"
-        platformNumber_list:                "{{ item.Title
-                                                | regex_search(
-                                                                '(?P<prefix>^.*)[-](?P<hwid>.*)[.](?P<suffix>.*$)',
-                                                                '\\g<prefix>',
-                                                                '\\g<hwid>',
-                                                                '\\g<suffix>'
-                                                              )
-                                            }}"
+        platformNumber_list:                "{{ item.Title | regex_search('(?P<prefix>^.*)[-](?P<hwid>.*)[.](?P<suffix>.*$)', '\\g<prefix>', '\\g<hwid>', '\\g<suffix>')}}"
                                             # setting the checksum value to true is used durring download to update field with correct checksum.
         bom_update:                         "
                                             {#-  -#}
@@ -136,8 +129,6 @@
                                             "
       loop:                                 "{{ sap_search_results.entry | flatten(levels = 1) }}"
       when:                                 sap_platform_map_lookup.number == platformNumber_list[1]
-      tags:
-        - skip_ansible_lint
 # Step: 03-03 - END
 # -------------------------------------+---------------------------------------8
 

--- a/deploy/ansible/roles-sap/0.1-bom-validator/tasks/sap_sso_authentication.yaml
+++ b/deploy/ansible/roles-sap/0.1-bom-validator/tasks/sap_sso_authentication.yaml
@@ -2,10 +2,7 @@
 #
 # Description:  SAP SSO Authentication Process
 #
-
-
 # TODO: create a Windows version?
-
 
 # -------------------------------------+---------------------------------------8
 # Step: 01
@@ -82,18 +79,16 @@
       - "signature:                     {{ signature }}"
     verbosity:                          1
   vars:
-    origin:                             "{{ step1Results.url     | regex_search('^http.*?://[^/]+') }}"
-    referer:                            "{{ step1Results.url     | regex_search('^http.*?://[^/]+') }}/"
-    post_action:                        "{{ step1Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> action=\".*?>)',              '\\g<first_part>', '\\g<second_part>') | join | regex_search(' action=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
-    tenantId:                           "{{ step1Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"tenantId\".*?>)',      '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-    idpName:                            "{{ step1Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"idpName\".*?>)',       '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-    requestUrl:                         "{{ step1Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"requestUrl\".*?>)',    '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-    requestId:                          "{{ step1Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"requestId\".*?>)',     '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-    relayState:                         "{{ step1Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"relayState\".*?>)',    '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-    action:                             "{{ step1Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"action\".*?>)',        '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-    signature:                          "{{ step1Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"signature\".*?>)',     '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-  tags:
-    - skip_ansible_lint
+    origin:                             "{{ step1Results.url | regex_search('^http.*?://[^/]+') }}"
+    referer:                            "{{ step1Results.url | regex_search('^http.*?://[^/]+') }}/"
+    post_action:                        "{{ step1Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> action=\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' action=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+    tenantId:                           "{{ step1Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"tenantId\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+    idpName:                            "{{ step1Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"idpName\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+    requestUrl:                         "{{ step1Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"requestUrl\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+    requestId:                          "{{ step1Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"requestId\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+    relayState:                         "{{ step1Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"relayState\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+    action:                             "{{ step1Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"action\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+    signature:                          "{{ step1Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"signature\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
 # Step: 01 - END
 # -------------------------------------+---------------------------------------8
 
@@ -102,13 +97,13 @@
 # Step: 02
 # Description:  Maintain Cookie Jar
 #
-- name:                                 "SAP SSO Logon - Maintain Cookie Jar"
+- name:                                 "SAP SSO Logon - Maintain Cookie Jar"  # noqa no-tabs jinja[spacing]
   ansible.builtin.lineinfile:
     state:                              present
     create:                             true
     path:                               cookie_jar
     mode:                               0644
-    regexp:                             ^#.*?_({{ url|regex_replace('[.]','[.]') }}).*?\s({{ (item.split('=', 1))[0]|trim|regex_replace('[.]','[.]') }})\s
+    regexp:                             ^#.*?_({{ url | regex_replace('[.]', '[.]') }}).*?\s({{ (item.split('=', 1))[0] | trim | regex_replace('[.]', '[.]') }})\s
     line:                               "
                                         {#-  -#}
                                         {% set _cookie = {  'cookie_name':  '',
@@ -125,17 +120,17 @@
                                         {% for element in item.split(';')                              -%}
                                         {%   if loop.index == 1                                        -%}
                                         {%     set sub = element.split('=', 1)                         -%}
-                                        {%     set _ = _cookie.update({'cookie_name':  sub[0]|trim})   -%}
-                                        {%     set _ = _cookie.update({'cookie_value': sub[1]|trim})   -%}
-                                        {%   elif 'PATH' in element.split('=', 1)|trim|upper           -%}
+                                        {%     set _ = _cookie.update({'cookie_name': sub[0] | trim})   -%}
+                                        {%     set _ = _cookie.update({'cookie_value': sub[1] | trim})   -%}
+                                        {%   elif 'PATH' in element.split('=', 1) | trim | upper           -%}
                                         {%     set sub = element.split('=', 1)                         -%}
-                                        {%     set _ = _cookie.update({'Path':         sub[1]|trim})   -%}
-                                        {%   elif 'HTTPONLY' in element|trim|upper                     -%}
+                                        {%     set _ = _cookie.update({'Path':         sub[1] | trim})   -%}
+                                        {%   elif 'HTTPONLY' in element | trim | upper                     -%}
                                         {%     set _ = _cookie.update({'HttpOnly':     'TRUE'})        -%}
-                                        {%   elif 'DOMAIN' in element.split('=', 1)|trim|upper         -%}
+                                        {%   elif 'DOMAIN' in element.split('=', 1) | trim | upper         -%}
                                         {%     set sub = element.split('=', 1)                         -%}
                                         {%     set _ = _cookie.update({'Domain':       'TRUE'})        -%}
-                                        {%     set _ = _cookie.update({'Url':          '.' + sub[1]|trim|regex_search('^[.]?(?P<hostname>.*)$', '\\g<hostname>')|join}) -%}
+                                        {%     set _ = _cookie.update({'Url':          '.' + sub[1] | trim | regex_search('^[.]?(?P<hostname>.*)$', '\\g<hostname>') | join}) -%}
                                         {%   endif                                                     -%}
                                         {% endfor                                                      -%}
                                         {% if not _cookie.Url                                          -%}
@@ -153,13 +148,9 @@
   loop:                                 "{{ set_cookie_string_filtered.split(',') }}"
   vars:
     set_cookie_string_filtered:         "{{ step1Results.set_cookie | regex_replace('Expires=(?P<day>...),', 'Expires=\\g<day>%2C') }}"
-    url:                                "{{ step1Results.url|urlsplit('hostname') }}"
-  tags:
-    - skip_ansible_lint
+    url:                                "{{ step1Results.url | urlsplit('hostname') }}"
 # Step: 02 - END
 # -------------------------------------+---------------------------------------8
-
-
 
 # -------------------------------------+---------------------------------------8
 # Step: 03
@@ -204,7 +195,7 @@
 #     Connection: keep-alive              | Connection: close
 #     Keep-Alive: timeout=20              |
 # -------------------------------------+---------------------------------------8
-    - name:                                 "SAP SSO Logon - Step 2 - Get SAML request"
+    - name:                                 "SAP SSO Logon - Step 2 - Get SAML request"  # noqa jinga[spacing]
       ansible.builtin.uri:
         url:                                "{{ post_action }}"
         method:                             POST
@@ -235,20 +226,17 @@
         force:                              true
         return_content:                     true
       vars:
-        origin:                             "{{ step1Results.url     | regex_search('^http.*?://[^/]+') }}"
-        referer:                            "{{ step1Results.url     | regex_search('^http.*?://[^/]+') }}/"
-        post_action:                        "{{ step1Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> action=\".*?>)',              '\\g<first_part>', '\\g<second_part>') | join | regex_search(' action=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
-        tenantId:                           "{{ step1Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"tenantId\".*?>)',      '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        idpName:                            "{{ step1Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"idpName\".*?>)',       '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        requestUrl:                         "{{ step1Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"requestUrl\".*?>)',    '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        requestId:                          "{{ step1Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"requestId\".*?>)',     '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        relayState:                         "{{ step1Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"relayState\".*?>)',    '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        action:                             "{{ step1Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"action\".*?>)',        '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        signature:                          "{{ step1Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"signature\".*?>)',     '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
+        origin:                             "{{ step1Results.url | regex_search('^http.*?://[^/]+') }}"
+        referer:                            "{{ step1Results.url | regex_search('^http.*?://[^/]+') }}/"
+        post_action:                        "{{ step1Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> action=\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' action=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        tenantId:                           "{{ step1Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"tenantId\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        idpName:                            "{{ step1Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"idpName\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        requestUrl:                         "{{ step1Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"requestUrl\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        requestId:                          "{{ step1Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"requestId\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        relayState:                         "{{ step1Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"relayState\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        action:                             "{{ step1Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"action\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        signature:                          "{{ step1Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"signature\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
       register:                             step2Results
-      tags:
-        - skip_ansible_lint
-
 
     - name:                                 "SAP SSO Logon - Step 2 - Show data"
       ansible.builtin.debug:
@@ -260,29 +248,25 @@
           - "RelayState:                    {{ RelayState }}"
         verbosity:                          1
       vars:
-        origin:                             "{{ step2Results.url     | regex_search('^http.*?://[^/]+') }}"
-        referer:                            "{{ step2Results.url     | regex_search('^http.*?://[^/]+') }}/"
-        post_action:                        "{{ step2Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> action=\".*?>)',              '\\g<first_part>', '\\g<second_part>') | join | regex_search(' action=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
-        SAMLRequest:                        "{{ step2Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"SAMLRequest\".*?>)',   '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        RelayState:                         "{{ step2Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"RelayState\".*?>)',    '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-      tags:
-        - skip_ansible_lint
+        origin:                             "{{ step2Results.url | regex_search('^http.*?://[^/]+') }}"
+        referer:                            "{{ step2Results.url | regex_search('^http.*?://[^/]+') }}/"
+        post_action:                        "{{ step2Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> action=\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' action=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        SAMLRequest:                        "{{ step2Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"SAMLRequest\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        RelayState:                         "{{ step2Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"RelayState\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
 # Step: 03-01 - END
 # -------------------------------------+---------------------------------------8
-
-
 
 # -------------------------------------+---------------------------------------8
 # Step: 03-02
 # Description:  Maintain Cookie Jar
 #
-    - name:                                 "SAP SSO Logon - Step 2 - Maintain Cookie Jar"
+    - name:                                 "SAP SSO Logon - Step 2 - Maintain Cookie Jar"  # noqa no-tabs jinja[spacing]
       ansible.builtin.lineinfile:
         state:                              present
         create:                             true
         path:                               cookie_jar
         mode:                               0644
-        regexp:                             ^#.*?_({{ url|regex_replace('[.]','[.]') }}).*?\s({{ (item.split('=', 1))[0]|trim|regex_replace('[.]','[.]') }})\s
+        regexp:                             ^#.*?_({{ url | regex_replace('[.]', '[.]') }}).*?\s({{ (item.split('=', 1))[0] | trim | regex_replace('[.]', '[.]') }})\s
         line:                               "
                                             {#-  -#}
                                             {% set _cookie = {  'cookie_name':  '',
@@ -299,17 +283,17 @@
                                             {% for element in item.split(';')                              -%}
                                             {%   if loop.index == 1                                        -%}
                                             {%     set sub = element.split('=', 1)                         -%}
-                                            {%     set _ = _cookie.update({'cookie_name':  sub[0]|trim})   -%}
-                                            {%     set _ = _cookie.update({'cookie_value': sub[1]|trim})   -%}
-                                            {%   elif 'PATH' in element.split('=', 1)|trim|upper           -%}
+                                            {%     set _ = _cookie.update({'cookie_name':  sub[0] | trim})   -%}
+                                            {%     set _ = _cookie.update({'cookie_value': sub[1] | trim})   -%}
+                                            {%   elif 'PATH' in element.split('=', 1) | trim | upper           -%}
                                             {%     set sub = element.split('=', 1)                         -%}
-                                            {%     set _ = _cookie.update({'Path':         sub[1]|trim})   -%}
-                                            {%   elif 'HTTPONLY' in element|trim|upper                     -%}
+                                            {%     set _ = _cookie.update({'Path':         sub[1] | trim})   -%}
+                                            {%   elif 'HTTPONLY' in element | trim | upper                     -%}
                                             {%     set _ = _cookie.update({'HttpOnly':     'TRUE'})        -%}
-                                            {%   elif 'DOMAIN' in element.split('=', 1)|trim|upper         -%}
+                                            {%   elif 'DOMAIN' in element.split('=', 1) | trim | upper         -%}
                                             {%     set sub = element.split('=', 1)                         -%}
                                             {%     set _ = _cookie.update({'Domain':       'TRUE'})        -%}
-                                            {%     set _ = _cookie.update({'Url':          '.' + sub[1]|trim|regex_search('^[.]?(?P<hostname>.*)$', '\\g<hostname>')|join}) -%}
+                                            {%     set _ = _cookie.update({'Url':          '.' + sub[1] | trim | regex_search('^[.]?(?P<hostname>.*)$', '\\g<hostname>') | join}) -%}
                                             {%   endif                                                     -%}
                                             {% endfor                                                      -%}
                                             {% if not _cookie.Url                                          -%}
@@ -327,13 +311,9 @@
       loop:                                 "{{ set_cookie_string_filtered.split(',') }}"
       vars:
         set_cookie_string_filtered:         "{{ step2Results.set_cookie | regex_replace('Expires=(?P<day>...),', 'Expires=\\g<day>%2C') }}"
-        url:                                "{{ step2Results.url|urlsplit('hostname') }}"
-      tags:
-        - skip_ansible_lint
+        url:                                "{{ step2Results.url | urlsplit('hostname') }}"
 # Step: 03-02 - END
 # -------------------------------------+---------------------------------------8
-
-
 
 # -------------------------------------+---------------------------------------8
 # Step: 03-03
@@ -407,21 +387,16 @@
         force:                                true
         return_content:                       true
       vars:
-        origin:                               "{{ step2Results.url     | regex_search('^http.*?://[^/]+') }}"
-        referer:                              "{{ step2Results.url     | regex_search('^http.*?://[^/]+') }}/"
-        post_action:                          "{{ step2Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> action=\".*?>)',           '\\g<first_part>', '\\g<second_part>') | join | regex_search(' action=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
-        SAMLRequest:                          "{{ step2Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"SAMLRequest\".*?>)',   '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        RelayState:                           "{{ step2Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"RelayState\".*?>)',    '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
+        origin:                               "{{ step2Results.url | regex_search('^http.*?://[^/]+') }}"
+        referer:                              "{{ step2Results.url | regex_search('^http.*?://[^/]+') }}/"
+        post_action:                          "{{ step2Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> action=\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' action=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        SAMLRequest:                          "{{ step2Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"SAMLRequest\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        RelayState:                           "{{ step2Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"RelayState\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
       register:                               step3Results
-      tags:
-        - skip_ansible_lint
-
 
     - name:                                   "SAP SSO Logon - Step 3 - Store cookies for accounts.sap.com"
       ansible.builtin.set_fact:
         cookies_accounts_sap_com:             "{{ step3Results.cookies }}"
-
-
 
     - name:                                   "SAP SSO Logon - Step 3 - Show data"
       ansible.builtin.debug:
@@ -450,49 +425,45 @@
           - "cookies_accounts_sap_com_string: {{ cookies_accounts_sap_com_string }}"
         verbosity:                            1
       vars:
-        origin:                               "{{ step3Results.url     | regex_search('^http.*?://[^/]+') }}"
-        referer:                              "{{ step3Results.url     | regex_search('^http.*?://[^/]+') }}/"
-        post_action:                          "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> action=\".*?>)',                         '\\g<first_part>', '\\g<second_part>') | join                              | regex_search(' action=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        origin:                               "{{ step3Results.url | regex_search('^http.*?://[^/]+') }}"
+        referer:                              "{{ step3Results.url | regex_search('^http.*?://[^/]+') }}/"
+        post_action:                          "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> action=\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' action=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
         post_url:                             "{{ origin }}{{ post_action }}"
-        authenticity_token:                   "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"authenticity_token\".*?>)',       '\\g<first_part>', '\\g<second_part>') | join                              | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        xsrfProtection:                       "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"xsrfProtection\".*?>)',           '\\g<first_part>', '\\g<second_part>') | join                              | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        method:                               "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"method\".*?>)',                   '\\g<first_part>', '\\g<second_part>') | join                              | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        idpSSOEndpoint:                       "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"idpSSOEndpoint\".*?>)',           '\\g<first_part>', '\\g<second_part>') | join                              | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        SAMLRequest:                          "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"SAMLRequest\".*?>)',              '\\g<first_part>', '\\g<second_part>') | join                              | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        RelayState:                           "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"RelayState\".*?>)',               '\\g<first_part>', '\\g<second_part>') | join                              | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        targetUrl:                            "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.targetUrl..*?>)',                  '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        sourceUrl:                            "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.sourceUrl..*?>)',                  '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        org:                                  "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.org..*?>)',                        '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        spId:                                 "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.spId..*?>)',                       '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        spName:                               "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.spName..*?>)',                     '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        mobileSSOToken:                       "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.mobileSSOToken..*?>)',             '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        tfaToken:                             "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.tfaToken..*?>)',                   '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        css:                                  "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.css..*?>)',                        '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        passwordlessAuthnSelected:            "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.passwordlessAuthnSelected..*?>)',  '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
+        authenticity_token:                   "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"authenticity_token\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        xsrfProtection:                       "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"xsrfProtection\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        method:                               "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"method\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        idpSSOEndpoint:                       "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"idpSSOEndpoint\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        SAMLRequest:                          "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"SAMLRequest\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        RelayState:                           "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"RelayState\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        targetUrl:                            "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.targetUrl..*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        sourceUrl:                            "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.sourceUrl..*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        org:                                  "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.org..*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        spId:                                 "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.spId..*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        spName:                               "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.spName..*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        mobileSSOToken:                       "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.mobileSSOToken..*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        tfaToken:                             "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.tfaToken..*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        css:                                  "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.css..*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        passwordlessAuthnSelected:            "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.passwordlessAuthnSelected..*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
         j_username:                           "{{ s_user }}"
-        cookies_accounts_sap_com_string:      "{{ cookies_accounts_sap_com.keys()        |
+        cookies_accounts_sap_com_string:      "{{ cookies_accounts_sap_com.keys() |
                                                   zip(cookies_accounts_sap_com.values()) |
-                                                  map('join', '=')                       |
+                                                  map('join', '=') |
                                                   join('; ')
                                                 }}"
-      tags:
-        - skip_ansible_lint
 # Step: 03-03 - END
 # -------------------------------------+---------------------------------------8
-
-
 
 # -------------------------------------+---------------------------------------8
 # Step: 03-04
 # Description:  Maintain Cookie Jar
 #
-    - name:                                 "SAP SSO Logon - Step 3 - Maintain Cookie Jar"
+    - name:                                 "SAP SSO Logon - Step 3 - Maintain Cookie Jar"  # noqa no-tabs jinja[spacing]
       ansible.builtin.lineinfile:
         state:                              present
         create:                             true
         path:                               cookie_jar
         mode:                               0644
-        regexp:                             ^#.*?_({{ url|regex_replace('[.]','[.]') }}).*?\s({{ (item.split('=', 1))[0]|trim|regex_replace('[.]','[.]') }})\s
+        regexp:                             ^#.*?_({{ url | regex_replace('[.]', '[.]') }}).*?\s({{ (item.split('=', 1))[0] | trim | regex_replace('[.]', '[.]') }})\s
         line:                               "
                                             {#-  -#}
                                             {% set _cookie = {  'cookie_name':  '',
@@ -509,17 +480,17 @@
                                             {% for element in item.split(';')                              -%}
                                             {%   if loop.index == 1                                        -%}
                                             {%     set sub = element.split('=', 1)                         -%}
-                                            {%     set _ = _cookie.update({'cookie_name':  sub[0]|trim})   -%}
-                                            {%     set _ = _cookie.update({'cookie_value': sub[1]|trim})   -%}
-                                            {%   elif 'PATH' in element.split('=', 1)|trim|upper           -%}
+                                            {%     set _ = _cookie.update({'cookie_name':  sub[0] | trim})   -%}
+                                            {%     set _ = _cookie.update({'cookie_value': sub[1] | trim})   -%}
+                                            {%   elif 'PATH' in element.split('=', 1) | trim | upper           -%}
                                             {%     set sub = element.split('=', 1)                         -%}
-                                            {%     set _ = _cookie.update({'Path':         sub[1]|trim})   -%}
-                                            {%   elif 'HTTPONLY' in element|trim|upper                     -%}
+                                            {%     set _ = _cookie.update({'Path':         sub[1] | trim})   -%}
+                                            {%   elif 'HTTPONLY' in element | trim | upper                     -%}
                                             {%     set _ = _cookie.update({'HttpOnly':     'TRUE'})        -%}
-                                            {%   elif 'DOMAIN' in element.split('=', 1)|trim|upper         -%}
+                                            {%   elif 'DOMAIN' in element.split('=', 1) | trim | upper         -%}
                                             {%     set sub = element.split('=', 1)                         -%}
                                             {%     set _ = _cookie.update({'Domain':       'TRUE'})        -%}
-                                            {%     set _ = _cookie.update({'Url':          '.' + sub[1]|trim|regex_search('^[.]?(?P<hostname>.*)$', '\\g<hostname>')|join}) -%}
+                                            {%     set _ = _cookie.update({'Url':          '.' + sub[1] | trim | regex_search('^[.]?(?P<hostname>.*)$', '\\g<hostname>') | join}) -%}
                                             {%   endif                                                     -%}
                                             {% endfor                                                      -%}
                                             {% if not _cookie.Url                                          -%}
@@ -537,14 +508,9 @@
       loop:                                 "{{ set_cookie_string_filtered.split(',') }}"
       vars:
         set_cookie_string_filtered:         "{{ step3Results.set_cookie | regex_replace('Expires=(?P<day>...),', 'Expires=\\g<day>%2C') }}"
-        url:                                "{{ step3Results.url|urlsplit('hostname') }}"
-      tags:
-        - skip_ansible_lint
+        url:                                "{{ step3Results.url | urlsplit('hostname') }}"
 # Step: 03-04 - END
 # -------------------------------------+---------------------------------------8
-
-
-
 
 # -------------------------------------+---------------------------------------8
 # Step: 03-05
@@ -652,35 +618,32 @@
         force:                              true
         return_content:                     true
       vars:
-        origin:                             "{{ step3Results.url     | regex_search('^http.*?://[^/]+') }}"
-        referer:                            "{{ step3Results.url     | regex_search('^http.*?://[^/]+') }}/"
-        post_action:                        "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> action=\".*?>)',                         '\\g<first_part>', '\\g<second_part>') | join                              | regex_search(' action=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        origin:                             "{{ step3Results.url | regex_search('^http.*?://[^/]+') }}"
+        referer:                            "{{ step3Results.url | regex_search('^http.*?://[^/]+') }}/"
+        post_action:                        "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> action=\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' action=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
         post_url:                           "{{ origin }}{{ post_action }}"
-        authenticity_token:                 "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"authenticity_token\".*?>)',       '\\g<first_part>', '\\g<second_part>') | join                              | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        xsrfProtection:                     "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"xsrfProtection\".*?>)',           '\\g<first_part>', '\\g<second_part>') | join                              | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        method:                             "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"method\".*?>)',                   '\\g<first_part>', '\\g<second_part>') | join                              | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        idpSSOEndpoint:                     "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"idpSSOEndpoint\".*?>)',           '\\g<first_part>', '\\g<second_part>') | join                              | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        SAMLRequest:                        "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"SAMLRequest\".*?>)',              '\\g<first_part>', '\\g<second_part>') | join                              | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        RelayState:                         "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"RelayState\".*?>)',               '\\g<first_part>', '\\g<second_part>') | join                              | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        targetUrl:                          "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.targetUrl..*?>)',                  '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        sourceUrl:                          "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.sourceUrl..*?>)',                  '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        org:                                "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.org..*?>)',                        '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        spId:                               "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.spId..*?>)',                       '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        spName:                             "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.spName..*?>)',                     '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        mobileSSOToken:                     "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.mobileSSOToken..*?>)',             '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        tfaToken:                           "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.tfaToken..*?>)',                   '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        css:                                "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.css..*?>)',                        '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        passwordlessAuthnSelected:          "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.passwordlessAuthnSelected..*?>)',  '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
+        authenticity_token:                 "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"authenticity_token\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        xsrfProtection:                     "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"xsrfProtection\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        method:                             "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"method\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        idpSSOEndpoint:                     "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"idpSSOEndpoint\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        SAMLRequest:                        "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"SAMLRequest\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        RelayState:                         "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"RelayState\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        targetUrl:                          "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.targetUrl..*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        sourceUrl:                          "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.sourceUrl..*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        org:                                "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.org..*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        spId:                               "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.spId..*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        spName:                             "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.spName..*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        mobileSSOToken:                     "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.mobileSSOToken..*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        tfaToken:                           "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.tfaToken..*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        css:                                "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.css..*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        passwordlessAuthnSelected:          "{{ step3Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.passwordlessAuthnSelected..*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
         j_username:                         "{{ s_user }}"
-        cookies_accounts_sap_com_string:    "{{ cookies_accounts_sap_com.keys()        |
+        cookies_accounts_sap_com_string:    "{{ cookies_accounts_sap_com.keys() |
                                                 zip(cookies_accounts_sap_com.values()) |
-                                                map('join', '=')                       |
+                                                map('join', '=') |
                                                 join('; ')
                                                 }}"
       register:                             step4Results
-      tags:
-        - skip_ansible_lint
-
 
     - name:                                 "SAP SSO Logon - Step 4 - Update cookies for accounts.sap.com"
       ansible.builtin.set_fact:
@@ -721,51 +684,47 @@
           - "cookies_accounts_sap_com_string: {{ cookies_accounts_sap_com_string }}"
         verbosity:                            0
       vars:
-        origin:                               "{{ step4Results.url     | regex_search('^http.*?://[^/]+') }}"
-        referer:                              "{{ step4Results.url     | regex_search('^http.*?://[^/]+') }}/"
-        post_action:                          "{%- if (step4Results.content | regex_search(' action='))                           -%}{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> action=\".*?>)',                         '\\g<first_part>', '\\g<second_part>') | join                              | regex_search(' action=\"(?P<value>.*?)\"', '\\g<value>') | join }}{%- else -%}NOT_SET{%- endif -%}"
+        origin:                               "{{ step4Results.url | regex_search('^http.*?://[^/]+') }}"
+        referer:                              "{{ step4Results.url | regex_search('^http.*?://[^/]+') }}/"
+        post_action:                          "{%- if (step4Results.content | regex_search(' action=')) -%}{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> action=\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' action=\"(?P<value>.*?)\"', '\\g<value>') | join }}{%- else -%}NOT_SET{%- endif -%}"
         post_url:                             "{{ origin }}{{ post_action }}"
-        authenticity_token:                   "{%- if (step4Results.content | regex_search(' name=.authenticity_token. '))        -%}{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"authenticity_token\".*?>)',       '\\g<first_part>', '\\g<second_part>') | join                              | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}{%- else -%}NOT_SET{%- endif -%}"
-        xsrfProtection:                       "{%- if (step4Results.content | regex_search(' name=.xsrfProtection. '))            -%}{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"xsrfProtection\".*?>)',           '\\g<first_part>', '\\g<second_part>') | join                              | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}{%- else -%}NOT_SET{%- endif -%}"
-        method:                               "{%- if (step4Results.content | regex_search(' name=.method. '))                    -%}{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"method\".*?>)',                   '\\g<first_part>', '\\g<second_part>') | join                              | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}{%- else -%}NOT_SET{%- endif -%}"
-        idpSSOEndpoint:                       "{%- if (step4Results.content | regex_search(' name=.idpSSOEndpoint. '))            -%}{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"idpSSOEndpoint\".*?>)',           '\\g<first_part>', '\\g<second_part>') | join                              | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}{%- else -%}NOT_SET{%- endif -%}"
-        SAMLRequest:                          "{%- if (step4Results.content | regex_search(' name=.SAMLRequest. '))               -%}{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"SAMLRequest\".*?>)',              '\\g<first_part>', '\\g<second_part>') | join                              | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}{%- else -%}NOT_SET{%- endif -%}"
-        RelayState:                           "{%- if (step4Results.content | regex_search(' name=.RelayState. '))                -%}{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"RelayState\".*?>)',               '\\g<first_part>', '\\g<second_part>') | join                              | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}{%- else -%}NOT_SET{%- endif -%}"
-        targetUrl:                            "{%- if (step4Results.content | regex_search(' name=.targetUrl. '))                 -%}{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.targetUrl..*?>)',                  '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}{%- else -%}NOT_SET{%- endif -%}"
-        sourceUrl:                            "{%- if (step4Results.content | regex_search(' name=.sourceUrl. '))                 -%}{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.sourceUrl..*?>)',                  '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}{%- else -%}NOT_SET{%- endif -%}"
-        org:                                  "{%- if (step4Results.content | regex_search(' name=.org. '))                       -%}{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.org..*?>)',                        '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}{%- else -%}NOT_SET{%- endif -%}"
-        spId:                                 "{%- if (step4Results.content | regex_search(' name=.spId. '))                      -%}{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.spId..*?>)',                       '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}{%- else -%}NOT_SET{%- endif -%}"
-        spName:                               "{%- if (step4Results.content | regex_search(' name=.spName. '))                    -%}{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.spName..*?>)',                     '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}{%- else -%}NOT_SET{%- endif -%}"
-        mobileSSOToken:                       "{%- if (step4Results.content | regex_search(' name=.mobileSSOToken. '))            -%}{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.mobileSSOToken..*?>)',             '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}{%- else -%}NOT_SET{%- endif -%}"
-        tfaToken:                             "{%- if (step4Results.content | regex_search(' name=.tfaToken. '))                  -%}{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.tfaToken..*?>)',                   '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}{%- else -%}NOT_SET{%- endif -%}"
-        css:                                  "{%- if (step4Results.content | regex_search(' name=.css. '))                       -%}{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.css..*?>)',                        '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}{%- else -%}NOT_SET{%- endif -%}"
-        passwordlessAuthnSelected:            "{%- if (step4Results.content | regex_search(' name=.passwordlessAuthnSelected. ')) -%}{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.passwordlessAuthnSelected..*?>)',  '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}{%- else -%}NOT_SET{%- endif -%}"
-        login_hint:                           "{%- if (step4Results.content | regex_search(' name=.login_hint. '))                -%}{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.login_hint..*?>)',  '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}{%- else -%}NOT_SET{%- endif -%}"
+        authenticity_token:                   "{%- if (step4Results.content | regex_search(' name=.authenticity_token. ')) -%}{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"authenticity_token\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}{%- else -%}NOT_SET{%- endif -%}"
+        xsrfProtection:                       "{%- if (step4Results.content | regex_search(' name=.xsrfProtection. ')) -%}{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"xsrfProtection\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}{%- else -%}NOT_SET{%- endif -%}"
+        method:                               "{%- if (step4Results.content | regex_search(' name=.method. ')) -%}{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"method\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}{%- else -%}NOT_SET{%- endif -%}"
+        idpSSOEndpoint:                       "{%- if (step4Results.content | regex_search(' name=.idpSSOEndpoint. ')) -%}{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"idpSSOEndpoint\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}{%- else -%}NOT_SET{%- endif -%}"
+        SAMLRequest:                          "{%- if (step4Results.content | regex_search(' name=.SAMLRequest. ')) -%}{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"SAMLRequest\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}{%- else -%}NOT_SET{%- endif -%}"
+        RelayState:                           "{%- if (step4Results.content | regex_search(' name=.RelayState. ')) -%}{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"RelayState\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}{%- else -%}NOT_SET{%- endif -%}"
+        targetUrl:                            "{%- if (step4Results.content | regex_search(' name=.targetUrl. ')) -%}{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.targetUrl..*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}{%- else -%}NOT_SET{%- endif -%}"
+        sourceUrl:                            "{%- if (step4Results.content | regex_search(' name=.sourceUrl. ')) -%}{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.sourceUrl..*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}{%- else -%}NOT_SET{%- endif -%}"
+        org:                                  "{%- if (step4Results.content | regex_search(' name=.org. ')) -%}{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.org..*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}{%- else -%}NOT_SET{%- endif -%}"
+        spId:                                 "{%- if (step4Results.content | regex_search(' name=.spId. ')) -%}{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.spId..*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}{%- else -%}NOT_SET{%- endif -%}"
+        spName:                               "{%- if (step4Results.content | regex_search(' name=.spName. ')) -%}{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.spName..*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}{%- else -%}NOT_SET{%- endif -%}"
+        mobileSSOToken:                       "{%- if (step4Results.content | regex_search(' name=.mobileSSOToken. ')) -%}{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.mobileSSOToken..*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}{%- else -%}NOT_SET{%- endif -%}"
+        tfaToken:                             "{%- if (step4Results.content | regex_search(' name=.tfaToken. ')) -%}{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.tfaToken..*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}{%- else -%}NOT_SET{%- endif -%}"
+        css:                                  "{%- if (step4Results.content | regex_search(' name=.css. ')) -%}{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.css..*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}{%- else -%}NOT_SET{%- endif -%}"
+        passwordlessAuthnSelected:            "{%- if (step4Results.content | regex_search(' name=.passwordlessAuthnSelected. ')) -%}{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.passwordlessAuthnSelected..*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}{%- else -%}NOT_SET{%- endif -%}"
+        login_hint:                           "{%- if (step4Results.content | regex_search(' name=.login_hint. ')) -%}{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.login_hint..*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}{%- else -%}NOT_SET{%- endif -%}"
         j_username:                           "{{ s_user }}"
         j_password:                           "{{ s_password }}"
-        cookies_accounts_sap_com_string:      "{{ cookies_accounts_sap_com.keys()        |
+        cookies_accounts_sap_com_string:      "{{ cookies_accounts_sap_com.keys() |
                                                   zip(cookies_accounts_sap_com.values()) |
-                                                  map('join', '=')                       |
+                                                  map('join', '=') |
                                                   join('; ')
                                                 }}"
-      tags:
-        - skip_ansible_lint
 # Step: 03-05 - END
 # -------------------------------------+---------------------------------------8
-
-
 
 # -------------------------------------+---------------------------------------8
 # Step: 03-06
 # Description:  Maintain Cookie Jar
 #
-    - name:                                 "SAP SSO Logon - Step 4 - Maintain Cookie Jar"
+    - name:                                 "SAP SSO Logon - Step 4 - Maintain Cookie Jar"  # noqa no-tabs jinja[spacing]
       ansible.builtin.lineinfile:
         state:                              present
         create:                             true
         path:                               cookie_jar
         mode:                               0644
-        regexp:                             ^#.*?_({{ url|regex_replace('[.]','[.]') }}).*?\s({{ (item.split('=', 1))[0]|trim|regex_replace('[.]','[.]') }})\s
+        regexp:                             ^#.*?_({{ url | regex_replace('[.]', '[.]') }}).*?\s({{ (item.split('=', 1))[0] | trim | regex_replace('[.]', '[.]') }})\s
         line:                               "
                                             {#-  -#}
                                             {% set _cookie = {  'cookie_name':  '',
@@ -782,20 +741,20 @@
                                             {% for element in item.split(';')                              -%}
                                             {%   if loop.index == 1                                        -%}
                                             {%     set sub = element.split('=', 1)                         -%}
-                                            {%     set _ = _cookie.update({'cookie_name':  sub[0]|trim})   -%}
-                                            {%     set _ = _cookie.update({'cookie_value': sub[1]|trim})   -%}
-                                            {%   elif 'PATH' in element.split('=', 1)|trim|upper           -%}
+                                            {%     set _ = _cookie.update({'cookie_name':  sub[0] | trim})   -%}
+                                            {%     set _ = _cookie.update({'cookie_value': sub[1] | trim})   -%}
+                                            {%   elif 'PATH' in element.split('=', 1) | trim | upper           -%}
                                             {%     set sub = element.split('=', 1)                         -%}
-                                            {%     set _ = _cookie.update({'Path':         sub[1]|trim})   -%}
-                                            {%   elif 'HTTPONLY' in element|trim|upper                     -%}
+                                            {%     set _ = _cookie.update({'Path':         sub[1] | trim})   -%}
+                                            {%   elif 'HTTPONLY' in element | trim | upper                     -%}
                                             {%     set _ = _cookie.update({'HttpOnly':     'TRUE'})        -%}
-                                            {%   elif 'DOMAIN' in element.split('=', 1)|trim|upper         -%}
+                                            {%   elif 'DOMAIN' in element.split('=', 1) | trim | upper         -%}
                                             {%     set sub = element.split('=', 1)                         -%}
                                             {%     set _ = _cookie.update({'Domain':       'TRUE'})        -%}
-                                            {%     set _ = _cookie.update({'Url':          '.' + sub[1]|trim|regex_search('^[.]?(?P<hostname>.*)$', '\\g<hostname>')|join}) -%}
-                                            {%   elif 'EXPIRES' in element.split('=', 1)|trim|upper        -%}
+                                            {%     set _ = _cookie.update({'Url':          '.' + sub[1] | trim | regex_search('^[.]?(?P<hostname>.*)$', '\\g<hostname>') | join}) -%}
+                                            {%   elif 'EXPIRES' in element.split('=', 1) | trim | upper        -%}
                                             {%     set sub = element.split('=', 1)                         -%}
-                                            {%     set _ = _cookie.update({'Expires':      (sub[1]|trim|to_datetime('%a%%2C %d %b %Y %H:%M:%S %Z')).strftime('%s')})     -%}
+                                            {%     set _ = _cookie.update({'Expires':      (sub[1] | trim | to_datetime('%a%%2C %d %b %Y %H:%M:%S %Z')).strftime('%s')})     -%}
                                             {%   endif                                                     -%}
                                             {% endfor                                                      -%}
                                             {% if not _cookie.Url                                          -%}
@@ -813,15 +772,11 @@
       loop:                                 "{{ set_cookie_string_filtered.split(',') }}"
       vars:
         set_cookie_string_filtered:         "{{ step4Results.set_cookie | regex_replace('Expires=(?P<day>...),', 'Expires=\\g<day>%2C') }}"
-        url:                                "{{ step4Results.url|urlsplit('hostname') }}"
-      tags:
-        - skip_ansible_lint
+        url:                                "{{ step4Results.url | urlsplit('hostname') }}"
 
-                                            # {%     set _ = _cookie.update({'Expires':      (sub[1]|trim|to_datetime('%a%%2C %d-%b-%Y %H:%M:%S %Z')).strftime('%s')})     -%}
+                                            # {%     set _ = _cookie.update({'Expires':      (sub[1] | trim | to_datetime('%a%%2C %d-%b-%Y %H:%M:%S %Z')).strftime('%s')})     -%}
 # Step: 03-06 - END
 # -------------------------------------+---------------------------------------8
-
-
 
 # -------------------------------------+---------------------------------------8
 # Step: 03-07
@@ -874,9 +829,9 @@
 #     Keep-Alive: timeout=20              |
 #     Set-Cookie: JSESSIONID=<id>         |
 # -------------------------------------+---------------------------------------8
-    - name:                                 "SAP SSO Logon - Step 5 - Submit Password information to IPD provider: {{ post_url }}"
+    - name:                                 "SAP SSO Logon - Step 5 - Submit Password information to IPD provider: {{ post_url }}"  # noqa command-instead-of-module
       ansible.builtin.command: >-
-                                            curl  {{ post_url }}                                                        \
+                                            curl {{ post_url }}                                                        \
                                             --include                                                                   \
                                             --cookie-jar cookie_jar                                                     \
                                             --cookie     cookie_jar                                                     \
@@ -918,30 +873,28 @@
                                             --data-urlencode 'j_password={{ j_password }}'                              \
                                             --output -
       vars:
-        origin:                             "{{ step4Results.url     | regex_search('^http.*?://[^/]+') }}"
-        referer:                            "{{ step4Results.url     | regex_search('^http.*?://[^/]+') }}/"
-        post_action:                        "{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> action=\".*?>)',                         '\\g<first_part>', '\\g<second_part>') | join                              | regex_search(' action=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        origin:                             "{{ step4Results.url | regex_search('^http.*?://[^/]+') }}"
+        referer:                            "{{ step4Results.url | regex_search('^http.*?://[^/]+') }}/"
+        post_action:                        "{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> action=\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' action=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
         post_url:                           "{{ origin }}{{ post_action }}"
-        authenticity_token:                 "{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"authenticity_token\".*?>)',       '\\g<first_part>', '\\g<second_part>') | join                              | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        xsrfProtection:                     "{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"xsrfProtection\".*?>)',           '\\g<first_part>', '\\g<second_part>') | join                              | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        method:                             "{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"method\".*?>)',                   '\\g<first_part>', '\\g<second_part>') | join                              | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        idpSSOEndpoint:                     "{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"idpSSOEndpoint\".*?>)',           '\\g<first_part>', '\\g<second_part>') | join                              | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        SAMLRequest:                        "{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"SAMLRequest\".*?>)',              '\\g<first_part>', '\\g<second_part>') | join                              | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        RelayState:                         "{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"RelayState\".*?>)',               '\\g<first_part>', '\\g<second_part>') | join                              | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        targetUrl:                          "{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.targetUrl..*?>)',                  '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        sourceUrl:                          "{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.sourceUrl..*?>)',                  '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        org:                                "{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.org..*?>)',                        '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        spId:                               "{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.spId..*?>)',                       '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        spName:                             "{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.spName..*?>)',                     '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        mobileSSOToken:                     "{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.mobileSSOToken..*?>)',             '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        tfaToken:                           "{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.tfaToken..*?>)',                   '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        css:                                "{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.css..*?>)',                        '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        passwordlessAuthnSelected:          "{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.passwordlessAuthnSelected..*?>)',  '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
+        authenticity_token:                 "{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"authenticity_token\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        xsrfProtection:                     "{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"xsrfProtection\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        method:                             "{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"method\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        idpSSOEndpoint:                     "{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"idpSSOEndpoint\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        SAMLRequest:                        "{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"SAMLRequest\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        RelayState:                         "{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"RelayState\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        targetUrl:                          "{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.targetUrl..*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        sourceUrl:                          "{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.sourceUrl..*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        org:                                "{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.org..*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        spId:                               "{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.spId..*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        spName:                             "{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.spName..*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        mobileSSOToken:                     "{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.mobileSSOToken..*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        tfaToken:                           "{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.tfaToken..*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        css:                                "{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.css..*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        passwordlessAuthnSelected:          "{{ step4Results.content | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=.passwordlessAuthnSelected..*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_replace(\"'\", '\"') | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
         j_username:                         "{{ s_user }}"
         j_password:                         "{{ s_password }}"
       register:                             step5Results
-      tags:
-        - skip_ansible_lint
 
     # - name:                                 "SAP SSO Logon - Step 5 - Submit Password information to IPD provider: {{ post_url }}"
     #   ansible.builtin.command: >-
@@ -997,15 +950,10 @@
     #     j_username:                         "{{ s_user }}"
     #     j_password:                         "{{ s_password }}"
     #   register:                             step5Results
-    #   tags:
-    #     - skip_ansible_lint
 
     # - name:                                 "SAP SSO Logon - Step 5 - Show data - step5Results"
     #   ansible.builtin.debug:
     #     var:                                step5Results.content
-
-
-
 
     - name:                                           "Step 5 - Show data"
       ansible.builtin.debug:
@@ -1023,18 +971,14 @@
       vars:
         results:                                      "{{ step5Results }}"
         stdout:                                       "{{ step5Results.stdout }}"
-        origin:                                       "{{ step4Results.url     | regex_search('^http.*?://[^/]+') }}"
-        referer:                                      "{{ step4Results.url     | regex_search('^http.*?://[^/]+') }}/"
-        post_action:                                  "{{ step5Results.stdout  | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> action=\".*?>)',                         '\\g<first_part>', '\\g<second_part>') | join                              | regex_search(' action=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
-        authenticity_token:                           "{{ step5Results.stdout  | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"authenticity_token\".*?>)',       '\\g<first_part>', '\\g<second_part>') | join                              | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        SAMLResponse:                                 "{{ step5Results.stdout  | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"SAMLResponse\".*?>)',             '\\g<first_part>', '\\g<second_part>') | join                              | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        RelayState:                                   "{{ step5Results.stdout  | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"RelayState\".*?>)',               '\\g<first_part>', '\\g<second_part>') | join                              | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-      tags:
-        - skip_ansible_lint
+        origin:                                       "{{ step4Results.url | regex_search('^http.*?://[^/]+') }}"
+        referer:                                      "{{ step4Results.url | regex_search('^http.*?://[^/]+') }}/"
+        post_action:                                  "{{ step5Results.stdout | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> action=\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' action=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        authenticity_token:                           "{{ step5Results.stdout | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"authenticity_token\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        SAMLResponse:                                 "{{ step5Results.stdout | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"SAMLResponse\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        RelayState:                                   "{{ step5Results.stdout | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"RelayState\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
 # Step: 03-07 - END
 # -------------------------------------+---------------------------------------8
-
-
 
 # -------------------------------------+---------------------------------------8
 # Step: 03-08
@@ -1071,7 +1015,7 @@
 #     Connection: keep-alive              | Connection: close
 #     Keep-Alive: timeout=20              |
 # -------------------------------------+---------------------------------------8
-    - name:                                 "SAP SSO Logon - Step 6 - Return SAML response to SAML provider: {{ post_action }}"
+    - name:                                 "SAP SSO Logon - Step 6 - Return SAML response to SAML provider: {{ post_action }}"  # noqa command-instead-of-module
       ansible.builtin.command: >-
                                             curl  {{ post_action }}                                                     \
                                             --include                                                                   \
@@ -1101,16 +1045,13 @@
                                             --data-urlencode 'RelayState={{ RelayState }}'                              \
                                             --output -
       vars:
-        origin:                             "{{ step4Results.url     | regex_search('^http.*?://[^/]+') }}"
-        referer:                            "{{ step4Results.url     | regex_search('^http.*?://[^/]+') }}/"
-        post_action:                        "{{ step5Results.stdout  | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> action=\".*?>)',                         '\\g<first_part>', '\\g<second_part>') | join                              | regex_search(' action=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
-        authenticity_token:                 "{{ step5Results.stdout  | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"authenticity_token\".*?>)',       '\\g<first_part>', '\\g<second_part>') | join                              | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        SAMLResponse:                       "{{ step5Results.stdout  | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"SAMLResponse\".*?>)',             '\\g<first_part>', '\\g<second_part>') | join                              | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        RelayState:                         "{{ step5Results.stdout  | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"RelayState\".*?>)',               '\\g<first_part>', '\\g<second_part>') | join                              | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
+        origin:                             "{{ step4Results.url | regex_search('^http.*?://[^/]+') }}"
+        referer:                            "{{ step4Results.url | regex_search('^http.*?://[^/]+') }}/"
+        post_action:                        "{{ step5Results.stdout | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> action=\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' action=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        authenticity_token:                 "{{ step5Results.stdout | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"authenticity_token\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        SAMLResponse:                       "{{ step5Results.stdout | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"SAMLResponse\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        RelayState:                         "{{ step5Results.stdout | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"RelayState\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
       register:                             step6Results
-      tags:
-        - skip_ansible_lint
-
 
     - name:                                 "SAP SSO Logon - Step 6 - Show data"
       ansible.builtin.debug:
@@ -1131,21 +1072,17 @@
       vars:
         results:                                      "{{ step6Results }}"
         stdout:                                       "{{ step6Results.stdout }}"
-        origin_action:                                "{{ step5Results.stdout  | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> action=\".*?>)',                         '\\g<first_part>', '\\g<second_part>') | join                              | regex_search(' action=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
-        origin_scheme:                                "{{ origin_action  | urlsplit('scheme') }}"
-        origin_hostname:                              "{{ origin_action  | urlsplit('hostname') }}"
+        origin_action:                                "{{ step5Results.stdout | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> action=\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' action=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        origin_scheme:                                "{{ origin_action | urlsplit('scheme') }}"
+        origin_hostname:                              "{{ origin_action | urlsplit('hostname') }}"
         origin:                                       "{{ origin_scheme }}://{{ origin_hostname }}"
         referer:                                      "{{ origin }}/"
-        post_action:                                  "{{ step6Results.stdout  | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> action=\".*?>)',                         '\\g<first_part>', '\\g<second_part>') | join                              | regex_search(' action=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
-        authenticity_token:                           "{{ step6Results.stdout  | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"authenticity_token\".*?>)',       '\\g<first_part>', '\\g<second_part>') | join                              | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        SAMLResponse:                                 "{{ step6Results.stdout  | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"SAMLResponse\".*?>)',             '\\g<first_part>', '\\g<second_part>') | join                              | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        RelayState:                                   "{{ step6Results.stdout  | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"RelayState\".*?>)',               '\\g<first_part>', '\\g<second_part>') | join                              | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-      tags:
-        - skip_ansible_lint
+        post_action:                                  "{{ step6Results.stdout | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> action=\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' action=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        authenticity_token:                           "{{ step6Results.stdout | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"authenticity_token\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        SAMLResponse:                                 "{{ step6Results.stdout | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"SAMLResponse\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        RelayState:                                   "{{ step6Results.stdout | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"RelayState\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
 # Step: 03-08 - END
 # -------------------------------------+---------------------------------------8
-
-
 
 # -------------------------------------+---------------------------------------8
 # Step: 03-09
@@ -1178,7 +1115,7 @@
 #     Connection: keep-alive              | Connection: close
 #     Keep-Alive: timeout=20              |
 # -------------------------------------+---------------------------------------8
-    - name:                                 "SAP SSO Logon - Step 7 - back to {{ post_action }}"
+    - name:                                 "SAP SSO Logon - Step 7 - back to {{ post_action }}"  # noqa command-instead-of-module
       ansible.builtin.command: >-
                                             curl  {{ post_action }}                                                     \
                                             --include                                                                   \
@@ -1208,18 +1145,16 @@
                                             --data-urlencode 'RelayState={{ RelayState }}'                              \
                                             --output -
       vars:
-        origin_action:                      "{{ step5Results.stdout  | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> action=\".*?>)',                         '\\g<first_part>', '\\g<second_part>') | join                              | regex_search(' action=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
-        origin_scheme:                      "{{ origin_action  | urlsplit('scheme') }}"
-        origin_hostname:                    "{{ origin_action  | urlsplit('hostname') }}"
+        origin_action:                      "{{ step5Results.stdout | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> action=\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' action=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        origin_scheme:                      "{{ origin_action | urlsplit('scheme') }}"
+        origin_hostname:                    "{{ origin_action | urlsplit('hostname') }}"
         origin:                             "{{ origin_scheme }}://{{ origin_hostname }}"
         referer:                            "{{ origin }}/"
-        post_action:                        "{{ step6Results.stdout  | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> action=\".*?>)',                         '\\g<first_part>', '\\g<second_part>') | join                              | regex_search(' action=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
-        authenticity_token:                 "{{ step6Results.stdout  | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"authenticity_token\".*?>)',       '\\g<first_part>', '\\g<second_part>') | join                              | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        SAMLResponse:                       "{{ step6Results.stdout  | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"SAMLResponse\".*?>)',             '\\g<first_part>', '\\g<second_part>') | join                              | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
-        RelayState:                         "{{ step6Results.stdout  | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"RelayState\".*?>)',               '\\g<first_part>', '\\g<second_part>') | join                              | regex_search(' value=\"(?P<value>.*?)\"',  '\\g<value>') | join }}"
+        post_action:                        "{{ step6Results.stdout | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> action=\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' action=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        authenticity_token:                 "{{ step6Results.stdout | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"authenticity_token\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        SAMLResponse:                       "{{ step6Results.stdout | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"SAMLResponse\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
+        RelayState:                         "{{ step6Results.stdout | regex_search('(?:.*(?P<first_part><.*))(?P<second_part> name=\"RelayState\".*?>)', '\\g<first_part>', '\\g<second_part>') | join | regex_search(' value=\"(?P<value>.*?)\"', '\\g<value>') | join }}"
       register:                             step7Results
-      tags:
-        - skip_ansible_lint
 # Step: 03-09 - END
 # -------------------------------------+---------------------------------------8
 
@@ -1230,13 +1165,11 @@
 # Step: 03 - END
 # -------------------------------------+---------------------------------------8
 
-
-
 # -------------------------------------+---------------------------------------8
 # Step: 04
 #   Description:
 #
-- name:                                 "SAP SSO Logon - Step 8 - Query {{ post_action }}"
+- name:                                 "SAP SSO Logon - Step 8 - Query {{ post_action }}"  # noqa command-instead-of-module
   ansible.builtin.command: >-
                                         curl  {{ post_action }}                                                     \
                                         --include                                                                   \
@@ -1262,12 +1195,8 @@
   vars:
     post_action:                        "https://launchpad.support.sap.com/services/odata/svt/swdcuisrv/SearchResultSet?SEARCH_MAX_RESULT=500&RESULT_PER_PAGE=500&SEARCH_STRING={{ asset }}&sap-language=en"
   register:                             sap_asset_search
-  tags:
-    - skip_ansible_lint
 # Step: 04 - END
 # -------------------------------------+---------------------------------------8
-
-
 
 # -------------------------------------+---------------------------------------8
 # Step: 05
@@ -1285,8 +1214,6 @@
     post_action:                        "https://launchpad.support.sap.com/services/odata/svt/swdcuisrv/SearchResultSet?SEARCH_MAX_RESULT=500&RESULT_PER_PAGE=500&SEARCH_STRING={{ asset }}&sap-language=en"
 # Step: 05 - END
 # -------------------------------------+---------------------------------------8
-
-
 
 # -------------------------------------+---------------------------------------8
 # Step: 06

--- a/deploy/ansible/roles-sap/3.3.1-bom-utility/tasks/bom-register.yaml
+++ b/deploy/ansible/roles-sap/3.3.1-bom-utility/tasks/bom-register.yaml
@@ -23,9 +23,8 @@
     state:                              directory
     mode:                               0755
   delegate_to:                          localhost
-# 20221201 MKD (DynBOM)- mitigate become
-  # become:                               "{{ bom_processing_become }}"
-  # become_user:                          root
+  become:                               "{{ bom_processing_become }}"
+  become_user:                          root
   loop:
     - path: "{{ download_directory }}"
     - path: "{{ download_directory }}/tmp"
@@ -69,8 +68,7 @@
         dest:                           "{{ download_directory }}/bom/{{ new_bom_name }}.yaml"
         mode:                           0644
       delegate_to:                      localhost
-# 20221201 MKD (DynBOM)- mitigate become
-      # become:                           "{{ bom_processing_become }}"
+      become:                           "{{ bom_processing_become }}"
       ignore_errors:                    true
       register:                         result
 # Step: 03-01 - END
@@ -155,6 +153,8 @@
         path:                           "{{ BOM_directory }}/{{ bom_name }}/{{ bom_name }}.yaml"
       register:                         microsoft_supplied_bom
       delegate_to:                      localhost
+      become:                          "{{ bom_processing_become }}"
+
 # Step: 05-01 - END
 # -------------------------------------+---------------------------------------8
 
@@ -214,6 +214,7 @@
             path:                       "{{ BOM_directory }}/archives/{{ bom_name }}/{{ bom_name }}.yaml"
           register:                     microsoft_supplied_bom_archive
           delegate_to:                  localhost
+          become:                       "{{ bom_processing_become }}"
 # Step: 05-05-01 - END
 # -------------------------------------+---------------------------------------8
 

--- a/deploy/ansible/roles-sap/5.0.0-scs-install/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.0.0-scs-install/tasks/main.yaml
@@ -107,14 +107,11 @@
         sap_db_hostname:
         sap_ciVirtualHostname:
         sap_appVirtualHostname:
-        tier:                          "{{ tier }}"
         param_directory:               "{{ dir_params }}"
         sap_sid:                       "{{ sid_to_be_deployed.sid }}"
         scs_instance_number:           "{{ sid_to_be_deployed.ascs_inst_no }}"
         sidadm_uid:                    "{{ sid_to_be_deployed.sidadm_uid }}"
         hdb_instance_number:           "{{ db_instance_number }}"
-      tags:
-        - skip_ansible_lint
 
     - name:                            "SCS Install: install variables"
       ansible.builtin.debug:
@@ -185,8 +182,6 @@
         TMPDIR:                        "{{ tmp_directory }}/{{ sid_to_be_deployed.sid | upper }}"
       register:                        scs_installation
       failed_when:                     scs_installation.rc > 0
-      tags:
-        - skip_ansible_lint
 
     - name:                            "SCS Install: Cleanup ini file {{ ansible_hostname }}"
       ansible.builtin.file:

--- a/deploy/ansible/roles-sap/5.0.1-scs-ha-install/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.0.1-scs-ha-install/tasks/main.yaml
@@ -101,8 +101,6 @@
         sap_appVirtualHostname:
         param_directory:               "{{ dir_params }}"
         hdb_instance_number:           "{{ db_instance_number }}"
-      tags:
-        - skip_ansible_lint
 
     - name:                            "SCS HA Install: check if installed"
       ansible.builtin.debug:
@@ -193,8 +191,6 @@
             TMPDIR:                    "{{ tmp_directory }}/{{ sid_to_be_deployed.sid | upper }}"
           register:                    scs_installation
           failed_when:                 scs_installation.rc > 0
-          tags:
-            - skip_ansible_lint
           when:                        node_tier == 'scs'
       rescue:
         # ToDO: cleanup file systems on failed install.
@@ -272,8 +268,6 @@
             TMPDIR:                    "{{ tmp_directory }}/{{ sid_to_be_deployed.sid | upper }}"
           register:                    scs_installation
           failed_when:                 false
-          tags:
-            - skip_ansible_lint
           when:                        node_tier == 'scs'
 
     - name:                            "SCS HA Install: Installation results"

--- a/deploy/ansible/roles-sap/5.0.2-ers-ha-install/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.0.2-ers-ha-install/tasks/main.yaml
@@ -86,8 +86,6 @@
         sap_scs_hostname:              "{{ sid_to_be_deployed.sid | lower }}scs{{ scs_instance_number }}cl1"
         param_directory:               "{{ dir_params }}"
         hdb_instance_number:           "{{ db_instance_number }}"
-      tags:
-        - skip_ansible_lint
 
     - name:                            "ERS Install: register variables"
       ansible.builtin.set_fact:
@@ -151,8 +149,6 @@
             TMPDIR:                    "{{ tmp_directory }}/{{ sid_to_be_deployed.sid | upper }}"
           register:                    ers_installation
           failed_when:                 ers_installation.rc > 0
-          tags:
-            - skip_ansible_lint
       rescue:
         - name:                        "RESCUE - ERS Install: Check '/usr/sap/<SAPSID>/SYS/exe/uc/linuxx86_64' exists"
           ansible.builtin.stat:
@@ -198,8 +194,6 @@
             TMPDIR:                    "{{ tmp_directory }}/{{ sid_to_be_deployed.sid | upper }}"
           register:                    ers_installation
           failed_when:                 false
-          tags:
-            - skip_ansible_lint
 
     - name:                            "ERS Install: Installation results"
       block:
@@ -210,7 +204,7 @@
 
         - name:                        "ERS Install: Save installation results"
           ansible.builtin.set_fact:
-            ers_installation_succeeded: false                    
+            ers_installation_succeeded: false
 
         - name:                        "ERS Install: Installation results"
           ansible.builtin.fail:

--- a/deploy/ansible/roles-sap/5.1-dbload/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.1-dbload/tasks/main.yaml
@@ -158,12 +158,8 @@
         sidadm_uid:                    "{{ sid_to_be_deployed.sidadm_uid }}"
         # support older dbload inifile templates where hdb_instance_number was used
         hdb_instance_number:           "{{ db_instance_number }}"
-        db_instance_number:            "{{ db_instance_number }}"
         hana_backup_path:              "{{ backup_path }}"
         sa_enabled:                    true
-
-      tags:
-        - skip_ansible_lint
 
     - name:                            "DBLoad: install variables"
       ansible.builtin.debug:
@@ -206,8 +202,6 @@
         TMPDIR:                        "{{ tmp_directory }}/{{ sid_to_be_deployed.sid | upper }}"
         SAPSYSTEMNAME:                 "{{ sid_to_be_deployed.sid | upper }}"
       register:                        dbload_results
-      tags:
-        - skip_ansible_lint
       async:                           7200
       poll:                            0
 

--- a/deploy/ansible/roles-sap/5.1-dbload/tasks/oracle.yaml
+++ b/deploy/ansible/roles-sap/5.1-dbload/tasks/oracle.yaml
@@ -46,8 +46,6 @@
     executable:                        /bin/csh
   register:                            lsnrstatus
   failed_when:                         lsnrstatus.rc >= 2
-  tags:
-    - skip_ansible_lint
 
 - name:                                "DBLoad (sharedHome): create startlsnrctl.txt"
   ansible.builtin.file:

--- a/deploy/ansible/roles-sap/5.2-pas-install/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.2-pas-install/tasks/main.yaml
@@ -129,7 +129,6 @@
         sap_db_hostname:               "{{ db_lb_virtual_host }}"
         sap_ciVirtualHostname:
         sap_appVirtualHostname:
-        tier:                          "{{ tier }}"
         param_directory:               "{{ dir_params }}"
         sap_sid:                       "{{ sid_to_be_deployed.sid }}"
         scs_instance_number:           "{{ sid_to_be_deployed.ascs_inst_no }}"
@@ -137,8 +136,6 @@
         virt_do_not_resolve_hostname:  "{{ db_lb_virtual_host }}"
         # support older app inifile templates where hdb_instance_number was used
         hdb_instance_number:           "{{ db_instance_number }}"
-      tags:
-        - skip_ansible_lint
 
     - name:                            "PAS Install: register variables"
       ansible.builtin.set_fact:
@@ -189,8 +186,6 @@
         SAPSYSTEMNAME:                 "{{ sid_to_be_deployed.sid | upper }}"
       register:                        pas_installation
       failed_when:                     pas_installation.rc > 0
-      tags:
-        - skip_ansible_lint
 
     - name:                            "PAS Install: Installation results"
       ansible.builtin.debug:
@@ -260,12 +255,10 @@
       environment:
         SAPSYSTEMNAME:                 "{{ sid_to_be_deployed.sid | upper }}"
         TMPDIR:                        "{{ hdbuserstore_path }}"
-        ssfs_connect:                  1
+        ssfs_connect:                  "1"
       register:                        hdbuserstore
       vars:
         allow_world_readable_tmpfiles: true
-      tags:
-        - skip_ansible_lint
       when:
         - db_high_availability
         - platform == 'HANA'
@@ -335,7 +328,7 @@
                                        {{ hdbuserstore_path }} SET DEFAULT {{ db_lb_virtual_host }}:3{{ db_instance_number }}13@{{ db_sid | upper }} {{ hana_schema }} {{ main_password }}
       environment:
         SAPSYSTEMNAME:                 "{{ sid_to_be_deployed.sid | upper }}"
-        ssfs_connect:                  1
+        ssfs_connect:                  "1"
       register:                        hdbuserstore
       become:                          true
       become_user:                     "{{ sid_to_be_deployed.sid | lower }}adm"
@@ -344,8 +337,6 @@
       when:
         - db_high_availability
         - platform == 'HANA'
-      tags:
-        - skip_ansible_lint
 
 
   when:

--- a/deploy/ansible/roles-sap/5.3-app-install/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.3-app-install/tasks/main.yaml
@@ -5,7 +5,6 @@
 # |         SAP APP: Install                                                   |
 # |                                                                            |
 # +------------------------------------4--------------------------------------*/
-
 ---
 - name:                                "APP Install: Set the SCS Server name list"
   ansible.builtin.set_fact:
@@ -62,14 +61,13 @@
   ansible.builtin.set_fact:
     app_bom_id:                        "{{ bom.product_ids.app }}"
 
-- name:                                "APP Install"
-  block:
-
 # *====================================4=======================================8
 #   SAP APP: Install
 # 2230669 - System Provisioning Using a Parameter Input File
 #
-
+- name:                                "APP Install"
+  when:                                not app_installed.stat.exists
+  block:
     - name:                            "APP Install: Set the SCS Server name"
       ansible.builtin.set_fact:
         scs_server:                    "{% if scs_high_availability %}{{ sid_to_be_deployed.sid | lower }}scs{{ scs_instance_number }}cl1{% else %}{{ hostvars[scs_server_temp | first]['virtual_host'] }}{% endif %}"
@@ -116,8 +114,6 @@
         virt_do_not_resolve_hostname:  "{{ db_lb_virtual_host }}"
         # support older app inifile templates where hdb_instance_number was used
         hdb_instance_number:           "{{ db_instance_number }}"
-      tags:
-        - skip_ansible_lint
 
     - name:                            "App install: register variables"
       ansible.builtin.set_fact:
@@ -165,8 +161,6 @@
         TMPDIR:                        "{{ tmp_directory }}/{{ sid_to_be_deployed.sid | upper }}"
       register:                        app_installation
       failed_when:                     app_installation.rc > 0
-      tags:
-        - skip_ansible_lint
 
     - name:                            "APP Install: Installation results"
       ansible.builtin.debug:
@@ -228,24 +222,18 @@
     - name:                            "APP Install: Set DB Virtual Host name"
       become:                          true
       become_user:                     "{{ sid_to_be_deployed.sid | lower }}adm"
-      ansible.builtin.shell: |
-                                       {{ hdbuserstore_path }} SET DEFAULT {{ db_lb_virtual_host }}:3{{ db_instance_number }}13@{{ db_sid | upper }} {{ hana_schema }} {{ main_password }}
+      ansible.builtin.shell:           "{{ hdbuserstore_path }} SET DEFAULT {{ db_lb_virtual_host }}:3{{ db_instance_number }}13@{{ db_sid | upper }} {{ hana_schema }} {{ main_password }}"
       environment:
         SAPSYSTEMNAME:                 "{{ sid_to_be_deployed.sid | upper }}"
-        ssfs_connect:                  1
+        ssfs_connect:                  "1"
       register:                        hdbuserstore
       vars:
         allow_world_readable_tmpfiles: true
-      tags:
-        - skip_ansible_lint
       when:
         - db_high_availability
         - platform == 'HANA'
         - pas_installed_according_to_sapinst is defined
         - pas_installed_according_to_sapinst | length > 0
-
-  when:
-    - not app_installed.stat.exists
 
 - name:                                "APP Install: - status"
   block:
@@ -285,11 +273,10 @@
         - platform == 'HANA'
 
     - name:                            "APP Install: Set DB Virtual Host name ({{ db_lb_virtual_host }})"
-      ansible.builtin.shell: |
-                                       {{ hdbuserstore_path }} SET DEFAULT {{ db_lb_virtual_host }}:30313@{{ db_sid | upper }} {{ hana_schema }} {{ main_password }}
+      ansible.builtin.shell:           "{{ hdbuserstore_path }} SET DEFAULT {{ db_lb_virtual_host }}:30313@{{ db_sid | upper }} {{ hana_schema }} {{ main_password }}"
       environment:
         SAPSYSTEMNAME:                 "{{ sid_to_be_deployed.sid | upper }}"
-        ssfs_connect:                  1
+        ssfs_connect:                  "1"
       register:                        hdbuserstore
       become:                          true
       become_user:                     "{{ sid_to_be_deployed.sid | lower }}adm"
@@ -298,8 +285,6 @@
       when:
         - db_high_availability
         - platform == 'HANA'
-      tags:
-        - skip_ansible_lint
 
   when:
     - app_installed.stat.exists

--- a/deploy/ansible/roles-sap/5.4-web-install/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.4-web-install/tasks/main.yaml
@@ -96,9 +96,6 @@
         sap_installSAPHostAgent:       false
         hdb_instance_number:           "{{ db_instance_number }}"
 
-      tags:
-        - skip_ansible_lint
-
     - name:                            "Web install: register variables"
       ansible.builtin.set_fact:
         web_bom_id:                    "{{ bom.product_ids.web }}"
@@ -144,8 +141,6 @@
         TMPDIR:                        "{{ tmp_directory }}/{{ sid_to_be_deployed.sid | upper }}"
       register:                        web_installation
       failed_when:                     web_installation.rc > 0
-      tags:
-        - skip_ansible_lint
       when:                            node_tier == 'web'
 
     - name:                            "WEB Install: Installation results"

--- a/deploy/ansible/roles-sap/5.5-hanadb-pacemaker/tasks/5.5.4.0-cluster-RedHat.yml
+++ b/deploy/ansible/roles-sap/5.5-hanadb-pacemaker/tasks/5.5.4.0-cluster-RedHat.yml
@@ -111,8 +111,6 @@
       delay:                           10
       until:                           "(primary_instance_name + ' ' + secondary_instance_name) in cluster_stable_check.stdout or (secondary_instance_name + ' ' + primary_instance_name) in cluster_stable_check.stdout"
       when:                            ansible_distribution_major_version != "8"
-      tags:
-        - skip_ansible_lint
     # '*' is a special character in regexp and needs to be escaped for literal matching
     # if we are worried about character spacing across distros we can match for '\* Online:'
     - name:                            Wait until cluster has stabilized
@@ -122,8 +120,6 @@
       delay:                           10
       until:                           "(primary_instance_name + ' ' + secondary_instance_name) in cluster_stable_check.stdout or (secondary_instance_name + ' ' + primary_instance_name) in cluster_stable_check.stdout"
       when:                            ansible_distribution_major_version == "8"
-      tags:
-        - skip_ansible_lint
 
     # - name:                            Ensure Cluster resources are started
     #   ansible.builtin.shell:           pcs status | grep '\* Started:'
@@ -146,10 +142,7 @@
       retries:                         12
       delay:                           10
       until:                           "(primary_instance_name + ' ' + secondary_instance_name) in hana_cluster_resource_check.stdout or (secondary_instance_name + ' ' + primary_instance_name) in hana_cluster_resource_check.stdout"
-
       when:                            ansible_distribution_major_version != "8"
-      tags:
-        - skip_ansible_lint
 
     - name:                            Ensure Cluster resources are started
       ansible.builtin.shell:           pcs resource status | grep '\* Started:'
@@ -158,8 +151,6 @@
       delay:                           10
       until:                           "(primary_instance_name + ' ' + secondary_instance_name) in hana_cluster_resource_check.stdout or (secondary_instance_name + ' ' + primary_instance_name) in hana_cluster_resource_check.stdout"
       when:                            ansible_distribution_major_version == "8"
-      tags:
-        - skip_ansible_lint
   when: ansible_hostname == primary_instance_name
 
 # End of HANA clustering resources

--- a/deploy/ansible/roles-sap/5.6-scsers-pacemaker/tasks/5.6.4.0-cluster-RedHat.yml
+++ b/deploy/ansible/roles-sap/5.6-scsers-pacemaker/tasks/5.6.4.0-cluster-RedHat.yml
@@ -74,8 +74,6 @@
         - { path: '/usr/sap/{{ sap_sid | upper }}/SYS', mode: '0700' }
         - { path: '/usr/sap/{{ sap_sid }}/{{ instance_type | upper }}{{ scs_instance_number }}', mode: '0755' }
       when: inventory_hostname == primary_instance_name
-      tags:
-        - skip_ansible_lint
 
     - name:                            "5.6 SCSERS - RHEL - SCS - Install SCS on Primary host"
       ansible.builtin.include_role:
@@ -161,8 +159,6 @@
         - { path: '/usr/sap/{{ sap_sid | upper }}/SYS', mode: '0700' }
         - { path: '/usr/sap/{{ sap_sid | upper }}/ERS{{ ers_instance_number }}', mode: '0755' }
       when: inventory_hostname == secondary_instance_name
-      tags:
-        - skip_ansible_lint
 
     - name:                            "5.6 SCSERS - RHEL - ERS - Install on Secondary host"
       ansible.builtin.include_role:
@@ -178,7 +174,7 @@
       ansible.builtin.stat:
         path:                          "/etc/sap_deployment_automation/{{ sap_sid | upper }}/sap_deployment_ers.txt"
       register:                        ers_installed
- 
+
     - name:                            "ErrorHandling"
       ansible.builtin.fail:
         msg:                           "INSTALL:0014:ERS installation failed"

--- a/deploy/ansible/roles-sap/5.6-scsers-pacemaker/tasks/5.6.6-validate.yml
+++ b/deploy/ansible/roles-sap/5.6-scsers-pacemaker/tasks/5.6.6-validate.yml
@@ -24,8 +24,7 @@
     - name:                            "PAS Install: Set sapcontrol path"
       ansible.builtin.set_fact:
         sapcontrol_path:               "{{ sapcontrol_file.files[0].path }}"
-      when:
-        - sapcontrol_file | length > 0
+      when: sapcontrol_file | length > 0
 
     # {{ sapcontrol_path }} -nr {{ scs_instance_number }} -function GetProcessList | grep MessageServer | awk '{split($0,result,", "); print result[1],result[3] }'
     - name:                            "Determine if SCS is running on {{ ansible_hostname }}"
@@ -45,8 +44,6 @@
         DIR_LIBRARY:                   /usr/sap/{{ sap_sid | upper }}/SYS/exe/run
         LD_LIBRARY_PATH:               /usr/sap/{{ sap_sid | upper }}/SYS/exe/run:/usr/sap/{ sap_sid | upper }}/SYS/exe/uc/linuxx86_64
         SAPSYSTEMNAME:                 "{{ sap_sid | upper }}"
-      tags:
-        - skip_ansible_lint
 
     - name:                            "Show if SCS is running on {{ ansible_hostname }}"
       ansible.builtin.debug:
@@ -75,8 +72,6 @@
         - ansible_hostname == primary_instance_name
       failed_when:                     false
       register:                        cluster_group_location
-      tags:
-        - skip_ansible_lint
 
     # move cluster group g-{{ sap_sid }}_{{ instance_type | upper }} to primary_instance_name
     - name:                            "Move cluster group g-{{ sap_sid }}_{{ instance_type | upper }} to {{ primary_instance_name }}"
@@ -94,8 +89,6 @@
       failed_when:                     false
       changed_when:                    false
       register:                        cluster_group_moved
-      tags:
-        - skip_ansible_lint
 
     # move cluster group g-{{ sap_sid }}_{{ instance_type | upper }} to primary_instance_name
     - name:                            "Move cluster group g-{{ sap_sid }}_{{ instance_type | upper }} to {{ primary_instance_name }}"
@@ -117,8 +110,6 @@
       #                                  cluster_group_moved.stderr is not search('Already in requested state')
       #                                  or cluster_group_moved.stderr is not search('is already active on')
       #                                  )
-      tags:
-        - skip_ansible_lint
 
     - name:                            "Validate Cluster resource move and SAP start when the group g-{{ sap_sid }}_{{ instance_type | upper }} has moved"
       block:
@@ -127,7 +118,7 @@
           become_user:                 root
           ansible.builtin.shell: >-
             set -o pipefail;
-            crm_resource --resource g-{{ sap_sid }}_{{ instance_type | upper }} --locate | cut -d ':' -f 2| cut -d " " -f 2
+            crm_resource --resource g-{{ sap_sid }}_{{ instance_type | upper }} --locate | cut -d ':' -f 2 | cut -d " " -f 2
           vars:
             allow_world_readable_tmpfiles: true
             ansible_python_interpreter:    "{{ python_version }}"
@@ -135,18 +126,14 @@
           register:                    cluster_group_location
           failed_when:                 false
           changed_when:                false
-          tags:
-            - skip_ansible_lint
 
         - name:                        "Validate that cluster group g-{{ sap_sid }}_{{ instance_type | upper }} is running on {{ primary_instance_name }}"
           ansible.builtin.assert:
             that:
               - cluster_group_location.stdout == primary_instance_name
             fail_msg:                  "cluster group g-{{ sap_sid }}_{{ instance_type | upper }} is not running on {{ primary_instance_name }}"
-          tags:
-            - skip_ansible_lint
 
-        #{{ sapcontrol_path }} -nr {{ scs_instance_number }} -function GetProcessList | grep MessageServer | awk '{split($0,result,", "); print result[1],result[3] }'
+        # {{ sapcontrol_path }} -nr {{ scs_instance_number }} -function GetProcessList | grep MessageServer | awk '{split($0,result,", "); print result[1],result[3] }'
         - name:                        "Determine if SCS is running on {{ ansible_hostname }}"
           ansible.builtin.command:     "{{ sapcontrol_path }} -nr {{ scs_instance_number }} -function StartService {{ sap_sid | upper }}"
           changed_when:                false
@@ -164,14 +151,12 @@
             DIR_LIBRARY:               /usr/sap/{{ sap_sid | upper }}/SYS/exe/run
             LD_LIBRARY_PATH:           /usr/sap/{{ sap_sid | upper }}/SYS/exe/run:/usr/sap/{ sap_sid | upper }}/SYS/exe/uc/linuxx86_64
             SAPSYSTEMNAME:             "{{ sap_sid | upper }}"
-          tags:
-            - skip_ansible_lint
 
         - name:                        "Wait 60 secs for the StartService {{ sap_sid | upper }} to finish"
           ansible.builtin.wait_for:
             timeout:                   0
 
-        #{{ sapcontrol_path }} -nr {{ scs_instance_number }} -function GetProcessList | grep MessageServer | awk '{split($0,result,", "); print result[1],result[3] }'
+        # {{ sapcontrol_path }} -nr {{ scs_instance_number }} -function GetProcessList | grep MessageServer | awk '{split($0,result,", "); print result[1],result[3] }'
         - name:                        "Determine if SCS is running on {{ ansible_hostname }}"
           ansible.builtin.command:     "{{ sapcontrol_path }} -nr {{ scs_instance_number }} -function StartSystem ALL"
           changed_when:                false
@@ -189,8 +174,6 @@
             DIR_LIBRARY:               /usr/sap/{{ sap_sid | upper }}/SYS/exe/run
             LD_LIBRARY_PATH:           /usr/sap/{{ sap_sid | upper }}/SYS/exe/run:/usr/sap/{ sap_sid | upper }}/SYS/exe/uc/linuxx86_64
             SAPSYSTEMNAME:             "{{ sap_sid | upper }}"
-          tags:
-            - skip_ansible_lint
       when:
         - scs_running_on is not defined
         - ansible_hostname == primary_instance_name

--- a/deploy/ansible/roles-sap/5.7-db2-pacemaker/tasks/5.7.3.0-cluster-RedHat.yml
+++ b/deploy/ansible/roles-sap/5.7-db2-pacemaker/tasks/5.7.3.0-cluster-RedHat.yml
@@ -108,8 +108,6 @@
       delay:                           10
       until:                           "'{{ primary_instance_name }} {{ secondary_instance_name }}' in cluster_stable_check.stdout or '{{ secondary_instance_name }} {{ primary_instance_name }}' in cluster_stable_check.stdout"
       when:                            ansible_distribution_major_version != "8"
-      tags:
-        - skip_ansible_lint
 
     # '*' is a special character in regexp and needs to be escaped for literal matching
     # if we are worried about character spacing across distros we can match for '\* Online:'
@@ -120,8 +118,6 @@
       delay:                           10
       until:                           "'{{ primary_instance_name }} {{ secondary_instance_name }}' in cluster_stable_check.stdout or '{{ secondary_instance_name }} {{ primary_instance_name }}' in cluster_stable_check.stdout"
       when:                            ansible_distribution_major_version == "8"
-      tags:
-        - skip_ansible_lint
 
     - name:                            "Ensure Cluster resources are started"
       ansible.builtin.shell:           pcs resource show | grep '    Started:'
@@ -130,8 +126,6 @@
       delay:                           10
       until:                           "'{{ primary_instance_name }} {{ secondary_instance_name }}' in db2_cluster_resource_check.stdout or '{{ secondary_instance_name }} {{ primary_instance_name }}' in db2_cluster_resource_check.stdout"
       when:                            ansible_distribution_major_version != "8"
-      tags:
-        - skip_ansible_lint
 
     - name:                            "Ensure Cluster resources are started - RHEL 8.x"
       ansible.builtin.shell:           pcs resource status | grep 'Started'
@@ -140,8 +134,6 @@
       delay:                           10
       until:                           "'{{ primary_instance_name }}' in db2_cluster_resource_check.stdout or '{{ secondary_instance_name }}' in db2_cluster_resource_check.stdout"
       when:                            ansible_distribution_major_version == "8"
-      tags:
-        - skip_ansible_lint
   when: ansible_hostname == primary_instance_name
 
 # End of DB2 clustering resources

--- a/deploy/ansible/roles-sap/windows/3.3.1-bom-utility/tasks/bom-register.yaml
+++ b/deploy/ansible/roles-sap/windows/3.3.1-bom-utility/tasks/bom-register.yaml
@@ -78,6 +78,7 @@
         path:                          "{{ playbook_dir }}/BOM-catalog/{{ bom_name }}/{{ bom_name }}.yaml"
       register:                        microsoft_supplied_bom
       delegate_to:                     localhost
+      become:                          "{{ bom_processing_become }}"
 
     - name:                            "{{ task_prefix }} Show Microsoft Supplied BOM ({{ bom_base_name }}) result"
       ansible.builtin.debug:
@@ -105,6 +106,7 @@
             path:                      "{{ playbook_dir }}/BOM-catalog/archives/{{ bom_name }}/{{ bom_name }}.yaml"
           register:                    microsoft_supplied_bom_archive
           delegate_to:                 localhost
+          become:                      "{{ bom_processing_become }}"
 
         - name:                        "{{ task_prefix }} Register Microsoft Supplied BOM {{ bom_name }} from archives"
           ansible.builtin.include_vars:

--- a/deploy/ansible/roles-sap/windows/5.0.0-scs-install/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/windows/5.0.0-scs-install/tasks/main.yaml
@@ -146,13 +146,10 @@
     sap_db_hostname:
     sap_ciVirtualHostname:
     sap_appVirtualHostname:
-    tier:                              "{{ tier }}"
     param_directory:                   "{{ dir_params }}"
     sap_sid:                           "{{ sid_to_be_deployed.sid }}"
     scs_instance_number:               "{{ sid_to_be_deployed.ascs_inst_no }}"
     sidadm_uid:                        "{{ sid_to_be_deployed.sidadm_uid }}"
-  tags:
-    - skip_ansible_lint
 
 - name:                                "SCS Install: install variables"
   ansible.builtin.debug:
@@ -228,8 +225,6 @@
             ansible_become_password:   "{{ domain_user_password }}"
           register:                    scs_installation
           failed_when:                 scs_installation.rc > 0
-          tags:
-            - skip_ansible_lint
       rescue:
         - name:                        'RESCUE - SCS Install: Check {{ sap_drive }}\usr\sap\{{ sap_sid | upper }}\SYS\exe\uc\NTAMD64 exists'
           ansible.windows.win_stat:

--- a/deploy/ansible/roles-sap/windows/5.1-dbload/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/windows/5.1-dbload/tasks/main.yaml
@@ -147,14 +147,11 @@
     sap_db_hostname:                   "{{ db_virtual_host }}"
     sap_ciVirtualHostname:
     sap_appVirtualHostname:
-    tier:                              "{{ tier }}"
     param_directory:                   "{{ dir_params }}"
     sap_sid:                           "{{ sid_to_be_deployed.sid }}"
     sidadm_uid:                        "{{ sid_to_be_deployed.sidadm_uid }}"
     data_disks:                        "{{ vm_data_disks }}"
     log_disks:                         "{{ vm_log_disks }}"
-  tags:
-    - skip_ansible_lint
 
 - name:                                "DBLoad: install variables"
   ansible.builtin.debug:
@@ -211,7 +208,7 @@
       failed_when:                     scs_extraction.rc > 0
 
     - name:                            "DBLoad: - run SAPInst"
-      win_shell: |
+      ansible.windows.win_shell: |
                                        {{ download_directory_windows }}\sap_extract\sapinst.exe SAPINST_INPUT_PARAMETERS_URL={{ dir_params }}\{{ sap_inifile }}  `
                                                                                                 SAPINST_EXECUTE_PRODUCT_ID={{ bom.product_ids.dbl }}             `
                                                                                                 SAPINST_SKIP_DIALOGS=true                                        `
@@ -228,8 +225,6 @@
         ansible_become_password:       "{{ domain_user_password }}"
       register:                        dbload_results
       failed_when:                     dbload_results.rc > 0
-      tags:
-        - skip_ansible_lint
       # async:                           7200
       # poll:                            0
 

--- a/deploy/ansible/roles-sap/windows/5.2-pas-install/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/windows/5.2-pas-install/tasks/main.yaml
@@ -161,15 +161,11 @@
     sap_db_hostname:                   "{{ db_virtual_host }}"
     sap_ciVirtualHostname:
     sap_appVirtualHostname:
-    tier:                              "{{ tier }}"
     param_directory:                   "{{ dir_params }}"
     sap_sid:                           "{{ sid_to_be_deployed.sid }}"
     scs_instance_number:               "{{ sid_to_be_deployed.ascs_inst_no }}"
     sidadm_uid:                        "{{ sid_to_be_deployed.sidadm_uid }}"
     virt_do_not_resolve_hostname:      "{{ db_lb_virtual_host }}"
-
-  tags:
-    - skip_ansible_lint
 
 - name:                                "PAS Install: register variables"
   ansible.builtin.set_fact:
@@ -227,7 +223,7 @@
       failed_when:                     scs_extraction.rc > 0
 
     - name:                            "PAS Install"
-      win_shell: |
+      ansible.windows.win_shell: |
                                        {{ download_directory_windows }}\sap_extract\sapinst.exe SAPINST_INPUT_PARAMETERS_URL={{ dir_params }}\{{ sap_inifile }}  `
                                                                                                 SAPINST_EXECUTE_PRODUCT_ID={{ pas_bom_id }}                      `
                                                                                                 SAPINST_SKIP_DIALOGS=true                                        `
@@ -244,8 +240,6 @@
         ansible_become_password:       "{{ domain_user_password }}"
       register:                        pas_installation
       failed_when:                     pas_installation.rc > 0
-      tags:
-        - skip_ansible_lint
 
     - name:                            "PAS Install: Installation results"
       ansible.builtin.debug:

--- a/deploy/ansible/roles-sap/windows/5.3-app-install/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/windows/5.3-app-install/tasks/main.yaml
@@ -160,15 +160,11 @@
     sap_db_hostname:                   "{{ db_virtual_host }}"
     sap_ciVirtualHostname:
     sap_appVirtualHostname:            "{{ virtual_host }}"
-    tier:                              "{{ tier }}"
     param_directory:                   "{{ dir_params }}"
     sap_sid:                           "{{ sid_to_be_deployed.sid }}"
     scs_instance_number:               "{{ sid_to_be_deployed.ascs_inst_no }}"
     sidadm_uid:                        "{{ sid_to_be_deployed.sidadm_uid }}"
     virt_do_not_resolve_hostname:      "{{ db_lb_virtual_host }}"
-
-  tags:
-    - skip_ansible_lint
 
 - name:                                "APP Install: register variables"
   ansible.builtin.set_fact:
@@ -243,8 +239,6 @@
         ansible_become_password:       "{{ domain_user_password }}"
       register:                        app_installation
       failed_when:                     app_installation.rc > 0
-      tags:
-        - skip_ansible_lint
 
     - name:                            "APP Install: Installation results"
       ansible.builtin.debug:


### PR DESCRIPTION
## Problems
- No support for Red Hat Enterprise Linux 8.7 (which is supported by SAP / DB2 deployements)
- BOM processing fails when using a deployer without root permissions (again)
- Support deployer without /mnt disk
- OS configuration done flag tasks should run without root permissions
- 2.6.0-afs-mounts role is included for every other NFS type as ANF, should be AFS only
- BOM downloader fails when using a deployer without root permissions
- DB2 installation fails when /tmp has noexec mount option
- Ansible-Lint fails
- Github action workflow fails

## Solution
- Add Red Hat Enterprise Linux 8.7 (RHEL 8.7) as operating system
- Add bom_processing_become variable to allow bom processing without root permissions
- Add when statement to check free diskspace of /mnt filesystem
- Remove become parameter for OS configuration done flag task
- 2.6.0-afs-mounts role is included only when NFS type is set to AFS
- Add bom_processing_become variable to BOM downloader
- Add DB2TMPDIR to set temporary db2 installation location
- Remove skip_ansible_lint tags and add noqa comments when necessary
- Remove requirements.yml from workflow directory, requirements.yml in ansible directory is enough

## Tests
- Deploy a DB2 stack on RHEL 8.7 (custom azure image) with /tmp mounted as noexec. NFS option set to NFS (custom)

## Notes
- Ansible-Lint actions still shows warnings like 'Unable to load module ansible.windows.win_find at deploy/ansible/roles-sap/windows/5.1-dbload/tasks/main.yaml:265 for options validation'. I believe this has something to do with ansible-lint v 6.11 and should be fixed in v6.13 but there is no Ansible Lint for GitHub Action available for this version yet.