### PR TITLE
Fix iSCSI service tier typo and update iSCSI initiator name

### DIFF
--- a/deploy/ansible/roles-os/1.16-services/vars/os-services.yaml
+++ b/deploy/ansible/roles-os/1.16-services/vars/os-services.yaml
@@ -80,8 +80,8 @@ services:
     - { tier: 'os',          service: 'fstrim.timer', node_tier: 'all',     state: 'disabled'  }
     # --------------------------- Begin - Packages required for iSCSI -----------------------------------------8
     # https://learn.microsoft.com/en-us/azure/sap/workloads/high-availability-guide-suse-pacemaker#sbd-with-an-iscsi-target-server
-    - { tier: 'iscs',        service: 'targetcli',    node_tier: 'iscsi',   state: 'enabled'   }
-    - { tier: 'iscs',        service: 'targetcli',    node_tier: 'iscsi',   state: 'started'   }
+    - { tier: 'iscsi',        service: 'targetcli',    node_tier: 'iscsi',   state: 'enabled'   }
+    - { tier: 'iscsi',        service: 'targetcli',    node_tier: 'iscsi',   state: 'started'   }
     # ---------------------------- End - Packages required for iSCSI ------------------------------------------8
 
   oraclelinux8:

--- a/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.1.1-iSCSI.yml
+++ b/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.1.1-iSCSI.yml
@@ -26,9 +26,12 @@
   ansible.builtin.set_fact:
     iscsi_node_type: >-
                                        {%- set _clusterType = 'scs' -%}
-                                       {%- if (['hana', 'db2'] in supported_tiers) -%}
+                                       {%- if ('hana' in supported_tiers) -%}
                                        {%-   set _clusterType = 'db' -%}
-                                       {%- endif -%} {{- _clusterType -}}
+                                       {%- endif -%}
+                                       {%- if ('db2' in supported_tiers) -%}
+                                       {%-   set _clusterType = 'db' -%}
+                                       {%- endif -%}
                                        {{- _clusterType -}}
 
 - name:                                "1.17.1 iSCSI packages - Get initiator name"

--- a/deploy/ansible/roles-sap-os/2.11-iscsi-server/tasks/main.yaml
+++ b/deploy/ansible/roles-sap-os/2.11-iscsi-server/tasks/main.yaml
@@ -105,7 +105,7 @@
 - name:                               "2.11: SBD create iscsi/iqn DB"
   become_user:                        root
   become:                             true
-  ansible.builtin.command:            "targetcli iscsi/{{ item.iqn }}/tpg1/acls/ create iqn.2006-04.{{ sap_sid }}-db-0.local:{{ sap_sid }}-db-0"
+  ansible.builtin.command:            "targetcli iscsi/{{ item.iqn }}/tpg1/acls/ create iqn.2006-04.{{ sap_sid }}-xdb-0.local:{{ sap_sid }}-xdb-0"
   register:                           iscsi_create3_db
   failed_when:                        iscsi_create3_db.rc not in [0,1]
   changed_when:                       iscsi_create3_db.rc == 0
@@ -118,7 +118,7 @@
 - name:                               "2.11: SBD create iscsi/iqn DB"
   become_user:                        root
   become:                             true
-  ansible.builtin.command:            "targetcli iscsi/{{ item.iqn }}/tpg1/acls/ create iqn.2006-04.{{ sap_sid }}-db-1.local:{{ sap_sid }}-db-1"
+  ansible.builtin.command:            "targetcli iscsi/{{ item.iqn }}/tpg1/acls/ create iqn.2006-04.{{ sap_sid }}-xdb-1.local:{{ sap_sid }}-xdb-1"
   register:                           iscsi_create4_db
   failed_when:                        iscsi_create4_db.rc not in [0,1]
   changed_when:                       iscsi_create4_db.rc == 0


### PR DESCRIPTION
## Problem
DB installation is failing while configuring a HANA system with iSCSI servers as SBD device.

## Solution
Fix iSCSI service tier typo
Update iSCSI initiator name
Refactored if-else loop to get cluster type.

## Tests
Ran a successful DB installation.
