### PR TITLE
Fixes for HANA VM ppg and /etc/hosts file generation

### DIFF
--- a/deploy/ansible/roles-sap-os/2.4-hosts-file/templates/hosts.j2
+++ b/deploy/ansible/roles-sap-os/2.4-hosts-file/templates/hosts.j2
@@ -80,15 +80,15 @@ ansible_facts.
 {# Check if there are IPs available for the current host #}
 {% if host_ips %}
 {# Print the primary host entry #}
-{{ '%-19s' | format(host_ips[0]) }}{{ '%-50s' | format(host + '.' + sap_fqdn) }}{{ '%-21s' | format(host) }}
+{{ '%-19s' | format(host_ips[0]) }}{{ '%-80s ' | format(host + '.' + sap_fqdn) }}{{ '%-21s' | format(host) }}
 
 {# If there's only one IP, also use it for the virtual_host #}
 {% if host_ips|length == 1 %}
-{{ '%-19s' | format(host_ips[0]) }}{{ '%-50s' | format(virtual_host_name + '.' + sap_fqdn) }}{{ '%-21s' | format(virtual_host_name) }}
+{{ '%-19s' | format(host_ips[0]) }}{{ '%-80s ' | format(virtual_host_name + '.' + sap_fqdn) }}{{ '%-21s' | format(virtual_host_name) }}
 {% else %}
 {# Loop through remaining IPs for the virtual host #}
 {% for ip in host_ips[1:] %}
-{{ '%-19s' | format(ip) }}{{ '%-50s' | format(virtual_host_name + '.' + sap_fqdn) }}{{ '%-21s' | format(virtual_host_name) }}
+{{ '%-19s' | format(ip) }}{{ '%-80s ' | format(virtual_host_name + '.' + sap_fqdn) }}{{ '%-21s' | format(virtual_host_name) }}
 {% endfor %}
 {% endif %}
 {% endif %}

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/vm-hdb.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/vm-hdb.tf
@@ -167,7 +167,7 @@ resource "azurerm_linux_virtual_machine" "vm_dbnode" {
   location                             = var.resource_group[0].location
 
   proximity_placement_group_id         = var.database.use_ppg ? (
-                                           var.ppg[count.index]) : (
+                                           var.ppg[count.index % max(local.db_zone_count, 1)]) : (
                                            null
                                          )
 


### PR DESCRIPTION
## Problem

This PR fixes 2 issues

1. When deploying HANA in high availability with PPG an error occurs

<details>
<summary>Error</summary>


```json
{
  "@level": "error",
  "@message": "Error: Invalid index",
  "@module": "terraform.ui",
  "@timestamp": "2023-12-07T09:20:27.823652Z",
  "diagnostic": {
    "severity": "error",
    "summary": "Invalid index",
    "detail": "The given key does not identify an element in this collection value: the given index is greater than or equal to the length of the collection.",
    "range": {
      "filename": "../../terraform-units/modules/sap_system/hdb_node/vm-hdb.tf",
      "start": {
        "line": 170,
        "column": 51,
        "byte": 9395
      },
      "end": {
        "line": 170,
        "column": 64,
        "byte": 9408
      }
    },
    "snippet": {
      "context": "resource \"azurerm_linux_virtual_machine\" \"vm_dbnode\"",
      "code": "                                           var.ppg[count.index]) : (",
      "start_line": 170,
      "highlight_start_offset": 50,
      "highlight_end_offset": 63,
      "values": [
        {
          "traversal": "count.index",
          "statement": "is 2"
        },
        {
          "traversal": "var.ppg",
          "statement": "is list of string with 2 elements"
        }
      ]
    }
  },
  "type": "diagnostic"
}
```

</details>

2. When having a combined `{{ hostname }}` and `{{ sap_fqdn }}` that exceeds 50 chars the current hosts.j2 template doesn't ensure a whitespace between the `{{ fqdn }}` and `{{ hostname }}`.

## Solution

1. Ensure that the `proximity_placement_group_id` gets resolved as it does other places, see:
   1. https://github.com/Azure/sap-automation/blob/e3aba74e2ab4e1a42426fe2dc4c05ea47f2c2239/deploy/terraform/terraform-units/modules/sap_system/hdb_node/infrastructure.tf#L18
   2. https://github.com/Azure/sap-automation/blob/e3aba74e2ab4e1a42426fe2dc4c05ea47f2c2239/deploy/terraform/terraform-units/modules/sap_system/anydb_node/vm-anydb.tf#L131

2. Ensure that a whitespace is always included between `{{ fqdn }}` and `{{ hostname }}` in hosts.j2 and increase padding to %-80, to ensure that lines, in most use cases, are aligned.
