### PR TITLE
Update 5.5.1-set_runtime_facts.yml

### DIFF
--- a/deploy/ansible/roles-sap/5.5-hanadb-pacemaker/tasks/5.5.1-set_runtime_facts.yml
+++ b/deploy/ansible/roles-sap/5.5-hanadb-pacemaker/tasks/5.5.1-set_runtime_facts.yml
@@ -60,7 +60,7 @@
   block:
     - name:                            Check HANA DB Version and register
       become_user:                     "{{ db_sid | lower }}adm"
-      ansible.builtin.command:         /hana/shared/{{ db_sid | upper }}/HDB00/HDB version
+      ansible.builtin.command:         /hana/shared/{{ db_sid | upper }}/HDB{{ db_instance_number }}/HDB version
       register:                        hdbversion
       changed_when:                    false
 


### PR DESCRIPTION
Chaning the HDB instance number from hardcoded to a parameterized

## Problem
The customer was having HDB instance number other than 00 and the execution failed since it was hardcoded as HDB00

## Solution
Introduced the parameter db_instance_number

## Tests
Execute HANA HSR setup

## Notes
NA