### PR TITLE
Fixing Logical Volume creation order

### DIFF
--- a/deploy/ansible/roles-os/1.5-disk-setup/tasks/main.yml
+++ b/deploy/ansible/roles-os/1.5-disk-setup/tasks/main.yml
@@ -55,15 +55,15 @@
 - name:                                "1.5 Disk setup - Load the disk configuration settings"
   ansible.builtin.include_vars:        disks_config.yml
 
+- name:                                "1.5 Disk setup - Append 'install' if needed"
+  ansible.builtin.set_fact:
+    logical_volumes:                   "{{ logical_volumes + logical_volumes_install }}"
+  when: usr_sap_install_mountpoint is not defined
+
 - name:                                "1.5 Disk setup - Append 'sapmnt' if neeeded"
   ansible.builtin.set_fact:
     logical_volumes:                   "{{ logical_volumes_sapmnt + logical_volumes }}"
   when: sap_mnt is not defined
-
-- name:                                "1.5 Disk setup - Append 'install' if needed"
-  ansible.builtin.set_fact:
-    logical_volumes:                   "{{ logical_volumes_install + logical_volumes }}"
-  when: usr_sap_install_mountpoint is not defined
 
 - name:                                "1.5 Disk setup - Append 'hanashared' if needed"
   ansible.builtin.set_fact:


### PR DESCRIPTION
## Problem
logical volumes gets created in wrong order. usrsapinstall lv gets created first of all the lvs for vg_sap due to which usrsapinstall gets all the 100% free space from vg_sap

## Solution
fixed the order of the logical volume in such as way that usrsapinstall always comes at last and gets 100% of the free space left after creating logical volumes for sapmnt and usrsap

## Tests
End 2 End testing was performed on Single, distributed and High Availability senarios for RHEL as well as SUSE

## Notes
<Additional comments for the PR>