### PR TITLE
Use afs for shared storage

### DIFF
--- a/deploy/terraform/run/sap_landscape/module.tf
+++ b/deploy/terraform/run/sap_landscape/module.tf
@@ -55,7 +55,7 @@ module "sap_landscape" {
   transport_private_endpoint_id                = var.transport_private_endpoint_id
   transport_storage_account_id                 = var.transport_storage_account_id
   transport_volume_size                        = var.transport_volume_size
-  use_AFS_for_installation_media               = var.use_AFS_for_installation_media
+  use_AFS_for_shared_storage                   = var.use_AFS_for_shared_storage
   use_custom_dns_a_registration                = var.use_custom_dns_a_registration
   use_deployer                                 = length(var.deployer_tfstate_key) > 0
   use_private_endpoint                         = var.use_private_endpoint

--- a/deploy/terraform/run/sap_landscape/tfvar_variables.tf
+++ b/deploy/terraform/run/sap_landscape/tfvar_variables.tf
@@ -29,7 +29,7 @@ variable "name_override_file"                   {
                                                 }
 
 variable "place_delete_lock_on_resources"       {
-                                                  description = "f defined, a delete lock will be placed on the key resources"
+                                                  description = "If defined, a delete lock will be placed on the key resources"
                                                   default     = false
                                                 }
 
@@ -519,17 +519,17 @@ variable "ANF_transport_volume_use_existing"       {
                                                    }
 
 variable "ANF_transport_volume_name"               {
-                                                     description = "f defined provides the Transport volume name"
+                                                     description = "If defined provides the Transport volume name"
                                                      default     = false
                                                    }
 
 variable "ANF_transport_volume_throughput"         {
-                                                     description = "f defined provides the throughput of the transport volume"
+                                                     description = "If defined provides the throughput of the transport volume"
                                                      default     = 128
                                                    }
 
 variable "ANF_transport_volume_size"               {
-                                                     description = "f defined provides the size of the transport volume"
+                                                     description = "If defined provides the size of the transport volume"
                                                      default     = 128
                                                    }
 
@@ -539,25 +539,24 @@ variable "ANF_install_volume_use_existing"         {
                                                    }
 
 variable "ANF_install_volume_name"                 {
-                                                     description = "nstall volume name"
+                                                     description = "Install volume name"
                                                      default     = ""
                                                    }
 
 variable "ANF_install_volume_throughput"           {
-                                                     description = "f defined provides the throughput of the install volume"
+                                                     description = "If defined provides the throughput of the install volume"
                                                      default     = 128
                                                    }
 
 variable "ANF_install_volume_size"                 {
-                                                     description = "f defined provides the size of the install volume"
+                                                     description = "If defined provides the size of the install volume"
                                                      default     = 1024
                                                    }
 
-variable "use_AFS_for_installation_media"          {
-                                                     description = "f true, will use AFS for installation media."
+variable "use_AFS_for_shared_storage"              {
+                                                     description = "If true, will use AFS for all shared storage."
                                                      default = false
                                                    }
-
 
 #########################################################################################
 #                                                                                       #

--- a/deploy/terraform/terraform-units/modules/sap_landscape/anf.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/anf.tf
@@ -100,7 +100,7 @@ data "azurerm_netapp_pool" "workload_netapp_pool" {
 
 resource "azurerm_netapp_volume" "transport" {
   provider                             = azurerm.main
-  count                                = var.create_transport_storage && var.NFS_provider == "ANF" ? (
+  count                                = var.create_transport_storage && var.NFS_provider == "ANF" && !var.use_AFS_for_shared_storage ? (
                                            var.ANF_settings.use_existing_transport_volume ? (
                                              0) : (
                                              1
@@ -209,7 +209,7 @@ data "azurerm_netapp_volume" "transport" {
 
 resource "azurerm_netapp_volume" "install" {
   provider                             = azurerm.main
-  count                                = var.NFS_provider == "ANF" && !var.use_AFS_for_installation_media ? (
+  count                                = var.NFS_provider == "ANF" && !var.use_AFS_for_shared_storage ? (
                                            var.ANF_settings.use_existing_install_volume ? (
                                              0) : (
                                              1

--- a/deploy/terraform/terraform-units/modules/sap_landscape/outputs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/outputs.tf
@@ -392,7 +392,7 @@ output "saptransport_path"                     {
 
 output "install_path"                           {
                                                  description = "Path to the SAP installation volume"
-                                                 value       = try(local.use_AFS_for_install ? (
+                                                 value       = try(local.use_AFS_for_shared ? (
                                                                  length(var.install_private_endpoint_id) == 0 ? (
                                                                    format("%s:/%s/%s", try(azurerm_private_endpoint.install[0].private_dns_zone_configs[0].record_sets[0].fqdn,
                                                                      try(azurerm_private_endpoint.install[0].private_service_connection[0].private_ip_address, "")),

--- a/deploy/terraform/terraform-units/modules/sap_landscape/storage_accounts.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/storage_accounts.tf
@@ -630,13 +630,7 @@ data "azurerm_private_dns_a_record" "install" {
 
 data "azurerm_storage_account" "install" {
   provider                             = azurerm.main
-  count                                = local.use_AFS_for_shared (
-                                           length(var.install_storage_account_id) > 0 ? (
-                                             1) : (
-                                             0
-                                           )) : (
-                                           0
-                                         )
+  count                                = local.use_AFS_for_shared && length(var.install_storage_account_id) > 0 ? 1 : 0
   name                                 = split("/", var.install_storage_account_id)[8]
   resource_group_name                  = split("/", var.install_storage_account_id)[4]
 }

--- a/deploy/terraform/terraform-units/modules/sap_landscape/variables_global.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/variables_global.tf
@@ -281,7 +281,7 @@ variable "enable_firewall_for_keyvaults_and_storage"     { description = "Boolea
 
 variable "public_network_access_enabled"                 { description = "Defines if the public access should be enabled for keyvaults and storage accounts" }
 
-variable "use_AFS_for_installation_media"                {
+variable "use_AFS_for_shared_storage"                    {
                                                            description = "If true, will use AFS for installation media."
                                                            default = false
                                                          }

--- a/deploy/terraform/terraform-units/modules/sap_landscape/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/variables_local.tf
@@ -654,6 +654,6 @@ locals {
   use_Azure_native_DNS                            = length(var.dns_label) > 0 && !var.use_custom_dns_a_registration && !local.SAP_virtualnetwork_exists
 
 
-  use_AFS_for_install                             = (var.NFS_provider == "ANF" && var.use_AFS_for_installation_media) || var.NFS_provider == "AFS"
+  use_AFS_for_shared                             = (var.NFS_provider == "ANF" && var.use_AFS_for_shared_storage) || var.NFS_provider == "AFS"
 
 }


### PR DESCRIPTION
## Problem
ANF does not provide cross region resiliency, but Azure Files do

## Solution
Add a boolean flag 'use_AFS_for_shared_storage' that will cause the framework to create both the install and transport accounts using Azure Files but also create the ANF infrastructure for system storage

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>