### PR TITLE
Set remote user to orchestration_ansible_user

### DIFF
--- a/deploy/ansible/playbook_04_00_01_db_ha.yaml
+++ b/deploy/ansible/playbook_04_00_01_db_ha.yaml
@@ -206,7 +206,7 @@
 
 - hosts:                               "{{ sap_sid | upper }}_DB[0]"
   name:                                DB Dataguard setup - Oracle
-  remote_user:                         "root"
+  remote_user:                         "{{ orchestration_ansible_user }}"
   gather_facts:                        true
   vars_files:
     - vars/ansible-input-api.yaml                               # API Input template with defaults


### PR DESCRIPTION
## Problem
The corrected task tries to log in to managed node as root, when in fact it should be the orchestration_ansible_user

## Solution
remote_user value switched from root to orchestration_ansible_user
