### PR TITLE
Fix linting

### DIFF
--- a/deploy/ansible/roles-db/4.0.1-hdb-hsr/tasks/4.0.1.5-provision_hana_replication.yml
+++ b/deploy/ansible/roles-db/4.0.1-hdb-hsr/tasks/4.0.1.5-provision_hana_replication.yml
@@ -29,7 +29,7 @@
     HOME:                              "/usr/sap/{{ db_sid | upper }}/home"
     PYTHONHOME:                        "/usr/sap/{{ DB }}/exe/Python3"
     DIR_EXECUTABLE:                    "/usr/sap/{{ DB }}/exe"
-    SAP_RETRIEVAL_PATH:                "/usr/sap/{{ DB }}/{{ ansible_hostname | lower}}"
+    SAP_RETRIEVAL_PATH:                "/usr/sap/{{ DB }}/{{ ansible_hostname | lower }}"
     DIR_SYSEXE:                        "/usr/sap/{{ db_sid | upper }}/SYS/exe/hdb"
     SAPSYSTEMNAME:                     "{{ db_sid | upper }}"
     SECUDIR:                           "/usr/sap/{{ DB }}/{{ ansible_hostname | lower }}/sec"

--- a/deploy/ansible/roles-os/1.5.1-disk-setup-asm/tasks/main.yml
+++ b/deploy/ansible/roles-os/1.5.1-disk-setup-asm/tasks/main.yml
@@ -58,7 +58,7 @@
 # -------------------------------------+---------------------------------------8
 #
 - name:                                "ORACLE ASM: Volume Group creation"
-  community.general.system.lvg:
+  community.general.lvg:
     vg:                                "{{ item.vg }}"
     pvs:                               "{{ item.pvs }}"
     pesize:                            4M
@@ -89,7 +89,7 @@
 # -------------------------------------+---------------------------------------8
 #
 - name:                                "ORACLE ASM: Logical Volume creation"
-  community.general.system.lvol:
+  community.general.lvol:
     lv:                                "{{ item.lv }}"
     vg:                                "{{ item.vg }}"
     size:                              "{{ item.size }}"
@@ -137,7 +137,7 @@
 
 
 - name:                                "ORACLE ASM: Filesystem creation"
-  community.general.system.filesystem:
+  community.general.filesystem:
     dev:                               "{{ dev_path_from_lv_item }}"
     fstype:                            "{{ item.fstype }}"
     opts:                              "{{ item.fsopts | default('') }}"

--- a/deploy/ansible/roles-os/1.5.2-disk-setup-ora-multi-sid/tasks/main.yml
+++ b/deploy/ansible/roles-os/1.5.2-disk-setup-ora-multi-sid/tasks/main.yml
@@ -30,7 +30,7 @@
 # -------------------------------------+---------------------------------------8
 #
 - name:                                "Oracle (sharedHome) - Volume Group creation"
-  community.general.system.lvg:
+  community.general.lvg:
     vg:                                "{{ item.vg }}"
     pvs:                               "{{ item.pvs }}"
     pesize:                            4M
@@ -46,7 +46,7 @@
 # -------------------------------------+---------------------------------------8
 #
 - name:                                "Oracle (sharedHome) - Logical Volume creation"
-  community.general.system.lvol:
+  community.general.lvol:
     lv:                                "{{ item.lv }}"
     vg:                                "{{ item.vg }}"
     size:                              "{{ item.size }}"
@@ -71,7 +71,7 @@
     lv_created_list:                   "{{ lv_created_list_tmp | map(attribute='item.lv') | list }}"
 
 - name:                                "Oracle (sharedHome) - File system creation"
-  community.general.system.filesystem:
+  community.general.filesystem:
     dev:                               "{{ dev_path_from_lv_item }}"
     fstype:                            "{{ item.fstype }}"
     opts:                              "{{ item.fsopts | default('') }}"

--- a/deploy/ansible/roles-os/1.6-timezone/tasks/main.yaml
+++ b/deploy/ansible/roles-os/1.6-timezone/tasks/main.yaml
@@ -5,7 +5,7 @@
 # -----------------------------------------------------------------------------
 
 - name:                                1.6 - Setting OS timezone
-  community.general.system.timezone:
+  community.general.timezone:
     name:                              "{{ timezone }}"
 
 # /*----------------------------------------------------------------------------8


### PR DESCRIPTION
## Problem
- Jinja spacing lint failure in provision_hana_replication task
- Use of community.general.system is deprecated

## Solution
- Fix jinja spacing in provision_hana_replication task
- Use community.general fqcn (same as other tasks)