### PR TITLE
Bug Fix - ensure sapmtn_volume_size is used

### DIFF
--- a/deploy/ansible/vars/disks_config.yml
+++ b/deploy/ansible/vars/disks_config.yml
@@ -353,7 +353,7 @@ logical_volumes_sapmnt:
     node_tier:  'scs'
     vg:         'vg_sap'
     lv:         'lv_sapmnt'
-    size:       '32g'
+    size:       "{% if sapmnt_volume_size is defined %}{{ sapmnt_volume_size }}{% else %}32g{% endif %}"
     fstype:     'xfs'
 
 logical_volumes_install:


### PR DESCRIPTION
## Problem
When using NFS_provider = "NONE" and using NFS exports from the SCS the sapmnt_volume_size is not used for the logical volume.
Example using a `sap` disk of 256g, `usrsap_volume_size = 128g`  and `sapmnt_volume_size = 128g`, the lv gets created with lv_usrsap = 128g and lv_sapmnt = 32g.

## Solution
Change the 
 logical_volumes_sapmnt to conditionally check on `sapmnt_volume_size` and use that if defined else default to the 32g.