### PR TITLE
Add support for RHEL8.9

### DIFF
--- a/deploy/ansible/roles-os/1.3-repository/vars/repos.yaml
+++ b/deploy/ansible/roles-os/1.3-repository/vars/repos.yaml
@@ -24,6 +24,8 @@ repos:
     - { tier:   'ha', repo: 'epel', url: 'https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm', state: 'present' }
   redhat8.8:
     - { tier:   'ha', repo: 'epel', url: 'https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm', state: 'present' }
+  redhat8.9:
+    - { tier:   'ha', repo: 'epel', url: 'https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm', state: 'present' }
   redhat9.0:
   redhat9.2:
   # do not have any repos that are needed for RedHat at the moment.

--- a/deploy/ansible/roles-os/1.4-packages/vars/os-packages.yaml
+++ b/deploy/ansible/roles-os/1.4-packages/vars/os-packages.yaml
@@ -259,6 +259,7 @@ packages:
   redhat8.4:
   redhat8.6:
   redhat8.8:
+  redhat8.9:
   redhat9.0:
     - { tier: 'sapos', package: 'chkconfig',                                    node_tier: 'hana',    state: 'present' }
   redhat9.2:


### PR DESCRIPTION
## Problem
Red Hat released RHEL8.9 in November 2023 and, thus, the framework fails due to lack of RHEL 8.9-specific variables included in roles 1.3-repository and 1.4-packages

## Solution
Add support for RHEL8.9

## Tests
A single-stack DB2 JAVA deployment was used for testing 

## Notes
<Additional comments for the PR>