### PR TITLE
Add SCSHA and ERS inifile for HA deployments of S4HANA_2021_FP01 BOM

### DIFF
--- a/deploy/ansible/BOM-catalog/S4HANA_2021_FP01_v0001ms/templates/S4HANA_2021_FP01_v0001ms-scsha-inifile-param.j2
+++ b/deploy/ansible/BOM-catalog/S4HANA_2021_FP01_v0001ms/templates/S4HANA_2021_FP01_v0001ms-scsha-inifile-param.j2
@@ -1,0 +1,37 @@
+#   2482103 - Installation with SWPM in unattended mode using parameter input file fails
+#   2393060 - SAPinst Framework 749 Central Note
+
+########################################################################################################################################################################################################
+#                                                                                                                                                                                                      #
+# Installation service 'SAP S/4HANA Server 2021 > SAP HANA Database > Installation > Application Server ABAP                                                                                           #
+#                       > Distributed System > ASCS Instance', product id 'NW_ABAP_ASCS:S4HANA2021.CORE.HDB.ABAP'                                                                                      #
+#                       > Distributed System > Database Instance', product id 'NW_ABAP_DB:S4HANA2021.CORE.HDB.ABAP'                                                                                    #
+#                       > Distributed System > Primary Application Server Instance', product id 'NW_ABAP_CI:S4HANA2021.CORE.HDB.ABAP'                                                                  #
+#                       > Additional SAP System Instances > Additional Application Server Instance', product id 'NW_DI:S4HANA2021.CORE.HDB.PD'                                                         #
+#                       Generic Options > SAP HANA Database > Preparations > Operating System Users and Groups', product id 'NW_Users_Create:GENERIC.HDB.PD'                                           #
+########################################################################################################################################################################################################
+
+archives.downloadBasket                                               = {{ target_media_location }}/download_basket
+
+nwUsers.sapadmUID                                                     = {{ sapadm_uid }}
+nwUsers.sapsysGID                                                     = {{ sapsys_gid }}
+nwUsers.sidAdmUID                                                     = {{ sidadm_uid }}
+
+#nwUsers.sidadmPassword                                               = {{ main_password }}
+
+NW_Delete_Sapinst_Users.removeUsers                                   = true
+NW_GetMasterPassword.masterPwd                                        = {{ main_password }}
+NW_GetSidNoProfiles.sid                                               = {{ sap_sid }}
+
+NW_SCS_Instance.ascsInstallGateway                                    = true
+NW_SCS_Instance.ascsInstallWebDispatcher                              = false
+NW_SCS_Instance.instanceNumber                                        = {{ scs_instance_number }}
+NW_SCS_Instance.scsVirtualHostname                                    = {{ sap_scs_hostname }}
+
+NW_adaptProfile.skipSecurityProfileSettings                           = true
+NW_getFQDN.FQDN                                                       = {{ sap_fqdn }}
+
+
+
+
+


### PR DESCRIPTION
## Problem
- S4HANA_2021_FP01_v0001ms-scsha-inifile-param.j2 is missing
- S4HANA_2021_FP01_v0001ms-ers-inifile-param.j2 is missing

## Solution
- Add S4HANA_2021_FP01_v0001ms-scsha-inifile-param.j2 (copy of scs-inifile)
- Add S4HANA_2021_FP01_v0001ms-ers-inifile-param.j2 (copy of S4HANA_2021_ISS_v0001ms-ers-inifile-param)