### PR TITLE
Directory permissions sap_deployment_automation should be set to 0755

### DIFF
--- a/deploy/ansible/roles-sap-os/2.5-sap-users/tasks/user_nw.yaml
+++ b/deploy/ansible/roles-sap-os/2.5-sap-users/tasks/user_nw.yaml
@@ -22,7 +22,7 @@
   loop:
     - { mode: '0755', path: '{{ dir_params }}' }
     - { mode: '0755', path: '{{ tmp_directory }}/{{ sid_to_be_deployed.sid | upper }}' }
-    - { mode: '0766', path: '/etc/sap_deployment_automation/{{ sid_to_be_deployed.sid | upper }}' }
+    - { mode: '0755', path: '/etc/sap_deployment_automation/{{ sid_to_be_deployed.sid | upper }}' }
 
 - name:                                "User Creation: Set the Server name list"
   ansible.builtin.set_fact:


### PR DESCRIPTION
0766 is useless as the other user has no execute permissions and can't traverse into the directory. On all other places in the code 0755 is specified, lets keep it the same.