### PR TITLE
Fixed ordering for logical volume creation.

### DIFF
--- a/deploy/ansible/roles-os/1.5-disk-setup/tasks/main.yml
+++ b/deploy/ansible/roles-os/1.5-disk-setup/tasks/main.yml
@@ -55,15 +55,15 @@
 - name:                                "1.5 Disk setup - Load the disk configuration settings"
   ansible.builtin.include_vars:        disks_config.yml
 
-- name:                                "1.5 Disk setup - Append 'sapmnt' if neeeded"
-  ansible.builtin.set_fact:
-    logical_volumes:                   "{{ logical_volumes_sapmnt + logical_volumes }}"
-  when: sap_mnt is not defined
-
 - name:                                "1.5 Disk setup - Append 'install' if needed"
   ansible.builtin.set_fact:
     logical_volumes:                   "{{ logical_volumes_install + logical_volumes }}"
   when: usr_sap_install_mountpoint is not defined
+
+- name:                                "1.5 Disk setup - Append 'sapmnt' if neeeded"
+  ansible.builtin.set_fact:
+    logical_volumes:                   "{{ logical_volumes_sapmnt + logical_volumes }}"
+  when: sap_mnt is not defined
 
 - name:                                "1.5 Disk setup - Append 'hanashared' if needed"
   ansible.builtin.set_fact:


### PR DESCRIPTION
## Problem
Merge the code for 3.8.3.1 release in sdaf. This release contains a fix that plagues single server installations due to the faulty order of the lv creation within vg_sap. lv_usrsapinstall was being created before the other lvs which was resulting in the entire space allocated to the vg_sap being allocated to the lv_usrsapinstall. This was failing the other lv creations.

## Solution
lv_usrsapinstall creation is now made the last lv created so that all remaining space is allocated to it post the creation of lv_sapmnt and lv_usrsap.

## Tests
Deploy single server systems using by the sdaf release 3.8.3.1 from ACSS portal. The create infra procedure should succeed.

## Proof of Testing

Query to view the results for createinfra test:

https://waasservices.eastus.kusto.windows.net/WaaSKustoDB?query=H4sIAAAAAAAEAG2RTUsDQQyG7%2FsrwpwqbGFZQUGpILXCHvzAFXoQD2kmtaO7M0sm21Lwxzur0A8qzCFD3id5k8wR6wdWcTRbs9fsGzYrFoZnYXKRX13LtWLbwQ1YVNb0H5VFeT4uLsblJRTF1e8724F1v4gkrlMXfGXBeRhVXlk8NoepuCdeOIZeiJOagld0PoJBuwpkdpq71NfHgXsz8yBfyyZsHrFl8w6TCZipcDJX%2BaVgVOlJe%2BH%2F4aeOBQcDaSod8MGgqXsiZsvW5GDu0TUpGgx2Ej6Z9GQb%2BVHNmUiQabD85yiHmmXtiG9J3drptrL5wZBD%2FJHAHPb51CqIZYHF9kh5cgWMdJ1lP74BzVW1AQAA&web=0 

WaaSMetricEvent
| where PreciseTimeStamp > datetime(2023-06-27 00:00:00)
| where SubscriptionId in (InternalSubscriptions)
| where ResourceId contains "adhoc"
| where Dimensions["WorkflowName"] == "CreateInfrastructure"
| where Dimensions["OperationState"] in ("Succeeded", "Failed")
| project PreciseTimeStamp, Dimensions["ErrorCodeName"], ServiceActivityId, ResourceId, Region, ActivityId
| order by ResourceId, PreciseTimeStamp asc;

Query to view the results for install test:

https://waasservices.eastus.kusto.windows.net/WaaSKustoDB?query=H4sIAAAAAAAEAG2RTUsDMRCG7%2FsrhpwqbGFZQUGpIFphD37gCj2Ih2ky2mg2WSazWwr%2BeBOFflAhhwnv%2B%2BSdmSwQ23sStno%2BkpfiG9YrYoInJm0jvdiOWsGuhyswKCTpPqmr%2BnRanU3rc6iqi99zsgXbYRk1215s8I0B62HSeCH26PaluCOeKYaBNSW3Dl7Q%2BggKzSpotfXcplwfM%2FeqFoG%2F3l1YP2BH6g1mM1CNj4LOZcUFNP9zjz0x5uw0kGQy96baQWsiQ0aVoO7QulTl3noOn6TlaBHlwZtz5sA3wdBfMyW0xKPVdK3FjlY2jSn35sv1RwJL2OkpKrAhhuXmwHn0ARj1ZVH8AGqZJGKwAQAA&web=0 

WaaSMetricEvent
| where PreciseTimeStamp > datetime(2023-06-27 00:00:00)
| where SubscriptionId in (InternalSubscriptions)
| where ResourceId contains "adhoc"
| where Dimensions["WorkflowName"] == "InstallWorkload"
| where Dimensions["OperationState"] in ("Succeeded", "Failed")
| project PreciseTimeStamp, Dimensions["ErrorCodeName"], ServiceActivityId, ResourceId, Region, ActivityId
| order by ResourceId, PreciseTimeStamp asc;

1 SCS failure observed which was transient and succeeded on retry
These are the other errors observed which are not related to ansible:
InstallHostUnreachable
InstallServiceError
AzureVMIsNotInSupportedProvisioningState