### PR TITLE
Set DB2 sapdata stripesize to 32 KB

### DIFF
--- a/deploy/ansible/vars/disks_config.yml
+++ b/deploy/ansible/vars/disks_config.yml
@@ -219,7 +219,7 @@ logical_volumes:
     vg:         'vg_db2_sapdata'
     lv:         'lv_db2_sapdata1'
     size:       '25%VG'
-    stripesize: 256
+    stripesize: 32
     fstype:     'xfs'
 
   - tier:       'sapos'
@@ -227,7 +227,7 @@ logical_volumes:
     vg:         'vg_db2_sapdata'
     lv:         'lv_db2_sapdata2'
     size:       '25%VG'
-    stripesize: 256
+    stripesize: 32
     fstype:     'xfs'
 
   - tier:       'sapos'
@@ -235,7 +235,7 @@ logical_volumes:
     vg:         'vg_db2_sapdata'
     lv:         'lv_db2_sapdata3'
     size:       '25%VG'
-    stripesize: 256
+    stripesize: 32
     fstype:     'xfs'
   # Here we are left with 25%VG so we assign 100%FREE so as to not fail because
   # the calculated size is less than what is available on disk xD
@@ -244,7 +244,7 @@ logical_volumes:
     vg:         'vg_db2_sapdata'
     lv:         'lv_db2_sapdata4'
     size:       '100%FREE'
-    stripesize: 256
+    stripesize: 32
     fstype:     'xfs'
 
   - tier:       'sapos'


### PR DESCRIPTION
## Problem
When using LVM striping along with Db2 striping, the extent size of the table space and the stripe size
of the disk should be identical (https://www.ibm.com/docs/en/db2/11.5?topic=management-database-managed-space).
The Page Size is set by default to 16 KB and the Extent size is 2 pages = 32 KB.

## Solution
Set the LVM stripesize to 32 KB.
