### PR TITLE
Add pacemaker versions for RedHat 8.9

### DIFF
--- a/deploy/ansible/roles-os/1.17-generic-pacemaker/vars/main.yml
+++ b/deploy/ansible/roles-os/1.17-generic-pacemaker/vars/main.yml
@@ -77,6 +77,9 @@ package_versions:
   redhat8.8:
     - {name: "pacemaker",               version: "2.0.5",   compare_operator: ">=", version_type: "loose"}
     - {name: "resource-agents",         version: "4.9.0",   compare_operator: ">=", version_type: "loose"}
+  redhat8.9:
+    - {name: "pacemaker",               version: "2.0.5",   compare_operator: ">=", version_type: "loose"}
+    - {name: "resource-agents",         version: "4.9.0",   compare_operator: ">=", version_type: "loose"}
   redhat9.0:
     - {name: "pacemaker",               version: "2.0.5",   compare_operator: ">=", version_type: "loose"}
     - {name: "resource-agents-cloud",   version: "4.10.0",  compare_operator: ">=", version_type: "loose"}


### PR DESCRIPTION
## Problem
No pacemaker package version list is present for RHEL 8.9: `'dict object' has no attribute 'redhat8.9'`

## Solution
Add version list for RHEL8.9 (based on 8.8)