### PR TITLE
Update configure_deployer.sh

### DIFF
--- a/deploy/scripts/configure_deployer.sh
+++ b/deploy/scripts/configure_deployer.sh
@@ -429,11 +429,11 @@ esac
 case "$(get_distro_name)" in
 (ubuntu)
     sudo snap install dotnet-sdk --classic --channel=7.0
-    sudo snap alias dotnet-sdk.dotnet dotnet dotnet
+    sudo snap alias dotnet-sdk.dotnet dotnet
     ;;
 (sles)
     sudo snap install dotnet-sdk --classic --channel=7.0
-    sudo snap alias dotnet-sdk.dotnet dotnet dotnet
+    sudo snap alias dotnet-sdk.dotnet dotnet
     ;;
   (rhel*)
     sudo dnf install dotnet-sdk-7.0


### PR DESCRIPTION
Removed duplicate "dotnet" argument in dotnet-sdk alias command for Ubuntu and SLES.



## Problem
Was resulting in error message: "error: too many arguments for command"

## Solution
Removed duplicate 'dotnet' argument

## Tests
Fail:  sudo snap alias dotnet-sdk.dotnet dotnet dotnet
Pass:  sudo snap alias dotnet-sdk.dotnet dotnet

## Notes
Testing on Ubuntu 22.04 LTS.