### PR TITLE
Add RHEL 8.8

### DIFF
--- a/deploy/ansible/roles-os/1.3-repository/vars/repos.yaml
+++ b/deploy/ansible/roles-os/1.3-repository/vars/repos.yaml
@@ -23,6 +23,7 @@ repos:
   redhat8.6:
     - { tier:   'os', repo: 'epel', url: 'https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm', state: 'present' }
   redhat8.7:
+  redhat8.8:
   redhat9.0:
   redhat9.2:
   # do not have any repos that are needed for RedHat at the moment.

--- a/deploy/ansible/roles-os/1.4-packages/vars/os-packages.yaml
+++ b/deploy/ansible/roles-os/1.4-packages/vars/os-packages.yaml
@@ -262,6 +262,8 @@ packages:
     - { tier: 'ha',    package: 'fence-agents-azure-arm',                       node_tier: 'all',     state: 'present' }
   redhat8.7:
     - { tier: 'ha',    package: 'fence-agents-azure-arm',                       node_tier: 'all',     state: 'present' }
+  redhat8.8:
+    - { tier: 'ha',    package: 'fence-agents-azure-arm',                       node_tier: 'all',     state: 'present' }
   redhat9.0:
     - { tier: 'sapos', package: 'chkconfig',                                    node_tier: 'hana',    state: 'present' }
     - { tier: 'ha',    package: 'fence-agents-azure-arm',                       node_tier: 'all',     state: 'present' }


### PR DESCRIPTION
## Problem
Red Hat Enterprise Linux 8.8 is missing causing this error: The task includes an option with an undefined variable. The error was: 'dict object' has no attribute 'redhat8.8'. Red Hat 8.8 can be used for db2 deployments.

## Solution
Define RedHat 8.8 in repos and os-packages
