### PR TITLE
Provide several fixes for Terraform and Ansible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,8 @@ Webapp/SDAF/Properties/PublishProfiles
 Webapp/.vs/ProjectEvaluation
 Webapp/SDAF/Properties/ServiceDependencies
 
-
 # Ignore OS files         - MKD 20221221
 **/.DS_Store
+
+# Ignore Python cache directories
+__pycache__

--- a/deploy/ansible/playbook_00_validate_parameters.yaml
+++ b/deploy/ansible/playbook_00_validate_parameters.yaml
@@ -408,26 +408,6 @@
 
     - name:                            "0.0 Validations - Check internet connectivity"
       ansible.builtin.uri:
-        # url: "https://management.azure.com/subscriptions/{{ subscription_id }}/providers/Microsoft.Web/sites?api-version=2022-03-01"
-        url: "https://azure.status.microsoft/en-us/status"
-        # headers:
-        #   Authorization: "Bearer {{ access_token }}"
-        #   Content-Type: application/json
-        #   Accept: application/json
-        status_code:
-          - 200
-          - 403
-      register: internet_check
-      vars:
-        ansible_python_interpreter: "{{ python_version }}"
-      when:
-        - (ansible_distribution | lower ~ ansible_distribution_major_version) in ['suse15', 'redhat8', 'redhat9', 'sles_sap15' ]
-        - ansible_os_family != "Windows"
-      tags:
-        - 0.0-internet
-
-    - name:                            "0.0 Validations - Check internet connectivity"
-      ansible.builtin.uri:
         url: "https://management.azure.com/subscriptions/{{ subscription_id }}/providers/Microsoft.Web/sites?api-version=2022-03-01"
         headers:
           Authorization: "Bearer {{ access_token }}"
@@ -436,13 +416,10 @@
         status_code:
           - 200
           - 403
-      register: internet_check
       when:
-        - (ansible_distribution | lower ~ ansible_distribution_major_version) != 'suse15'
-        - (ansible_distribution | lower ~ ansible_distribution_major_version) != 'sles_sap15'
-        - (ansible_distribution | lower ~ ansible_distribution_major_version) != 'redhat8'
-        - (ansible_distribution | lower ~ ansible_distribution_major_version) != 'redhat9'
+        - (ansible_distribution | lower ~ ansible_distribution_major_version) in ['suse15', 'redhat8', 'redhat9', 'sles_sap15' ]
         - ansible_os_family != "Windows"
+        - check_outbound | bool
       tags:
         - 0.0-internet
 

--- a/deploy/ansible/playbook_05_03_sap_app_install.yaml
+++ b/deploy/ansible/playbook_05_03_sap_app_install.yaml
@@ -161,6 +161,7 @@
         all_sids:                      "{% if MULTI_SIDS is defined %}{{ MULTI_SIDS }}{% else %}{{ all_sids | default([]) + [this_sid] }}{% endif %}"
 
     - name:                            "Run the APP Installation on Linux"
+      become:                          true
       when: ansible_os_family != "Windows"
       block:
 
@@ -186,7 +187,6 @@
                 - 2.6-sap-mounts
 
         - name:                        Run the APP installation Playbook
-          become:                      true
           block:
             - name:                    "APP Playbook - Install: Include 5.3-app-install"
               ansible.builtin.include_role:

--- a/deploy/ansible/playbook_bom_downloader.yaml
+++ b/deploy/ansible/playbook_bom_downloader.yaml
@@ -14,7 +14,7 @@
   connection:                           local
   environment:
     ANSIBLE_COLLECTIONS_PATHS:         "/opt/ansible/collections"
-  become:                               "{{ bom_processing_become  }}"
+  become:                               "{{ bom_processing_become }}"
   become_user:                          "{{ orchestration_ansible_user }}"
   vars_files:
     - vars/ansible-input-api.yaml                                               # API Input template with defaults

--- a/deploy/ansible/roles-misc/0.6-ARM-Deployment/tasks/main.yaml
+++ b/deploy/ansible/roles-misc/0.6-ARM-Deployment/tasks/main.yaml
@@ -1,14 +1,13 @@
 - name:                                "SDAF: Check if running on deployer"
-  become:                              true
-  become_user:                         "{{ orchestration_ansible_user }}"
   delegate_to:                         localhost
+  become:                              false
   ansible.builtin.stat:
     path:                              /etc/profile.d/deploy_server.sh
   register:                            on_deployer
 
 - name:                                "SDAF: Perform ARM Deployment"
+  when:                                on_deployer.stat.exists
   block:
-
     - name:                            "SDAF: Set Deployment Type"
       delegate_to:                     localhost
       ansible.builtin.set_fact:
@@ -56,5 +55,3 @@
                                        az deployment group create --resource-group {{ resourceGroupName }} --subscription {{ subscriptionId }} --name {{ deployment_name }} --template-file './templates/empty-deployment.json' --output none --no-prompt --no-wait --only-show-errors
           register:                    arm_deployment
           changed_when:                false
-
-  when:                                on_deployer.stat.exists

--- a/deploy/ansible/roles-sap-os/2.10-sap-notes/tasks/2.10.3119751.yaml
+++ b/deploy/ansible/roles-sap-os/2.10-sap-notes/tasks/2.10.3119751.yaml
@@ -1,4 +1,4 @@
-- name:                                "SAP Note 31197511 make directory"  # noqa package-latest
+- name:                                "SAP Note 3119751 make directory"
   become:                              true
   ansible.builtin.file:
     path:                              /usr/sap/lib
@@ -7,13 +7,13 @@
     owner:                             '{{ sidadm_uid }}'
     group:                             sapsys
 
-
-- name:                                "SAP Note 31197511 create link"  # noqa package-latest
+- name:                                "SAP Note 3119751 create symlink"
   become:                              true
   ansible.builtin.file:
     src:                               /opt/rh/SAP/lib64/compat-sap-c++-10.so
     dest:                              /usr/sap/lib/libstdc++.so.6
     state:                             link
+    follow:                            false
     mode:                              0755
     owner:                             '{{ sidadm_uid }}'
     group:                             sapsys

--- a/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/main.yaml
+++ b/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/main.yaml
@@ -197,7 +197,7 @@
     state:                             directory
     recurse:                           true
   when:
-    - node_tier != "oracle-asm"
+    - node_tier not in ['oracle-asm', 'hana']
 
 - name:                                "2.6 SAP Mounts: - sapmnt"
   block:

--- a/deploy/ansible/roles-sap/0.1-bom-validator/tasks/pre_checks.yaml
+++ b/deploy/ansible/roles-sap/0.1-bom-validator/tasks/pre_checks.yaml
@@ -214,18 +214,18 @@
 #
     - name:                            "{{ task_prefix }} - Create BOM download directories"
       become:                          "{{ bom_processing_become }}"
-      become_user:                     "{{ orchestration_ansible_user }}"
+      become_user:                     root
       ansible.builtin.file:
-        path:                          "{{ item.path }}"
+        path:                          "{{ item }}"
         state:                         directory
-        mode:                          '{{ item.mode }}'
-        owner:                         "{{ orchestration_ansible_user }}"
+        mode:                          0755
+        owner:                         "{{ orchestration_ansible_user if bom_processing_become else omit }}"
       delegate_to:                     localhost
       loop:
-        - { mode: '0755', path: '{{ download_directory }}' }
-        - { mode: '0755', path: '{{ download_directory }}/tmp' }
-        - { mode: '0755', path: '{{ download_directory }}/files' }
-        - { mode: '0755', path: '{{ download_directory }}/bom' }
+        - "{{ download_directory }}"
+        - "{{ download_directory }}/tmp"
+        - "{{ download_directory }}/files"
+        - "{{ download_directory }}/bom"
 
 
 # Step: 07-01 - END

--- a/deploy/ansible/roles-sap/3.3-bom-processing/tasks/bom_processor.yaml
+++ b/deploy/ansible/roles-sap/3.3-bom-processing/tasks/bom_processor.yaml
@@ -41,21 +41,6 @@
 #                                                                              |
 # +------------------------------------4--------------------------------------*/
 
-- name:                                "3.3 BoM Processing: - Create BOM download directories"
-  ansible.builtin.file:
-    path:                              "{{ item.path }}"
-    state:                             directory
-    mode:                              0755
-  become:                              "{{ bom_processing_become }}"
-  become_user:                         root
-  delegate_to:                         localhost
-  loop:
-    - path: "{{ download_directory }}"
-    - path: "{{ download_directory }}/tmp"
-    - path: "{{ download_directory }}/bom"
-    - path: "{{ download_directory }}/files"
-
-
 - name:                                "3.3 BoM Processing: - Register BoM"
   ansible.builtin.include_role:
     name:                              roles-sap/3.3.1-bom-utility

--- a/deploy/ansible/roles-sap/3.3-bom-processing/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/3.3-bom-processing/tasks/main.yaml
@@ -42,18 +42,18 @@
 
 - name:                                "3.3 BoM Processing: - Create BOM download directories"
   ansible.builtin.file:
-    path:                              "{{ item.path }}"
+    path:                              "{{ item }}"
     state:                             directory
     mode:                              0755
-    owner:                              "{{ orchestration_ansible_user }}"
+    owner:                              "{{ orchestration_ansible_user if bom_processing_become else omit }}"
   delegate_to:                         localhost
   become:                              "{{ bom_processing_become }}"
   become_user:                         root
   loop:
-    - path: "{{ download_directory }}"
-    - path: "{{ download_directory }}/tmp"
-    - path: "{{ download_directory }}/bom"
-    - path: "{{ download_directory }}/files"
+    - "{{ download_directory }}"
+    - "{{ download_directory }}/tmp"
+    - "{{ download_directory }}/bom"
+    - "{{ download_directory }}/files"
 
 - name:                                "3.3 BoM Processing: - Run the bom-register"
   ansible.builtin.include_role:

--- a/deploy/ansible/roles-sap/3.3.1-bom-utility/tasks/bom-register.yaml
+++ b/deploy/ansible/roles-sap/3.3.1-bom-utility/tasks/bom-register.yaml
@@ -19,18 +19,18 @@
 #
 - name:                                 "3.3.1 BoM Processing: - Create BOM download directories"
   ansible.builtin.file:
-    path:                               "{{ item.path }}"
+    path:                               "{{ item }}"
     state:                              directory
     mode:                               0755
-    owner:                              "{{ orchestration_ansible_user }}"
+    owner:                              "{{ orchestration_ansible_user if bom_processing_become else omit }}"
   delegate_to:                          localhost
   become:                               "{{ bom_processing_become }}"
   become_user:                          root
   loop:
-    - path: "{{ download_directory }}"
-    - path: "{{ download_directory }}/tmp"
-    - path: "{{ download_directory }}/bom"
-    - path: "{{ download_directory }}/files"
+    - "{{ download_directory }}"
+    - "{{ download_directory }}/tmp"
+    - "{{ download_directory }}/bom"
+    - "{{ download_directory }}/files"
 # Step: 01 - END
 # -------------------------------------+---------------------------------------8
 

--- a/deploy/ansible/roles-sap/3.3.1-bom-utility/tasks/bom-template.yaml
+++ b/deploy/ansible/roles-sap/3.3.1-bom-utility/tasks/bom-template.yaml
@@ -23,22 +23,6 @@
 # ------------------</DEBUGGING>------------------
 
 
-- name:                                "3.3.1 BoM Template processing: - Create BOM download directories"
-  ansible.builtin.file:
-    path:                              "{{ item.path }}"
-    state:                             directory
-    mode:                              0755
-    owner:                              "{{ orchestration_ansible_user }}"
-  delegate_to:                         localhost
-  become:                              "{{ bom_processing_become }}"
-  become_user:                         "{{ orchestration_ansible_user }}"
-  loop:
-    - path: "{{ download_directory }}"
-    - path: "{{ download_directory }}/tmp"
-    - path: "{{ download_directory }}/bom"
-    - path: "{{ download_directory }}/files"
-
-
 # -------------------------------------+---------------------------------------8
 #
 # Look for template in the storage account first

--- a/deploy/ansible/roles-sap/windows/3.3-bom-processing/tasks/bom_processor.yaml
+++ b/deploy/ansible/roles-sap/windows/3.3-bom-processing/tasks/bom_processor.yaml
@@ -41,21 +41,6 @@
 
 # +------------------------------------4--------------------------------------*/
 
-# - name:                                "3.3 BoM Processing: - Create BOM download directories"
-#   ansible.builtin.file:
-#     path:                              "{{ item.path }}"
-#     state:                             directory
-#     mode:                              0755
-#   become:                              true
-#   become_user:                         root
-#   delegate_to:                         localhost
-#   loop:
-#     - path: "{{ download_directory }}"
-#     - path: "{{ download_directory }}/tmp"
-#     - path: "{{ download_directory }}/bom"
-#     - path: "{{ download_directory }}/files"
-
-
 - name:                                "3.3 BoM Processing: - Register BoM"
   ansible.builtin.include_role:
     name:                              roles-sap/windows/3.3.1-bom-utility

--- a/deploy/ansible/roles-sap/windows/3.3-bom-processing/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/windows/3.3-bom-processing/tasks/main.yaml
@@ -40,21 +40,6 @@
   ansible.builtin.import_tasks:        pre_checks.yaml
 # -------------------------------------+---------------------------------------8
 
-# - name:                                "3.3 BoM Processing: - Create BOM download directories"
-#   ansible.builtin.file:
-#     path:                              "{{ item.path }}"
-#     state:                             directory
-#     mode:                              0755
-#   become:                              true
-#   delegate_to:                         localhost
-#   become_user:                         root
-#   loop:
-#     - path: "{{ download_directory }}"
-#     - path: "{{ download_directory }}/tmp"
-#     - path: "{{ download_directory }}/bom"
-#     - path: "{{ download_directory }}/files"
-
-
 - name:                                "3.3 BoM Processing: - Run the bom-register"
   ansible.builtin.include_role:
     name:                              roles-sap/windows/3.3.1-bom-utility

--- a/deploy/ansible/roles-sap/windows/3.3.1-bom-utility/tasks/bom-register.yaml
+++ b/deploy/ansible/roles-sap/windows/3.3.1-bom-utility/tasks/bom-register.yaml
@@ -15,17 +15,18 @@
 
 - name:                                "3.3.1 BoM Processing: - Create BOM download directories"
   ansible.builtin.file:
-    path:                              "{{ item.path }}"
+    path:                              "{{ item }}"
     state:                             directory
     mode:                              0755
+    owner:                             "{{ orchestration_ansible_user if bom_processing_become else omit }}"
   delegate_to:                         localhost
   become:                              "{{ bom_processing_become }}"
   become_user:                         root
   loop:
-    - path: "{{ download_directory }}"
-    - path: "{{ download_directory }}/tmp"
-    - path: "{{ download_directory }}/bom"
-    - path: "{{ download_directory }}/files"
+    - "{{ download_directory }}"
+    - "{{ download_directory }}/tmp"
+    - "{{ download_directory }}/bom"
+    - "{{ download_directory }}/files"
 
 - name:                                "3.3.1 BoM Processing: - Set the new name"
   ansible.builtin.set_fact:

--- a/deploy/terraform/run/sap_landscape/output.tf
+++ b/deploy/terraform/run/sap_landscape/output.tf
@@ -264,5 +264,5 @@ output "install_path" {
 
 output "controlplane_environment" {
   description = "Control plane environment"
-  value       = data.terraform_remote_state.deployer[0].outputs.environment
+  value       = try(data.terraform_remote_state.deployer[0].outputs.environmentm, "")
 }

--- a/deploy/terraform/terraform-units/modules/sap_landscape/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/infrastructure.tf
@@ -52,7 +52,7 @@ data "azurerm_virtual_network" "vnet_sap" {
 
 resource "azurerm_virtual_network_dns_servers" "vnet_sap_dns_servers" {
   provider = azurerm.main
-  count    = local.vnet_sap_exists && length(var.dns_server_list) > 0 ? 0 : 1
+  count    = local.vnet_sap_exists && length(var.dns_server_list) > 0 ? 1 : 0
   virtual_network_id = local.vnet_sap_exists ? (
     data.azurerm_virtual_network.vnet_sap[0].id) : (
     azurerm_virtual_network.vnet_sap[0].id

--- a/deploy/terraform/terraform-units/modules/sap_landscape/providers.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/providers.tf
@@ -3,7 +3,7 @@ terraform {
     azurerm = {
       source                = "hashicorp/azurerm"
       configuration_aliases = [azurerm.main, azurerm.deployer, azurerm.dnsmanagement, azurerm.peering]
-      version               = ">= 3.0"
+      version               = ">= 3.23"
     }
   }
 }

--- a/deploy/terraform/terraform-units/modules/sap_library/storage_accounts.tf
+++ b/deploy/terraform/terraform-units/modules/sap_library/storage_accounts.tf
@@ -62,6 +62,7 @@ resource "azurerm_storage_account_network_rules" "storage_tfstate" {
 }
 
 resource "azurerm_role_assignment" "storage_tfstate_contributor" {
+  count                = try(var.deployer_tfstate.deployer_uai.principal_id, "") != "" ? 1 : 0
   provider             = azurerm.main
   scope                = local.sa_tfstate_exists ? var.storage_account_tfstate.arm_id : azurerm_storage_account.storage_tfstate[0].id
   role_definition_name = "Storage Account Contributor"
@@ -378,6 +379,7 @@ resource "azurerm_storage_share" "fileshare_sapbits" {
 }
 
 resource "azurerm_role_assignment" "storage_sapbits_contributor" {
+  count                = try(var.deployer_tfstate.deployer_uai.principal_id, "") != "" ? 1 : 0
   provider             = azurerm.main
   scope                = local.sa_sapbits_exists ? var.storage_account_sapbits.arm_id : azurerm_storage_account.storage_sapbits[0].id
   role_definition_name = "Storage Account Contributor"

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/outputs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/outputs.tf
@@ -225,19 +225,19 @@ output "dns_info_vms" {
 
 output "dns_info_loadbalancers" {
   description = "DNS information for the application tier load balancers"
-
-  value = try(zipmap(
-    [
-      slice(local.load_balancer_IP_names, 0, try(length(azurerm_lb.scs[0].private_ip_addresses), 0)),
-      slice(local.web_load_balancer_IP_names, 0, try(length(azurerm_lb.web[0].private_ip_addresses), 0))
-    ],
-    [
-      azurerm_lb.scs[0].private_ip_addresses,
-      azurerm_lb.web[0].private_ip_addresses
-    ]
-  ), null)
-
-
+  value = try(
+    zipmap(
+      concat(
+        slice(local.load_balancer_IP_names, 0, try(length(azurerm_lb.scs[0].private_ip_addresses), 0)),
+        slice(local.web_load_balancer_IP_names, 0, try(length(azurerm_lb.web[0].private_ip_addresses), 0))
+      ),
+      concat(
+        try(azurerm_lb.scs[0].private_ip_addresses, []),
+        try(azurerm_lb.web[0].private_ip_addresses, [])
+      )
+    ),
+    null
+  )
 }
 
 

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/providers.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/providers.tf
@@ -3,7 +3,7 @@ terraform {
     azurerm = {
       source                = "hashicorp/azurerm"
       configuration_aliases = [azurerm.main, azurerm.deployer, azurerm.dnsmanagement]
-      version               = "~> 3.2"
+      version               = ">= 3.54"
     }
 
     azapi = {


### PR DESCRIPTION
## Problem
1. Terraform contained several problems when not using a deployer as well as some outdated version pins
2. The check for internet connection was always executed
3. When downloading the BOM it would be set to the `ansible_orchestrator_user` which isn't needed when running without become
4. `__pycache__` was included for commits
5. An unnecessary become was used on a check
6. The DNS loadbalancer output wasn't containing the SCS loadbalancer when not deploying the web
7. There is a become on a block of the installation of the APP, but not in the right place
8. A symlink is created for `compact-sap-c++-10`, but the owner and group was set on the source instead of the symlink
9. A `sapmnt` mountpoint is created on HANA systems which isn't needed

## Solution
1. Add/fix try statements and update version pins
2. Removed a duplicate task and added `check_outbound` to the when statement
3. Simplified some loops, removed duplicate tasks, and only set owner to `ansible_orchestrator_user` when become is true
4. `__pycache__` is added to the gitignore
5. Set the become to false
6. Fixed the zipmap/concat/slicing of the output variables
7. Moved the become to the correct position
8. Set `follow` to false to set the owner and group of the symlink itself
9. Updated the when statement to also exclude HANA

## Tests
We've deplyed a single and HA HANA stack without problems
