### PR TITLE
Fix hardcoded HANA port in hdbuserstore list

### DIFF
--- a/deploy/ansible/roles-sap/5.2-pas-install/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.2-pas-install/tasks/main.yaml
@@ -251,7 +251,7 @@
       become:                          true
       become_user:                     "{{ sid_to_be_deployed.sid | lower }}adm"
       ansible.builtin.shell: |
-                                       {{ hdbuserstore_path }} SET DEFAULT {{ db_lb_virtual_host }}:30313@{{ db_sid | upper }} {{ hana_schema }} {{ main_password }}
+                                       {{ hdbuserstore_path }} SET DEFAULT {{ db_lb_virtual_host }}:3{{ db_instance_number }}13@{{ db_sid | upper }} {{ hana_schema }} {{ main_password }}
       environment:
         SAPSYSTEMNAME:                 "{{ sid_to_be_deployed.sid | upper }}"
         TMPDIR:                        "{{ hdbuserstore_path }}"

--- a/deploy/ansible/roles-sap/5.3-app-install/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.3-app-install/tasks/main.yaml
@@ -273,7 +273,7 @@
         - platform == 'HANA'
 
     - name:                            "APP Install: Set DB Virtual Host name ({{ db_lb_virtual_host }})"
-      ansible.builtin.shell:           "{{ hdbuserstore_path }} SET DEFAULT {{ db_lb_virtual_host }}:30313@{{ db_sid | upper }} {{ hana_schema }} {{ main_password }}"
+      ansible.builtin.shell:           "{{ hdbuserstore_path }} SET DEFAULT {{ db_lb_virtual_host }}:3{{ db_instance_number }}13@{{ db_sid | upper }} {{ hana_schema }} {{ main_password }}"
       environment:
         SAPSYSTEMNAME:                 "{{ sid_to_be_deployed.sid | upper }}"
         ssfs_connect:                  "1"


### PR DESCRIPTION
HANA port in hdbuserstore is hardcoded to 30313 for App and PAS install tasks. Fixed to correctly generate correct port for deployed HANA instances.

## Problem
Issue reported by a customer. Customer notified us that hdbuserstore has incorrect HANA port assigned to cluster name.
Investigation revealed static port assignment of 30313 which assumes HANA instance ID is always 03.

## Solution
Fixed by assigning logic to generate port using ansible vaiable "db_instance_number"