### PR TITLE
Several DB2 HADR improvements

### DIFF
--- a/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.4-db2_haparameters.yaml
+++ b/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.4-db2_haparameters.yaml
@@ -54,6 +54,7 @@
             db2 update db cfg for {{ db_sid }} using HADR_REMOTE_HOST {{ db_hadr_remote_host }} immediate
             db2 update db cfg for {{ db_sid }} using HADR_REMOTE_SVC {{ db_sid | upper }}_HADR_2 immediate
             db2 update db cfg for {{ db_sid }} using HADR_REMOTE_INST db2{{ db_sid | lower }} immediate
+            db2 update db cfg for {{ db_sid }} using HADR_SSL_LABEL {{ db2_ssl_label }}
             db2 update db cfg for {{ db_sid }} using HADR_TIMEOUT 60 immediate
             db2 update db cfg for {{ db_sid }} using HADR_SYNCMODE NEARSYNC immediate
             db2 update db cfg for {{ db_sid }} using HADR_SPOOL_LIMIT 1000 immediate
@@ -80,6 +81,7 @@
             db2 update db cfg for {{ db_sid }} using HADR_REMOTE_HOST {{ db_hadr_remote_host }} immediate
             db2 update db cfg for {{ db_sid }} using HADR_REMOTE_SVC {{ db_sid | upper }}_HADR_2 immediate
             db2 update db cfg for {{ db_sid }} using HADR_REMOTE_INST db2{{ db_sid | lower }} immediate
+            db2 update db cfg for {{ db_sid }} using HADR_SSL_LABEL {{ db2_ssl_label }}
             db2 update db cfg for {{ db_sid }} using HADR_TIMEOUT 45 immediate
             db2 update db cfg for {{ db_sid }} using HADR_SYNCMODE NEARSYNC immediate
             db2 update db cfg for {{ db_sid }} using HADR_SPOOL_LIMIT 1000 immediate
@@ -155,6 +157,7 @@
             db2 update db cfg for {{ db_sid }} using HADR_REMOTE_HOST {{ db_hadr_remote_host }} immediate
             db2 update db cfg for {{ db_sid }} using HADR_REMOTE_SVC {{ db_sid | upper }}_HADR_1 immediate
             db2 update db cfg for {{ db_sid }} using HADR_REMOTE_INST db2{{ db_sid | lower }} immediate
+            db2 update db cfg for {{ db_sid }} using HADR_SSL_LABEL {{ db2_ssl_label }}
             db2 update db cfg for {{ db_sid }} using HADR_TIMEOUT 60 immediate
             db2 update db cfg for {{ db_sid }} using HADR_SYNCMODE NEARSYNC immediate
             db2 update db cfg for {{ db_sid }} using HADR_SPOOL_LIMIT 1000 immediate
@@ -181,6 +184,7 @@
             db2 update db cfg for {{ db_sid }} using HADR_REMOTE_HOST {{ db_hadr_remote_host }} immediate
             db2 update db cfg for {{ db_sid }} using HADR_REMOTE_SVC {{ db_sid | upper }}_HADR_1 immediate
             db2 update db cfg for {{ db_sid }} using HADR_REMOTE_INST db2{{ db_sid | lower }} immediate
+            db2 update db cfg for {{ db_sid }} using HADR_SSL_LABEL {{ db2_ssl_label }}
             db2 update db cfg for {{ db_sid }} using HADR_TIMEOUT 45 immediate
             db2 update db cfg for {{ db_sid }} using HADR_SYNCMODE NEARSYNC immediate
             db2 update db cfg for {{ db_sid }} using HADR_SPOOL_LIMIT 1000 immediate

--- a/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.4-db2_haparameters.yaml
+++ b/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.4-db2_haparameters.yaml
@@ -5,8 +5,8 @@
   block:
     - name:                            " DB2 Primary DB - Set Fact for hadr local host and remote host "
       ansible.builtin.set_fact:
-        db_hadr_local_host:            "{{ primary_instance_name }}.{{ sap_fqdn }}"
-        db_hadr_remote_host:           "{{ secondary_instance_name }}.{{ sap_fqdn }}"
+        db_hadr_local_host:            "{{ hostvars[primary_instance_name]['virtual_host'] }}.{{ sap_fqdn }}"
+        db_hadr_remote_host:           "{{ hostvars[secondary_instance_name]['virtual_host'] }}.{{ sap_fqdn }}"
 
     - name:                            "DB2 Primary DB- Switch user to db2<db_sid>"
       ansible.builtin.shell:           whoami
@@ -106,8 +106,8 @@
   block:
     - name:                            " DB2 Secondary DB - Set Fact for hadr local host and remote host "
       ansible.builtin.set_fact:
-        db_hadr_local_host:            "{{ secondary_instance_name }}.{{ sap_fqdn }}"
-        db_hadr_remote_host:           "{{ primary_instance_name }}.{{ sap_fqdn }}"
+        db_hadr_local_host:            "{{ hostvars[secondary_instance_name]['virtual_host'] }}.{{ sap_fqdn }}"
+        db_hadr_remote_host:           "{{ hostvars[primary_instance_name]['virtual_host'] }}.{{ sap_fqdn }}"
 
     - name:                            "DB2 Secondary DB- Switch user to db2<db_sid>"
       ansible.builtin.shell:           whoami
@@ -127,7 +127,7 @@
       failed_when:                      false
       changed_when:                     false
 
-    - name:                           "DB2  Secondary: Print return information from the Secondary db2status"
+    - name:                            "DB2 Secondary: Print return information from the Secondary db2status"
       ansible.builtin.debug:
         msg:                           "Result: {{ secdb2status.stdout }}"
 

--- a/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.7-sap-profile-changes.yaml
+++ b/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.7-sap-profile-changes.yaml
@@ -46,7 +46,7 @@
     - name:                            "4.2.1.7 - SAP db2cli.ini profile changes "
       ansible.builtin.lineinfile:
         path:                          /sapmnt/{{ sap_sid | upper }}/global/db6/db2cli.ini
-        line:                          Hostname = {{ custom_db_virtual_hostname | default(db_virtual_hostname, true) }}
+        line:                          Hostname={{ custom_db_virtual_hostname | default(db_virtual_hostname, true) }}
         insertafter:                   '#Hostname'
       tags:
         - virtdbhostpara

--- a/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.9-db2_generate_distribute_ssl.yml
+++ b/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.9-db2_generate_distribute_ssl.yml
@@ -1,0 +1,82 @@
+---
+- name:                                "DB2: variables for SSL certificate"
+  ansible.builtin.set_fact:
+    db2_ssl_cn:                        "{{ custom_db_virtual_hostname | default(db_virtual_hostname, true) }}.{{ sap_fqdn }}"
+    db2_ssl_keydb_file:                sapdb2{{ db_sid | lower }}_ssl_comm.kdb
+    db2_ssl_stash_file:                sapdb2{{ db_sid | lower }}_ssl_comm.sth
+    db2_ssl_label:                     sap_db2_{{ custom_db_virtual_hostname | default(db_virtual_hostname, true) }}_ssl_comm_000
+
+- name:                                "DB2 Primary DB: Generate SSL"
+  when:                                ansible_hostname == primary_instance_name
+  become:                              true
+  become_user:                         db2{{ db_sid | lower }}
+  block:
+    - name:                            "DB2 Primary DB - Create SSL Certificate"
+      ansible.builtin.shell:           gsk8capicmd_64 -cert -create -db {{ db2_ssl_keydb_file }} -pw {{ main_password }} -label {{ db2_ssl_label }} -dn 'CN={{ db2_ssl_cn }}' -expire 3650 -size 4096
+      args:
+        executable:                    /bin/csh
+        chdir:                         /db2/db2{{ db_sid | lower }}/keystore
+      environment:
+        PATH:                          "{{ ansible_env.PATH }}:/db2/db2{{ db_sid | lower }}/sqllib/gskit/bin"
+        LD_LIBRARY_PATH:               /db2/db2{{ db_sid | lower }}/sqllib/lib64:/db2/db2{{ db_sid | lower }}/sqllib/lib64/gskit:/db2/db2{{ db_sid | lower }}/sqllib/lib
+
+    - name:                            "DB2 Primary DB - Extract SSL Certificate"
+      ansible.builtin.shell:           gsk8capicmd_64 -cert -extract -db {{ db2_ssl_keydb_file }} -pw {{ main_password }} -label {{ db2_ssl_label }} -target {{ db2_ssl_label }}.arm -format ascii -fips
+      args:
+        executable:                    /bin/csh
+        chdir:                         /db2/db2{{ db_sid | lower }}/keystore
+      environment:
+        PATH:                          "{{ ansible_env.PATH }}:/db2/db2{{ db_sid | lower }}/sqllib/gskit/bin"
+        LD_LIBRARY_PATH:               /db2/db2{{ db_sid | lower }}/sqllib/lib64:/db2/db2{{ db_sid | lower }}/sqllib/lib64/gskit:/db2/db2{{ db_sid | lower }}/sqllib/lib
+
+- name:                                "DB2 Primary DB - Copy SSL Certificate and Keystore files"
+  when:                                ansible_hostname == primary_instance_name
+  block:
+    - name:                            "DB2 Primary DB - Copy SSL certificate to SSL_client directory"
+      ansible.builtin.copy:
+        src:                           /db2/db2{{ db_sid | lower }}/keystore/{{ db2_ssl_label }}.arm
+        dest:                          /usr/sap/{{ db_sid | upper }}/SYS/global/SSL_client/
+        remote_src:                    true
+        owner:                         "{{ db_sid | lower }}adm"
+        group:                         sapsys
+        mode:                          0640
+
+    - name:                            "DB2 Primary DB: Fetch keystore files to Controller"
+      ansible.builtin.fetch:
+        src:                           "/db2/db2{{ db_sid | lower }}/keystore/{{ item }}"
+        dest:                          /tmp/keystore_files/
+        flat:                          true
+      loop:
+        - "{{ db2_ssl_keydb_file }}"
+        - "{{ db2_ssl_stash_file }}"
+
+    - name:                            "DB2 Primary DB: Update SSL certificate in db2cli.ini"
+      ansible.builtin.lineinfile:
+        path:                          /sapmnt/{{ sap_sid | upper }}/global/db6/db2cli.ini
+        regexp:                        '^SSLServerCertificate='
+        line:                          SSLServerCertificate=/usr/sap/{{ db_sid | upper }}/SYS/global/SSL_client/{{ db2_ssl_label }}.arm
+
+- name:                                "DB2: Copy keystore files from Controller to Secondary node"
+  when:                                ansible_hostname == secondary_instance_name
+  ansible.builtin.copy:
+    src:                               /tmp/keystore_files/{{ item }}
+    dest:                              /db2/db2{{ db_sid | lower }}/keystore/
+    mode:                              0600
+    owner:                             db2{{ db_sid | lower }}
+    group:                             db{{ db_sid | lower }}adm
+  loop:
+    - "{{ db2_ssl_keydb_file }}"
+    - "{{ db2_ssl_stash_file }}"
+
+- name:                                "DB2 DB - Set SSL parameters"
+  become:                              true
+  become_user:                         db2{{ db_sid | lower }}
+  ansible.builtin.shell: |
+    db2 update dbm cfg using SSL_SVR_LABEL {{ db2_ssl_label }}
+    db2 update dbm cfg using SSL_VERSIONS TLSV13
+  register:                            db2_update
+  failed_when:                         db2_update.rc not in [0,2]
+  args:
+    executable:                        /bin/csh
+  environment:
+    PATH:                              "{{ ansible_env.PATH }}:/db2/db2{{ db_sid | lower }}/sqllib/gskit/bin"

--- a/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/main.yml
+++ b/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/main.yml
@@ -26,8 +26,11 @@
     - name:                            "DB2 - Take offline backup of Primary DB"
       ansible.builtin.import_tasks:    4.2.1.1-db2_primary_backup.yml
 
-    - name:                            "DB2 - Keystore Setup, Part 1"
+    - name:                            "DB2 - Keystore Setup on Primary node"
       ansible.builtin.import_tasks:    4.2.1.8-db2_copy_keystore_files.yml
+
+    - name:                            "DB2 - Generate SSL on Primary node"
+      ansible.builtin.import_tasks:    4.2.1.9-db2_generate_distribute_ssl.yml
   always:
     - name:                            "DB2 Primary System Install: result"
       ansible.builtin.debug:
@@ -50,8 +53,11 @@
     - name:                            "DB2 Secondary System Install"
       ansible.builtin.import_tasks:    4.2.1.2-db2_ha_install_secondary.yml
 
-    - name:                            "DB2 - Keystore Setup, Part 2"
+    - name:                            "DB2 - Keystore Setup on Secondary node"
       ansible.builtin.import_tasks:    4.2.1.8-db2_copy_keystore_files.yml
+
+    - name:                            "DB2 - Distribute SSL certificate to Secondary node"
+      ansible.builtin.import_tasks:    4.2.1.9-db2_generate_distribute_ssl.yml
 
     - name:                            "DB2 - Restore Secondary with backup of Primary DB"
       ansible.builtin.import_tasks:    4.2.1.3-db2_restore_secondary.yml

--- a/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.2.0-cluster-RedHat.yml
+++ b/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.2.0-cluster-RedHat.yml
@@ -225,17 +225,18 @@
     is_rhel_84_or_newer:               "{{ ansible_distribution_version is version('8.4', '>=') }}"
   when:                                ansible_distribution_major_version in ["8", "9"]
 
-- name:                                "1.17 Generic Pacemaker - Ensure Azure scheduled events is configured"
-  when:
-                                      - inventory_hostname == primary_instance_name
-                                      - is_rhel_84_or_newer
-  block:
   # After configuring the Pacemaker resources for azure-events agent,
   # when you place the cluster in or out of maintenance mode, you may get warning messages like:
   #   WARNING: cib-bootstrap-options: unknown attribute 'hostName_ hostname'
   #   WARNING: cib-bootstrap-options: unknown attribute 'azure-events_globalPullState'
   #   WARNING: cib-bootstrap-options: unknown attribute 'hostName_ hostname'
   # These warning messages can be ignored.
+- name:                                "1.17 Generic Pacemaker - Ensure Azure scheduled events is configured"
+  when:
+                                      - cluster_use_scheduled_events_agent
+                                      - inventory_hostname == primary_instance_name
+                                      - is_rhel_84_or_newer
+  block:
     - name:                            "1.17 Generic Pacemaker - Ensure maintenance mode is set"
       ansible.builtin.command:         pcs property set maintenance-mode=true
 
@@ -286,7 +287,7 @@
 
 # /*---------------------------------------------------------------------------8
 # |                                                                            |
-# | Azure scheduled events - BEGIN                                             |
+# | Azure scheduled events - END                                             |
 # |                                                                            |
 # +------------------------------------4--------------------------------------*/
 

--- a/deploy/ansible/roles-sap/5.6-scsers-pacemaker/tasks/5.6.1-set_runtime_facts.yml
+++ b/deploy/ansible/roles-sap/5.6-scsers-pacemaker/tasks/5.6.1-set_runtime_facts.yml
@@ -87,7 +87,7 @@
                                        {%- else -%}
                                        {%-   set _timeoutvalue = 40 -%}
                                        {%- endif -%}
-                                       {{- _timeoutvalue -}}
+                                       {{- custom_cluster_fs_mon_timeout | default(_timeoutvalue, true) -}}
   when:
     - scs_high_availability
 
@@ -104,7 +104,7 @@
                                        {%- else -%}
                                        {%-   set _timeoutvalue = 60 -%}
                                        {%- endif -%}
-                                       {{- _timeoutvalue -}}
+                                       {{- custom_cluster_sap_mon_timeout | default(_timeoutvalue, true) -}}
   when:
     - scs_high_availability
 

--- a/deploy/ansible/roles-sap/5.6-scsers-pacemaker/tasks/5.6.4.0-cluster-Suse.yml
+++ b/deploy/ansible/roles-sap/5.6-scsers-pacemaker/tasks/5.6.4.0-cluster-Suse.yml
@@ -27,22 +27,9 @@
                                        directory='{{ profile_directory }}' fstype='nfs' options='sec=sys,vers=4.1' \
                                        op start timeout="{{ cluster_sap_scs_timeouts.start }}" interval=0 \
                                        op stop timeout="{{ cluster_sap_scs_timeouts.stop }}"  interval=0 \
-                                       op monitor interval="20s" timeout="40s"
+                                       op monitor interval=200 timeout={{ clus_fs_mon_timeout | int }}
       register:                        ascs_fs_resource
       failed_when:                     ascs_fs_resource.rc > 1
-      when:                            NFS_version == "NFSv3"
-
-    - name:                            "5.6 SCSERS - SUSE - SCS - Configure File system resources"
-      ansible.builtin.command: >
-                                       crm configure primitive fs_{{ sap_sid | upper }}_{{ instance_type | upper }} Filesystem \
-                                       device='{{ ascs_filesystem_device }}' \
-                                       directory='{{ profile_directory }}' fstype='nfs' options='sec=sys,vers=4.1' \
-                                       op start timeout="{{ cluster_sap_scs_timeouts.start }}" interval=0 \
-                                       op stop timeout="{{ cluster_sap_scs_timeouts.stop }}"  interval=0 \
-                                       op monitor interval="20s" timeout="105s"
-      register:                        ascs_fs_resource
-      failed_when:                     ascs_fs_resource.rc > 1
-      when:                            NFS_version == "NFSv4.1"
 
     - name:                            "5.6 SCSERS - SUSE - SCS - Create ASCS VIP - This is LB frontend ASCS/SCS IP"
       ansible.builtin.command: >
@@ -185,22 +172,9 @@
                                        directory='/usr/sap/{{ sap_sid | upper }}/ERS{{ ers_instance_number }}' fstype='nfs' options='sec=sys,vers=4.1' \
                                        op start timeout="{{ cluster_sap_scs_timeouts.start }}" interval=0 \
                                        op stop timeout="{{ cluster_sap_scs_timeouts.stop }}"  interval=0 \
-                                       op monitor interval="20s" timeout="40s"
+                                       op monitor interval=200 timeout={{ clus_fs_mon_timeout | int }}
       register:                        ers_fs_resource
       failed_when:                     ers_fs_resource.rc > 1
-      when:                            NFS_version == "NFSv3"
-
-    - name:                            "5.6 SCSERS - SUSE - ERS - Configure File system resources"
-      ansible.builtin.command: >
-                                       crm configure primitive fs_{{ sap_sid | upper }}_ERS Filesystem \
-                                       device='{{ ers_filesystem_device }}' \
-                                       directory='/usr/sap/{{ sap_sid | upper }}/ERS{{ ers_instance_number }}' fstype='nfs' options='sec=sys,vers=4.1' \
-                                       op start timeout="{{ cluster_sap_scs_timeouts.start }}" interval=0 \
-                                       op stop timeout="{{ cluster_sap_scs_timeouts.stop }}"  interval=0 \
-                                       op monitor interval="20s" timeout="105s"
-      register:                        ers_fs_resource
-      failed_when:                     ers_fs_resource.rc > 1
-      when:                            NFS_version == "NFSv4.1"
 
     - name:                            "5.6 SCSERS - SUSE - ERS - Create ERS VIP - This is LB frontend ERS IP"
       ansible.builtin.command: >

--- a/deploy/ansible/vars/ansible-input-api.yaml
+++ b/deploy/ansible/vars/ansible-input-api.yaml
@@ -211,6 +211,8 @@ use_simple_mount:                       false
 database_cluster_type:                 "AFA"
 # scs_high_availability:                 false
 scs_cluster_type:                      "AFA"
+# Configure pacemaker for Azure scheduled events
+cluster_use_scheduled_events_agent:    true
 
 # ------------------- Begin - SAP SWAP settings variables --------------------8
 sap_swap:
@@ -227,4 +229,4 @@ sap_swap:
   - { tier: "oracle-multi-sid",   swap_size_mb: "20480" }
   - { tier: "observer",           swap_size_mb: "2048"  }
   - { tier: 'sqlserver',          swap_size_mb: '20480' }
-  # --------------------- End - SAP SWAP settings variables --------------------8
+# --------------------- End - SAP SWAP settings variables --------------------8

--- a/deploy/ansible/vars/ansible-input-api.yaml
+++ b/deploy/ansible/vars/ansible-input-api.yaml
@@ -213,6 +213,9 @@ database_cluster_type:                 "AFA"
 scs_cluster_type:                      "AFA"
 # Configure pacemaker for Azure scheduled events
 cluster_use_scheduled_events_agent:    true
+# Custom pacemaker NFS filesystem and SAP monitor timeouts
+custom_cluster_fs_mon_timeout:         ""
+custom_cluster_sap_mon_timeout:        ""
 
 # ------------------- Begin - SAP SWAP settings variables --------------------8
 sap_swap:

--- a/deploy/terraform/terraform-units/modules/sap_landscape/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/variables_local.tf
@@ -565,7 +565,7 @@ locals {
   sub_iscsi_nsg_arm_id                            = try(var.infrastructure.vnets.sap.subnet_iscsi.nsg.arm_id, "")
   sub_iscsi_nsg_exists                            = length(local.sub_iscsi_nsg_arm_id) > 0
   sub_iscsi_nsg_name                              = local.sub_iscsi_nsg_exists ? (
-                                                      try(split("/", local.sub_iscsi.nsg.arm_id)[8], "")) : (
+                                                      try(split("/", local.sub_iscsi_nsg_arm_id)[8], "")) : (
                                                       length(try(var.infrastructure.vnets.sap.subnet_iscsi.nsg.name, "")) > 0 ? (
                                                         var.infrastructure.vnets.sap.subnet_iscsi.nsg.name ) : (
                                                         format("%s%s%s%s",

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/vm-anydb.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/vm-anydb.tf
@@ -233,7 +233,6 @@ resource "azurerm_linux_virtual_machine" "dbserver" {
   lifecycle {
     ignore_changes = [
       // Ignore changes to computername
-      tags,
       computer_name
     ]
   }


### PR DESCRIPTION
## Problem
1. Error: A local value with the name "sub_iscsi" has not been declared
2. The Azure scheduled events agent for pacemaker is installed by default for Red Hat clusters. We've seen unexpected behavior during our tests. For example pacemaker won't come online after the node has been fenced. The agent is als relatively new and we want to be able to test it thoroughly before implementing it on our production clusters. 
3. When using a custom NFS solution different pacemaker filesystem time-outs may be required.
4. DB2 HADR local and remote hostnames are set to system hostnames and not the virtual_hosts.
5. Tags in Azure for the anydb_node dbserver linux virtual machine are ignored while they are managed for the other linux virtual machines.
6. After a HADR fail-over to the stand-by node the application server can't connect due to a missing SSL certificate on the stand-by node.
7. Communication between primary and standby HADR nodes is unencrypted.

## Solution
1. `local.sub_iscsi.nsg.arm_id` should be `local.sub_iscsi_nsg_arm_id`
2. Add `cluster_use_scheduled_events_agent` boolean in ansible-input-api.yaml to manage Azure scheduled events agent installation. Default is set to true.
3. Add `custom_cluster_fs_mon_timeout` and `custom_cluster_sap_mon_timeout` variables (empty by default) in ansible-input-api.yaml for custom pacemaker NFS filesystem and SAP monitor timeouts. Refactored the cluster-Suse tasks so that it utilizes the calculated filesystem timeout and SAP resource monitor timeout from the 5.6.1-set_runtime_facts task.
4. Use virtual_host names for DB2 HADR local host name configuration.
5. Remove `tags` from ignore_changes for `azurerm_linux_virtual_machine.dbserver`
6. Generate a SSL certificate which is valid for 10 years for the db virtual hostname (loadbalancer), share the SSL keystore with the stand-by node and update DB2 SSL settings.
7. Encrypt communication between HADR Primary and Standby Instances with generated SSL certificate.

## Tests
Tested with a RHEL8.9 DB2 cluster.

## Notes
- https://community.sap.com/t5/technology-blogs-by-sap/encrypting-an-sap-system-on-a-db2-for-luw-database-reduce-downtime-by/ba-p/13530157
- https://www.sap.com/documents/2018/12/d2922a3b-307d-0010-87a3-c30de2ffd8ff.html