### PR TITLE
Import KV secrets in SCS HA Installation Playbook

### DIFF
--- a/deploy/ansible/playbook_05_00_00_sap_scs_install.yaml
+++ b/deploy/ansible/playbook_05_00_00_sap_scs_install.yaml
@@ -70,15 +70,6 @@
                                             - scs_high_availability or database_high_availability
       tags:
                                             - 0.2-wincluster-witness
-# MKD - These two tasks (Above & Below) seem to achieve the same thing?
-    - name:                                 "SCS Installation Playbook: - Read/Create key vault secrets"
-      ansible.builtin.include_role:
-        name:                               roles-misc/0.2-kv-secrets
-        public:                             true
-      vars:
-        operation:                          fencing
-      tags:
-                                            - kv-secrets
 
     - name:                            "SCS Installation Playbook: - Read storage account details"
       ansible.builtin.include_role:
@@ -442,6 +433,15 @@
             ers_virtual_hostname:               "{{ sap_sid | lower }}ers{{ ers_instance_number }}cl2"
           tags:
                                                 - always
+
+        - name:                                 "SCS HA Installation Playbook: - Read/Create key vault secrets"
+          ansible.builtin.include_role:
+            name:                               roles-misc/0.2-kv-secrets
+            public:                             true
+          vars:
+            operation:                          fencing
+          tags:
+                                                - kv-secrets
 
         - name:                                 "SCS HA Installation Playbook: - Initialize facts... Fencing"
           ansible.builtin.set_fact:


### PR DESCRIPTION
## Problem
SCS HA Installation Playbook doesn't include the 0.2-kv-secrets role to fetch the SPN secrets resulting in the error: 
`"The task includes an option with an undefined variable. The error was: 'ansible.vars.hostvars.HostVarsVars object' has no attribute 'sap_fencing_spn_client_id'.`

## Solution
Include the roles-misc/0.2-kv-secrets role