### PR TITLE
Add support for controlling DNS A record creation for secondary names

### DIFF
--- a/deploy/terraform/run/sap_system/module.tf
+++ b/deploy/terraform/run/sap_system/module.tf
@@ -412,7 +412,7 @@ module "output_files" {
   management_dns_subscription_id                = try(data.terraform_remote_state.landscape.outputs.management_dns_subscription_id, null)
   management_dns_resourcegroup_name             = try(data.terraform_remote_state.landscape.outputs.management_dns_resourcegroup_name, local.saplib_resource_group_name)
   dns_zone_names                                = var.dns_zone_names
-
+  dns_a_records_for_secondary_names             = var.dns_a_records_for_secondary_names
 
   #########################################################################################
   #  Server counts                                                                        #

--- a/deploy/terraform/run/sap_system/tfvar_variables.tf
+++ b/deploy/terraform/run/sap_system/tfvar_variables.tf
@@ -1000,6 +1000,12 @@ variable "dns_zone_names"                       {
                                                             }
                                                 }
 
+variable "dns_a_records_for_secondary_names"    {
+                                                  description = "Boolean value indicating if dns a records should be created for the secondary DNS names"
+                                                  default     = true
+                                                  type        = bool
+                                                }
+
 #########################################################################################
 #                                                                                       #
 #  NFS and Shared Filed settings                                                        #

--- a/deploy/terraform/terraform-units/modules/sap_system/output_files/dns_records.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/output_files/dns_records.tf
@@ -1,6 +1,6 @@
 resource "azurerm_private_dns_a_record" "app_secondary" {
   provider            = azurerm.dnsmanagement
-  count               = var.use_secondary_ips && !var.use_custom_dns_a_registration && length(var.dns) > 0 ? var.app_server_count : 0
+  count               = var.dns_a_records_for_secondary_names && var.use_secondary_ips && !var.use_custom_dns_a_registration && length(var.dns) > 0 ? var.app_server_count : 0
   name                = var.naming.virtualmachine_names.APP_SECONDARY_DNSNAME[count.index]
   zone_name           = var.dns
   resource_group_name = var.management_dns_resourcegroup_name
@@ -15,7 +15,7 @@ resource "azurerm_private_dns_a_record" "app_secondary" {
 
 resource "azurerm_private_dns_a_record" "scs_secondary" {
   provider            = azurerm.dnsmanagement
-  count               = var.use_secondary_ips && !var.use_custom_dns_a_registration && length(var.dns) > 0 ? var.scs_server_count : 0
+  count               = var.dns_a_records_for_secondary_names && var.use_secondary_ips && !var.use_custom_dns_a_registration && length(var.dns) > 0 ? var.scs_server_count : 0
   name                = var.naming.virtualmachine_names.SCS_SECONDARY_DNSNAME[count.index]
   zone_name           = var.dns
   resource_group_name = var.management_dns_resourcegroup_name
@@ -30,7 +30,7 @@ resource "azurerm_private_dns_a_record" "scs_secondary" {
 
 resource "azurerm_private_dns_a_record" "web_secondary" {
   provider            = azurerm.dnsmanagement
-  count               = var.use_secondary_ips && !var.use_custom_dns_a_registration && length(var.dns) > 0 ? var.web_server_count : 0
+  count               = var.dns_a_records_for_secondary_names && var.use_secondary_ips && !var.use_custom_dns_a_registration && length(var.dns) > 0 ? var.web_server_count : 0
   name                = var.naming.virtualmachine_names.WEB_SECONDARY_DNSNAME[count.index]
   zone_name           = var.dns
   resource_group_name = var.management_dns_resourcegroup_name
@@ -45,7 +45,7 @@ resource "azurerm_private_dns_a_record" "web_secondary" {
 
 resource "azurerm_private_dns_a_record" "db_secondary" {
   provider            = azurerm.dnsmanagement
-  count               = var.use_secondary_ips && !var.use_custom_dns_a_registration && length(var.dns) > 0 ? var.db_server_count : 0
+  count               = var.dns_a_records_for_secondary_names && var.use_secondary_ips && !var.use_custom_dns_a_registration && length(var.dns) > 0 ? var.db_server_count : 0
   name                = local.db_secondary_dns_names[count.index]
   zone_name           = var.dns
   resource_group_name = var.management_dns_resourcegroup_name

--- a/deploy/terraform/terraform-units/modules/sap_system/output_files/variables_global.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/output_files/variables_global.tf
@@ -66,6 +66,7 @@ variable "dns"                                  {
                                                   description = "The DNS label"
                                                   default     = ""
                                                 }
+variable "dns_a_records_for_secondary_names"    { description = "Boolean value indicating if dns a records should be created for the secondary DNS names"}
 variable "ers_instance_number"                  {
                                                   description = "Instance number for ERS"
                                                   default     = "02"


### PR DESCRIPTION
## Problem
Currently there is no easy way to block the creation of DNS records for the secondary IP addresses
## Solution
Introduce a new variable for Terraform

dns_a_records_for_secondary_names

## Tests
Tested using the DevOps pipelines

## Notes
<Additional comments for the PR>