### PR TITLE
Support DB2 encrypted restore

### DIFF
--- a/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.3-db2_restore_secondary.yml
+++ b/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.3-db2_restore_secondary.yml
@@ -33,7 +33,6 @@
         - { dest: '/db2/{{ db_sid }}/saptmp2' }
         - { dest: '/db2/{{ db_sid }}/saptmp3' }
         - { dest: '/db2/{{ db_sid }}/saptmp4' }
-      run_once: true
 
     - name:                            "DB2 - check if database is already started"
       ansible.builtin.shell:           ps -eaf | grep -i {{ db_sid | upper }} | grep db2sysc | grep -v grep | wc -l
@@ -69,9 +68,9 @@
         msg:                           "DB2 - Restoring database, please wait"
 
 
-      # ##################### Start of Restore without Encryption ##################################
-    - name:                            "DB2 - Restore without encryption"
-      ansible.builtin.shell:           db2 restore database {{ db_sid }} from {{ db_sid_backup_dir }} taken at {{ backup_timestamp }} on /db2/{{ db_sid }} no encrypt without prompting
+      # ##################### Start of Restore with Encryption ##################################
+    - name:                            "DB2 - Restore with encryption"
+      ansible.builtin.shell:           db2 restore database {{ db_sid }} from {{ db_sid_backup_dir }} taken at {{ backup_timestamp }} on /db2/{{ db_sid }} encrypt without prompting
       args:
         executable:                    /bin/csh
       register:                        db2_restore_result
@@ -79,7 +78,7 @@
         PATH:                          "{{ ansible_env.PATH }}:/db2/db2{{ db_sid | lower }}/sqllib/gskit/bin"
       failed_when:                     db2_restore_result.rc > 2
       when:                            db2_started.rc == 0
-      # ######### ########### End of Restore without Encryption ####################################
+      # ######### ########### End of Restore with Encryption ####################################
   when:
     - ansible_hostname == secondary_instance_name
   become:                              true

--- a/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.8-db2_copy_keystore_files.yml
+++ b/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.8-db2_copy_keystore_files.yml
@@ -1,0 +1,32 @@
+---
+
+# /*------------------------------------------------------------------------------------------------------------------------------------8
+# |                                                                                                                                     |
+# | Copy keystore files from primary to secondary DB node as per the reference provided by SAP here:                                     |
+# | https://blogs.sap.com/2022/05/08/encrypting-an-sap-system-on-a-db2-for-luw-database-reduce-downtime-by-exploiting-the-hadr-feature/ |
+# |                                                                                                                                     |
+# +------------------------------------4-----------------------------------------------------------------------------------------------*/
+
+- name:                                "DB2: Variable for keystore files"
+  ansible.builtin.set_fact:
+    keystore_files:
+      - sapdb2{{ db_sid | lower }}_db_encr.p12
+      - sapdb2{{ db_sid | lower }}_db_encr.sth
+
+- name:                                "DB2: Fetch keystore files from Primary node to Controller"
+  ansible.builtin.fetch:
+    src:                               "/db2/db2{{ db_sid | lower }}/keystore/{{ item }}"
+    dest:                              /tmp/keystore_files/
+    flat:                              true
+  loop:                                "{{ keystore_files }}"
+  when:                                ansible_hostname == primary_instance_name
+
+- name:                                "DB2: Copy keystore files from Controller to Secondary node"
+  ansible.builtin.copy:
+    src:                               /tmp/keystore_files/{{ item }}
+    dest:                              /db2/db2{{ db_sid | lower }}/keystore/
+    mode:                              0600
+    owner:                             db2{{ db_sid | lower }}
+    group:                             db{{ db_sid | lower }}adm
+  loop:                                "{{ keystore_files }}"
+  when:                                ansible_hostname == secondary_instance_name

--- a/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/main.yml
+++ b/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/main.yml
@@ -25,6 +25,9 @@
 
     - name:                            "DB2 - Take offline backup of Primary DB"
       ansible.builtin.import_tasks:    4.2.1.1-db2_primary_backup.yml
+
+    - name:                            "DB2 - Keystore Setup, Part 1"
+      ansible.builtin.import_tasks:    4.2.1.8-db2_copy_keystore_files.yml
   always:
     - name:                            "DB2 Primary System Install: result"
       ansible.builtin.debug:
@@ -41,11 +44,14 @@
   when:
     - ansible_hostname == primary_instance_name
 
-- name:                                "DB2 Secodary System Setup"
+- name:                                "DB2 Secondary System Setup"
   block:
 
-    - name:                            "DB2 Secondary System Install "
+    - name:                            "DB2 Secondary System Install"
       ansible.builtin.import_tasks:    4.2.1.2-db2_ha_install_secondary.yml
+
+    - name:                            "DB2 - Keystore Setup, Part 2"
+      ansible.builtin.import_tasks:    4.2.1.8-db2_copy_keystore_files.yml
 
     - name:                            "DB2 - Restore Secondary with backup of Primary DB"
       ansible.builtin.import_tasks:    4.2.1.3-db2_restore_secondary.yml


### PR DESCRIPTION
## Problem
1. The directories /db2/{{ db_sid }}/saptmp[1-4] are not created on the secondary node.

2. Encrypted DBs cannot be restored

## Solution

Adjusted task "DB2 Backup -  Create SAPTMP Directories" to work correctly. 
Added task for keystore files transfer between nodes
Improved restore command

## Tests
Tested with an ABAP DB2 HA deployment on RHEL 8

## Notes
Keystore copy mechanism based on SAP knowledge base article:
https://blogs.sap.com/2022/05/08/encrypting-an-sap-system-on-a-db2-for-luw-database-reduce-downtime-by-exploiting-the-hadr-feature/