### PR TITLE
Cast db_sid for db2sid user and add abap_connect_user variable

### DIFF
--- a/deploy/ansible/roles-db/4.2.0-db2-install/tasks/main.yml
+++ b/deploy/ansible/roles-db/4.2.0-db2-install/tasks/main.yml
@@ -71,7 +71,7 @@
         sap_db_hostname:               "{{ query('inventory_hostnames', '{{ sap_sid | upper }}_DB') | first }}"
         db2_encryption_algo_type:      "AES"
         db2_ase_encryption_length:     "256"
-        db2_encryption_keystore_dir:   /db2/db2{{ db_sid }}/keystore
+        db2_encryption_keystore_dir:   /db2/db2{{ db_sid | lower }}/keystore
         db2_sslencryption_label:       "sap_db2{{ db_sid }}_{{ sap_db_hostname }}_ssl_comm_000"
         sap_scs_hostname:              "{{ query('inventory_hostnames', '{{ sap_sid | upper }}_SCS') | first }}"
         sap_profile_dir:               "/sapmnt/{{ sap_sid | upper }}/profile"
@@ -80,8 +80,8 @@
         param_directory:               "{{ dir_params }}"
     # +--------------------------------4--------------------------------------*/
     #
-    # - name:                            "SAP DB2 install: variables"
-    - name:                                "DB2 Install: install variables"
+    # - name:                          "SAP DB2 install: variables"
+    - name:                            "DB2 Install: install variables"
       ansible.builtin.debug:
         msg:
           - "INSTALLED:  {{ db2_installed.stat.exists }}"

--- a/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.0-db2_ha_install_primary.yml
+++ b/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.0-db2_ha_install_primary.yml
@@ -95,7 +95,7 @@
         sap_db_hostname:               "{{ query('inventory_hostnames', '{{ sap_sid | upper }}_DB') | first }}"
         db2_encryption_algo_type:      "AES"
         db2_ase_encryption_length:     "256"
-        db2_encryption_keystore_dir:   /db2/db2{{ db_sid }}/keystore
+        db2_encryption_keystore_dir:   /db2/db2{{ db_sid | lower }}/keystore
         db2_sslencryption_label:       "sap_db2{{ db_sid }}_{{ sap_db_hostname }}_ssl_comm_000"
         sap_scs_hostname:              "{{ query('inventory_hostnames', '{{ sap_sid | upper }}_SCS') | first }}"
         sap_profile_dir:               "/sapmnt/{{ sap_sid | upper }}/profile"

--- a/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.1-db2_primary_backup.yml
+++ b/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.1-db2_primary_backup.yml
@@ -96,7 +96,7 @@
         dbms_type: "db6"
         dbs_db6_schema: "sap{{ db_sid | lower }}"
         dbs_db6_user: "sap{{ db_sid | lower }}"
-        DB2DIR: "/db2/db2{{ db_sid }}/db2_software"
+        DB2DIR: "/db2/db2{{ db_sid | lower }}/db2_software"
         INST_DIR: "/db2/db2{{ db_sid | lower }}/sqllib"
         IBM_DB_DIR: "/db2/db2{{ db_sid | lower }}/sqllib"
         IBM_DB_LIB: "/db2/db2{{ db_sid | lower }}/sqllib/lib"

--- a/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.2-db2_ha_install_secondary.yml
+++ b/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.2-db2_ha_install_secondary.yml
@@ -85,7 +85,7 @@
         sap_db_hostname:               "{{ query('inventory_hostnames', '{{ sap_sid | upper }}_DB') | first }}"
         db2_encryption_algo_type:      "AES"
         db2_ase_encryption_length:     "256"
-        db2_encryption_keystore_dir:   /db2/db2{{ db_sid }}/keystore
+        db2_encryption_keystore_dir:   /db2/db2{{ db_sid | lower }}/keystore
         db2_sslencryption_label:       "sap_db2{{ db_sid }}_{{ sap_db_hostname }}_ssl_comm_000"
         sap_scs_hostname:               "{{ query('inventory_hostnames', '{{ sap_sid | upper }}_SCS') | first }}"
         sap_profile_dir:               "/sapmnt/{{ sap_sid | upper }}/profile"

--- a/deploy/ansible/vars/ansible-input-api.yaml
+++ b/deploy/ansible/vars/ansible-input-api.yaml
@@ -60,16 +60,18 @@ use_msi_for_clusters:                  false
 hana_components:                       "all"
 
 instance_type:                         "ASCS"
+
 # DB2 specific parameters
-# db2_sid:                                "DB6"
 db2sysadm_gid:                         3000
 db2sysctrl_gid:                        3001
 db2sysmaint_gid:                       3002
 db2sysmon_gid:                         3003
 db2sidadm_uid:                         3004
-db2sapsid_uid:                         3005
+db2sapsid_uid:                         3005 # Uid of the database connect user
 db2hadr_port1:                         51012
 db2hadr_port2:                         51013
+# Name of the database connect user for ABAP. Default value is 'sap<sapsid>'.
+db2_abap_connect_user:                 ""
 
 tmp_directory:                         "/var/tmp"
 url_internet:                          "http://www.github.com"                 # URL to use for internet access checks"


### PR DESCRIPTION
## Problem
- db2sid user has a lowercase home directory, db_sid is casted invalid to uppercase or not casted at all
- there is no option to control the username of the ABAP connect user

## Solution
- cast db2_sid to lower for db2 paths
- add db2_abap_connect_user to ansible-input-api

## Tests
Performed single stack DB2 installation on Red Hat Enterprise Linux 8.8