### PR TITLE
Bugfix kv-secrets debug and import tasks

### DIFF
--- a/deploy/ansible/roles-misc/0.2-kv-secrets/tasks/main.yaml
+++ b/deploy/ansible/roles-misc/0.2-kv-secrets/tasks/main.yaml
@@ -32,7 +32,9 @@
                                             - "use_msi_for_clusters:            {{ use_msi_for_clusters }}"
                                             - "platform:                        {{ platform | upper }}"
     verbosity:                              2
-  when:                                   operation == "fencing"
+  when:
+                                          - operation is defined
+                                          - operation == "fencing"
 
 # -------------------------------------+---------------------------------------8
 #
@@ -40,6 +42,7 @@
 - name:                                   "0.2 Key Vault: - Import S User tasks"
   ansible.builtin.import_tasks:           "s_user.yaml"
   when:
+                                          - operation is defined
                                           - operation == "SoftwareAcquisition"
 
 
@@ -49,6 +52,7 @@
 - name:                                   "0.2 Key Vault: - Import Fencing secrets"
   ansible.builtin.import_tasks:           "fencing.yaml"
   when:
+                                          - operation is defined
                                           - operation == "fencing"
                                           - (database_high_availability and database_cluster_type == "AFA") or
                                             (scs_high_availability      and      scs_cluster_type == "AFA")         # AFA (Azure Fencing Agent)
@@ -62,6 +66,7 @@
   ansible.builtin.import_tasks:           "wincluster-witness.yaml"
   # TODO: update when clause more appropriately
   when:
+                                          - operation is defined
                                           - operation == "fencing"
                                           - (scs_high_availability or database_high_availability)
                                           - not use_msi_for_clusters


### PR DESCRIPTION
Because the operation variable has no default within the rol its existence should be checked.

## Problem
Running the validation playbook errors out:

```
fatal: [localhost]: FAILED! => {"msg": "The conditional check 'operation == \"fencing\"' failed. The error was: error while evaluating conditional (operation == \"fencing\"): 'operation' is undefined. 'operation' is undefined\n\nThe error appears to be in '/opt/sap-automation/deploy/ansible/roles-misc/0.2-kv-secrets/tasks/main.yaml': line 24, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n# -------------------------------------+---------------------------------------8\n- name:                                   \"Cluster aware code...\"\n  ^ here\n"}
```

## Solution
Check if the `operation` variable is defined