### PR TITLE
Merging changes from sdaf-acss main after creation of v3.8.3.5 (#482)

### DIFF
--- a/deploy/ansible/filter_plugins/custom_filters.py
+++ b/deploy/ansible/filter_plugins/custom_filters.py
@@ -29,7 +29,13 @@ regex_to_error_msgs = [
         {'task_tag=dbload', 'failure=messageserver_offline'}),
     (r'([\s\d\w\D\W]*)Make sure the database is online([\s\w\d\W\D]*)',
         'INSTALL:0021:DB Load failure, database is offline.',
-        {'task_tag=dbload', 'failure=db_offline'})
+        {'task_tag=dbload', 'failure=db_offline'}),
+    (r'([\s\d\w\D\W]*)Connect to message server([\s\w\d\W\D]*)Make sure that the message server is started([\s\w\d\W\D]*)',
+        'INSTALL:0024:PAS Install failed, unable to connect to message server.',
+        {'task_tag=pasinstall', 'failure=messageserver_offline'}),
+    (r'([\s\d\w\D\W]*)Make sure the database is online([\s\w\d\W\D]*)',
+        'INSTALL:0025:PAS Install failed, database is offline.',
+        {'task_tag=pasinstall', 'failure=db_offline'})
 ]
 
 # Takes a dictionary and converts it into a set of

--- a/deploy/ansible/roles-sap/5.2-pas-install/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.2-pas-install/tasks/main.yaml
@@ -179,22 +179,42 @@
       ansible.builtin.debug:
         msg:                           "Starting PAS installation ({{ sid_to_be_deployed.sid | upper }})"
 
-    - name:                            "PAS Install"
-      ansible.builtin.shell: |
-                                       umask {{ custom_umask | default('022') }} ;
-                                       ./sapinst SAPINST_INPUT_PARAMETERS_URL={{ dir_params }}/{{ sap_inifile }} \
-                                                 SAPINST_EXECUTE_PRODUCT_ID={{ pas_bom_id }}                     \
-                                                 SAPINST_SKIP_DIALOGS=true                                       \
-                                                 SAPINST_USE_HOSTNAME={{ virtual_host }}                         \
-                                                 SAPINST_START_GUISERVER=false
-      args:
-        chdir:                         "{{ target_media_location }}/SWPM"
-        creates:                       "/etc/sap_deployment_automation/{{ sid_to_be_deployed.sid | upper }}/sap_deployment_pas.txt"
-      environment:
-        TMPDIR:                        "{{ tmp_directory }}/{{ sid_to_be_deployed.sid | upper }}"
-        SAPSYSTEMNAME:                 "{{ sid_to_be_deployed.sid | upper }}"
-      register:                        pas_installation
-      failed_when:                     pas_installation.rc > 0
+    - name:                            "Starting PAS installation"
+      block:
+        - name:                            "PAS Install"
+          ansible.builtin.shell: |
+                                          umask {{ custom_umask | default('022') }} ;
+                                          ./sapinst SAPINST_INPUT_PARAMETERS_URL={{ dir_params }}/{{ sap_inifile }} \
+                                                    SAPINST_EXECUTE_PRODUCT_ID={{ pas_bom_id }}                     \
+                                                    SAPINST_SKIP_DIALOGS=true                                       \
+                                                    SAPINST_USE_HOSTNAME={{ virtual_host }}                         \
+                                                    SAPINST_START_GUISERVER=false
+          args:
+            chdir:                         "{{ target_media_location }}/SWPM"
+            creates:                       "/etc/sap_deployment_automation/{{ sid_to_be_deployed.sid | upper }}/sap_deployment_pas.txt"
+          environment:
+            TMPDIR:                        "{{ tmp_directory }}/{{ sid_to_be_deployed.sid | upper }}"
+            SAPSYSTEMNAME:                 "{{ sid_to_be_deployed.sid | upper }}"
+          register:                        pas_installation
+          failed_when:                     pas_installation.rc > 0
+
+      rescue:
+        - name:                        "Capturing the modified message for message server being offline"
+          ansible.builtin.set_fact:
+            modified_error_message:    "{{ pas_installation.stdout | try_get_error_code(task_tag='pasinstall', failure='messageserver_offline') }}"
+
+        - name:                        "Capturing the modified message for database being offline"
+          ansible.builtin.set_fact:
+            modified_error_message:    "{{ modified_error_message | try_get_error_code(task_tag='pasinstall', failure='db_offline') }}"
+
+        - name:                        "Debug: Modified error message"
+          ansible.builtin.debug:
+            msg:                       "Modified error message: {{ modified_error_message }}"
+          when:                         modified_error_message != pas_installation.stdout
+
+        - name:                        "Error Handling: Fail with the modified error message "
+          ansible.builtin.fail:
+            msg:                       "{{ modified_error_message }}"
 
     - name:                            "PAS Install: Installation results"
       ansible.builtin.debug:


### PR DESCRIPTION
* Added README.md file

* Added file CONTRIBUTING.md

* Updated README.md

* Updated CONTRIBUTING.md

* Added .gitignore

* Adding owners.txt containing ServiceTree admins

* v3.6 release

* Updated owners.txt

* Current code for ansible 3.7 that is being tested by ACSS.

* Added a delay before validating the SCS ERS cluster.

* Removed the BOM-catalog folder.

* Merged PR 8320960: Merging sap-automation main into this repo's main branch.

This is done as part of the 3.8.3 parity task. This is an attempt to bring the Co-Dev model into effect so that all ansible development can now happen through the SDAF-ASCS repo.

Related work items: #24291278

* Merged PR 8350970: Fix Logical Volume creation

Fix Logical Volume creation:
Description:

In the volume group vg_sap, we need to create several logical volumes which include for lv_sapmnt, lv_usrsapinstall, lv_usrsap. The goal is to allocate a predetermined amount of space to lv_sapmnt, lv_usersap and then allocate the rest of the space to lv_usersapinstall. But the order in which this allocation was being done was in reverse which resulted in lv_usersapinstall consuming all the space in vg_sap therefore, blocking the creation of other logical volumes. The ordering has been fixed in this PR.

This is the test proof for the same:

Query to view the results for createinfra test:

https://waasservices.eastus.kusto.windows.net/WaaSKustoDB?query=H4sIAAAAAAAEAG2RTUsDQQyG7%2fsrwpwqbGFZQUGpILXCHvzAFXoQD2kmtaO7M0sm21Lwxzur0A8qzCFD3id5k8wR6wdWcTRbs9fsGzYrFoZnYXKRX13LtWLbwQ1YVNb0H5VFeT4uLsblJRTF1e8724F1v4gkrlMXfGXBeRhVXlk8NoepuCdeOIZeiJOagld0PoJBuwpkdpq71NfHgXsz8yBfyyZsHrFl8w6TCZipcDJX%2baVgVOlJe%2bH%2f4aeOBQcDaSod8MGgqXsiZsvW5GDu0TUpGgx2Ej6Z9GQb%2bVHNmUiQabD85yiHmmXtiG9J3drptrL5wZBD%2fJHAHPb51CqIZYHF9kh5cgWMdJ1lP74BzVW1AQAA&web=0

WaaSMetricEvent
| where PreciseTimeStamp > datetime(2023-06-27 00:00:00) | where SubscriptionId in (InternalSubscriptions)
| where ResourceId contains "adhoc"
| where Dimensions["WorkflowName"] == "CreateInfrastructure" | where Dimensions["OperationState"] in ("Succeeded", "Failed") | project PreciseTimeStamp, Dimensions["ErrorCodeName"], ServiceActivityId, ResourceId, Region, ActivityId | order by ResourceId, PreciseTimeStamp asc;

Query to view the results for install test:

https://waasservices.eastus.kusto.windows.net/WaaSKustoDB?query=H4sIAAAAAAAEAG2RTUsDMRCG7%2fsrhpwqbGFZQUGpIFphD37gCj2Ih2ky2mg2WSazWwr%2beBOFflAhhwnv%2b%2bSdmSwQ23sStno%2bkpfiG9YrYoInJm0jvdiOWsGuhyswKCTpPqmr%2bnRanU3rc6iqi99zsgXbYRk1215s8I0B62HSeCH26PaluCOeKYaBNSW3Dl7Q%2bggKzSpotfXcplwfM%2feqFoG%2f3l1YP2BH6g1mM1CNj4LOZcUFNP9zjz0x5uw0kGQy96baQWsiQ0aVoO7QulTl3noOn6TlaBHlwZtz5sA3wdBfMyW0xKPVdK3FjlY2jSn35sv1RwJL2OkpKrAhhuXmwHn0ARj1ZVH8AGqZJGKwAQAA&web=0

WaaSMetricEvent
| where PreciseTimeStamp > datetime(2023-06-27 00:00:00) | where SubscriptionId in (InternalSubscriptions)
| where ResourceId contains "adhoc"
| where Dimensions["WorkflowName"] == "InstallWorkload" | where Dimensions["OperationState"] in ("Succeeded", "Failed") | project PreciseTimeStamp, Dimensions["ErrorCodeName"], ServiceActivityId, ResourceId, Region, ActivityId | order by ResourceId, PreciseTimeStamp asc;

1 SCS failure observed which was transient and succeeded on retry These are the other errors observed which are not related to ansible: InstallHostUnreachable
InstallServiceError
AzureVMIsNotInSupportedProvisioningState

Related work items: #24199283

* Merged PR 8352697: fix logical volume order with vg_sap

fix logical volume order with vg_sap

* Remediating Azure Artifacts Configuration Issues in your Repository

* Update owners.txt

* Remediating Azure Artifacts Configuration Issues in your Repository

* Merged PR 8383025: Getting latest release code from github repo into main branch.

Pulling in the changes made to the experimental branch so that the hotfix release (3.8.3.2) made in github public repo is present here as well

* Merged PR 8497623: Syncing SDAF Public main branch to SDAF-ACSS main branch

Syncing SDAF Public main branch to SDAF-ACSS main branch

Related work items: #24650568

* Merged PR 8543963: Added checks to see if dynamic BOM download has succeeded.

In /deploy/ansible/roles-sap/3.3-bom-processing/tasks/bom_processor.yaml, added checks to see if:
For every media element defined in a BOM
- Dynamic BOM download has succeeded.
- Whether archive property is defined.

* Revert "Merging changes made in v3.8.3.4 into experimental branch. (#477)"

This reverts commit e0f896055443237e7c102e9d61a66d47875cbe5e.

* Merged PR 8645288: Adding Custom Errors for PAS Install

Adding Custom Errors for PAS Install

Cherry-picked from commit `d81a4375`.

When ansible code failed during the pas installation with message server or database offline, then error message doesn't have the proper information on the error. With this code change we will be getting below error messages:-

Message server is offline--

PAS Installation failed due to Message Server being offline on host(s) %hostName;.
		Possible Causes: Message server is offline.
		Recommended Action:
		a) Login to the SCS VM with &lt;SID&gt;adm. The password is present in the key vault of the managed resource group of the VIS. (Secret name: &lt;SID&gt;-&lt;SID&gt;-sap-password)
		b) Start SAP Service using command - /usr/sap/hostctrl/exe/sapcontrol -nr &lt;instance number&gt; -function StartService &lt;SID&gt;.
		c) Start SAP Instances using command - /usr/sap/hostctrl/exe/sapcontrol -nr &lt;instance number&gt; -function StartSystem ALL.
		d) Check if the message server is up with command - /usr/sap/hostctrl/exe/sapcontrol -nr &lt;instance number&gt; -function GetSystemInstanceList
		e) Retry the installation once the message server is up.
		f) If the issue is not resolve through above steps, please contact support.

Database is offline--

PAS Installation failed due to database being offline on host(s) %hostName;. Possible Causes: Database is offline.
Recommended Action:
a) Login to the primary DB VM with <SID>adm. The password is present in the key vault of the managed resource group of the VIS. (Secret name: <SID>-<SID>-sap-password) b) Start HANA Database using command - HDB start.
c) Check the status of HDB using command - HDB info. d) Retry the installation once HDB is up and running. e) If the issue is not resolve through above steps, please contact support

Cherry picked from !8623571

Cherry-picked from commit `cc2974f3`.

Tested for CCY:--
WaaSDiagnosticEvent
	//| where ServiceActivityId == "3e30dcfa-5c97-4c08-b461-a23497c57954"
	| where PreciseTimeStamp > datetime(2023-08-10 07:40:25.0903729)
	| where PreciseTimeStamp < datetime(2023-08-10 17:24:40.7082742)
	| where SubscriptionId =="49d64d54-e966-4c46-a868-1999802b762c"
	| where ResourceId =="/subscriptions/49d64d54-e966-4c46-a868-1999802b762c/resourceGroups/Ansibletest/providers/Microsoft.Workloads/sapVirtualInstances/AN1"
	//| where ActivityId == "da2d4265-cea1-4e61-9c2a-dc8196b81583"
	//| where SubscriptionId == "7235b861-9c47-4957-8841-e5f0b305a68a"
	//| where Message has "rsc_st_azure"
	//| take 100
	| where Level == 2
	//| project ServiceActivityId
//| distinct ServiceActivityId

![image.png](https://dev.azure.com/msazure/b32aa71e-8ed2-41b2-9d77-5bc261222004/_apis/git/repositories/d50e3885-12b7-4a8f-9117-e7ab4607513a/pullRequests/8645288/attachments/image.png)

Related work items: #24518471, #24518484

* Merged PR 8646997: Merged PR 8646670: Ansible: Fixing trailing-spaces in Ansible code

Merged PR 8646670: Ansible: Fixing trailing-spaces in Ansible code

Fixing trailing-spaces

Related work items: #24518471, #24518484

Cherry-picked from commit `3dfbb16a`.

Related work items: #24518471, #24518484

---------







Co-authored-by: MerlinBot <>

## Problem
<Please describe what problem this PR is trying to resolve>

## Solution
<Please elaborate the solution for the problem>

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>