### PR TITLE
Only use SSL generation and distribution when InstanceType is ABAP

### DIFF
--- a/deploy/ansible/playbook_04_00_00_db_install.yaml
+++ b/deploy/ansible/playbook_04_00_00_db_install.yaml
@@ -547,7 +547,7 @@
 
         - name:                        Setting the DB facts
           ansible.builtin.set_fact:
-            tier:                      db2                                    # Actions for Oracle DB Servers
+            tier:                      db2                                    # Actions for DB2 Servers
             main_password:             "{{ hostvars.localhost.sap_password }}"
             sapbits_location_base_path: "{{ hostvars.localhost.sapbits_location_base_path }}"
             sapbits_sas_token:         "{{ hostvars.localhost.sapbits_sas_token }}"
@@ -575,8 +575,8 @@
           vars:
             suffix:                    "_DB"
             tier:                      'db2'
-            prefix:                    "{{ bom.product_ids.dblha.replace('.', '/').replace('/ABAP', '').split(':')[1] }}"
-            path:                      "INSTALL/DISTRIBUTED/ABAP/DB"
+            prefix:                    "{{ bom.product_ids.dblha.replace('.', '/').replace('/' + {{ db2_instance_type }}, '').split(':')[1] }}"
+            path:                      "INSTALL/DISTRIBUTED/{{ db2_instance_type }}/DB"
             this_sid:                  "{{ sap_sid }}"
 
 

--- a/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.0-db2_ha_install_primary.yml
+++ b/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.0-db2_ha_install_primary.yml
@@ -110,6 +110,10 @@
           - "{{ bom.product_ids.dblha }}"
         verbosity:                     2
 
+    - name:                            "SAP DB2 - register InstanceType"
+      ansible.builtin.set_fact:
+        db2_instance_type:             "{{ bom.InstanceType | default('ABAP') }}"
+
     - name:                            "Create temp directory for sid"
       ansible.builtin.file:
         path:                          "{{ tmp_directory }}/{{ sap_sid | upper }}"

--- a/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.2-db2_ha_install_secondary.yml
+++ b/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.2-db2_ha_install_secondary.yml
@@ -101,6 +101,11 @@
           - "{{ sap_inifile }}"
           - "{{ bom.product_ids.dblsby }}"
         verbosity:                     2
+
+    - name:                            "SAP DB2 - register InstanceType"
+      ansible.builtin.set_fact:
+        db2_instance_type:             "{{ bom.InstanceType | default('ABAP') }}"
+
 # *====================================4=======================================8
 #   SAP DB2: Install
 #   2230669 - System Provisioning Using a Parameter Input File

--- a/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.4-db2_haparameters.yaml
+++ b/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.4-db2_haparameters.yaml
@@ -2,8 +2,11 @@
 
 # ###################  Setting DB2 HA parameters on Primary DB  #########################
 - name:                                "DB2 - Set up HA parameters on Primary DB"
+  when:                                ansible_hostname == primary_instance_name
+  become:                              true
+  become_user:                         db2{{ db_sid | lower }}
   block:
-    - name:                            " DB2 Primary DB - Set Fact for hadr local host and remote host "
+    - name:                            "DB2 Primary DB - Set Fact for hadr local host and remote host "
       ansible.builtin.set_fact:
         db_hadr_local_host:            "{{ hostvars[primary_instance_name]['virtual_host'] }}.{{ sap_fqdn }}"
         db_hadr_remote_host:           "{{ hostvars[secondary_instance_name]['virtual_host'] }}.{{ sap_fqdn }}"
@@ -30,7 +33,6 @@
       ansible.builtin.debug:
         msg:                           "Result: {{ pridb2status.stdout }}"
 
-
     - name:                            "DB2 Primary DB - Start the Primary DB"
       ansible.builtin.shell:           db2start
       register:                        db2startstatus
@@ -54,7 +56,6 @@
             db2 update db cfg for {{ db_sid }} using HADR_REMOTE_HOST {{ db_hadr_remote_host }} immediate
             db2 update db cfg for {{ db_sid }} using HADR_REMOTE_SVC {{ db_sid | upper }}_HADR_2 immediate
             db2 update db cfg for {{ db_sid }} using HADR_REMOTE_INST db2{{ db_sid | lower }} immediate
-            db2 update db cfg for {{ db_sid }} using HADR_SSL_LABEL {{ db2_ssl_label }}
             db2 update db cfg for {{ db_sid }} using HADR_TIMEOUT 60 immediate
             db2 update db cfg for {{ db_sid }} using HADR_SYNCMODE NEARSYNC immediate
             db2 update db cfg for {{ db_sid }} using HADR_SPOOL_LIMIT 1000 immediate
@@ -66,7 +67,7 @@
             executable:                /bin/csh
           environment:
             PATH:                      "{{ ansible_env.PATH }}:/db2/db2{{ db_sid | lower }}/sqllib/gskit/bin"
-      when:   ansible_os_family == 'Suse'
+      when: ansible_os_family == 'Suse'
 
     - name:                            "DB2 Primary DB - HA Config - RHEL"
       # RHEL - Settings - When you use an Azure Pacemaker fencing agent, set the following parameters:
@@ -81,7 +82,6 @@
             db2 update db cfg for {{ db_sid }} using HADR_REMOTE_HOST {{ db_hadr_remote_host }} immediate
             db2 update db cfg for {{ db_sid }} using HADR_REMOTE_SVC {{ db_sid | upper }}_HADR_2 immediate
             db2 update db cfg for {{ db_sid }} using HADR_REMOTE_INST db2{{ db_sid | lower }} immediate
-            db2 update db cfg for {{ db_sid }} using HADR_SSL_LABEL {{ db2_ssl_label }}
             db2 update db cfg for {{ db_sid }} using HADR_TIMEOUT 45 immediate
             db2 update db cfg for {{ db_sid }} using HADR_SYNCMODE NEARSYNC immediate
             db2 update db cfg for {{ db_sid }} using HADR_SPOOL_LIMIT 1000 immediate
@@ -93,18 +93,15 @@
             executable:                /bin/csh
           environment:
             PATH:                      "{{ ansible_env.PATH }}:/db2/db2{{ db_sid | lower }}/sqllib/gskit/bin"
-      when:   ansible_os_family == 'RedHat'
-
-  when:       ansible_hostname == primary_instance_name
-  become:                              true
-  become_user:                         db2{{ db_sid | lower }}
+      when: ansible_os_family == 'RedHat'
 
 # ################### End of Section for Primary DB   ######################
 
-# ##################  Section Start for Secondary DB               ###############################
 # ##################  Setup DB2 HA parameters on Secondary ###############################
-
 - name:                                "DB2 - Set up HA parameters on Secondary DB"
+  when:                                ansible_hostname == secondary_instance_name
+  become:                              true
+  become_user:                         db2{{ db_sid | lower }}
   block:
     - name:                            " DB2 Secondary DB - Set Fact for hadr local host and remote host "
       ansible.builtin.set_fact:
@@ -133,7 +130,6 @@
       ansible.builtin.debug:
         msg:                           "Result: {{ secdb2status.stdout }}"
 
-
     - name:                            "DB2 Secondary DB - Start the Primary DB"
       ansible.builtin.shell:           db2start
       args:
@@ -157,7 +153,6 @@
             db2 update db cfg for {{ db_sid }} using HADR_REMOTE_HOST {{ db_hadr_remote_host }} immediate
             db2 update db cfg for {{ db_sid }} using HADR_REMOTE_SVC {{ db_sid | upper }}_HADR_1 immediate
             db2 update db cfg for {{ db_sid }} using HADR_REMOTE_INST db2{{ db_sid | lower }} immediate
-            db2 update db cfg for {{ db_sid }} using HADR_SSL_LABEL {{ db2_ssl_label }}
             db2 update db cfg for {{ db_sid }} using HADR_TIMEOUT 60 immediate
             db2 update db cfg for {{ db_sid }} using HADR_SYNCMODE NEARSYNC immediate
             db2 update db cfg for {{ db_sid }} using HADR_SPOOL_LIMIT 1000 immediate
@@ -184,7 +179,6 @@
             db2 update db cfg for {{ db_sid }} using HADR_REMOTE_HOST {{ db_hadr_remote_host }} immediate
             db2 update db cfg for {{ db_sid }} using HADR_REMOTE_SVC {{ db_sid | upper }}_HADR_1 immediate
             db2 update db cfg for {{ db_sid }} using HADR_REMOTE_INST db2{{ db_sid | lower }} immediate
-            db2 update db cfg for {{ db_sid }} using HADR_SSL_LABEL {{ db2_ssl_label }}
             db2 update db cfg for {{ db_sid }} using HADR_TIMEOUT 45 immediate
             db2 update db cfg for {{ db_sid }} using HADR_SYNCMODE NEARSYNC immediate
             db2 update db cfg for {{ db_sid }} using HADR_SPOOL_LIMIT 1000 immediate
@@ -197,11 +191,21 @@
           register:                db2_update
           failed_when:             db2_update.rc not in [0,2]
       when:   ansible_os_family == 'RedHat'
-
-  when:       ansible_hostname == secondary_instance_name
-  become:                              true
-  become_user:                         db2{{ db_sid | lower }}
-
 # ################### End of Section for Secondary DB   ######################
 
+- name:                                "DB2 DB - HADR SSL Configuration"
+  when:
+    - db2_instance_type == 'ABAP'
+    - db2_ssl_label is defined
+  become:                              true
+  become_user:                         db2{{ db_sid | lower }}
+  block:
+    - name:                            "DB2 DB - Set HADR SSL Configuration"
+      ansible.builtin.shell:           db2 update db cfg for {{ db_sid }} using HADR_SSL_LABEL {{ db2_ssl_label }}
+      register:                        db2_update
+      failed_when:                     db2_update.rc not in [0,2]
+      args:
+        executable:                    /bin/csh
+      environment:
+        PATH:                          "{{ ansible_env.PATH }}:/db2/db2{{ db_sid | lower }}/sqllib/gskit/bin"
 ...

--- a/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/main.yml
+++ b/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/main.yml
@@ -19,7 +19,6 @@
 
 - name:                                "DB2 Primary System Setup"
   block:
-
     - name:                            "DB2 Primary System Install"
       ansible.builtin.import_tasks:    4.2.1.0-db2_ha_install_primary.yml
 
@@ -29,7 +28,10 @@
     - name:                            "DB2 - Keystore Setup on Primary node"
       ansible.builtin.import_tasks:    4.2.1.8-db2_copy_keystore_files.yml
 
+    # SSL communication via SWPM is only available if you're using AS ABAP
+    # Setting up SSL voor AS JAVA requires manual actions with the J2EE Config tool
     - name:                            "DB2 - Generate SSL on Primary node"
+      when:                            db2_instance_type == 'ABAP'
       ansible.builtin.import_tasks:    4.2.1.9-db2_generate_distribute_ssl.yml
   always:
     - name:                            "DB2 Primary System Install: result"
@@ -56,7 +58,10 @@
     - name:                            "DB2 - Keystore Setup on Secondary node"
       ansible.builtin.import_tasks:    4.2.1.8-db2_copy_keystore_files.yml
 
+    # SSL communication via SWPM is only available if you're using AS ABAP
+    # Setting up SSL voor AS JAVA requires manual actions with the J2EE Config tool
     - name:                            "DB2 - Distribute SSL certificate to Secondary node"
+      when:                            db2_instance_type == 'ABAP'
       ansible.builtin.import_tasks:    4.2.1.9-db2_generate_distribute_ssl.yml
 
     - name:                            "DB2 - Restore Secondary with backup of Primary DB"
@@ -87,7 +92,6 @@
 
 - name:                                "DB2 - HA Configuration Post Install Profile update"
   ansible.builtin.import_tasks:        4.2.1.7-sap-profile-changes.yaml
-
 
 # /*---------------------------------------------------------------------------8
 # |                                   END                                      |

--- a/deploy/ansible/roles-sap/5.3-app-install/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.3-app-install/tasks/main.yaml
@@ -33,7 +33,7 @@
     dir_params:                        "{{ tmp_directory }}/.{{ sid_to_be_deployed.sid | upper }}-params"
     db_lb_virtual_host_HANA:           "{% if database_high_availability %}{{ sid_to_be_deployed.sid | lower }}{{ db_sid | lower }}db{{ db_instance_number }}cl{% else %}{{ hostvars[db_server_temp | first]['virtual_host'] }}{% endif %}"
     db_lb_virtual_host_AnyDB:          "{% if database_high_availability %}{{ sid_to_be_deployed.sid | lower }}{{ db_sid | lower }}db{{ db_instance_number }}cl{% else %}{{ db_server_temp }}{% endif %}"
-    app_virtual_hostname:              "{{ default(virtual_host, true) }}"
+    app_virtual_hostname:              "{{ virtual_host }}"
 
 - name:                                "APP Install: Set BOM facts db host"
   ansible.builtin.set_fact:

--- a/deploy/terraform/terraform-units/modules/sap_landscape/key_vault_sap_landscape.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/key_vault_sap_landscape.tf
@@ -98,7 +98,7 @@ resource "azurerm_key_vault_access_policy" "kv_user" {
   provider                             = azurerm.main
   count                                = (var.key_vault.exists || var.enable_rbac_authorization_for_keyvault) ? (
                                            0) : (
-                                           (var.deployer_tfstate.deployer_uai.principal_id == local.service_principal.object_id) ? 0 : 1
+                                           (length(var.deployer_tfstate) > 0 ? var.deployer_tfstate.deployer_uai.principal_id == local.service_principal.object_id : false) ? 0 : 1
                                          )
   key_vault_id                         = local.user_keyvault_exist ? local.user_key_vault_id : azurerm_key_vault.kv_user[0].id
   tenant_id                            = local.service_principal.tenant_id


### PR DESCRIPTION
## Problem
Setting up SSL communication via SWPM is only available if you're using AS ABAP. SWPM doesn’t support SSL in AS Java environments. It currently isn't possible to set-up SSL voor AS JAVA because this requires manual actions with the J2EE Config tool (graphical X tool).

## Solution
- Only generate and distribute SSL when using AS ABAP.
- Only set-up encrypted HADR communication when using AS ABAP.
- Fix  post-install for DB2 AS JAVA (prefix and path was hard coded to ABAP)

## Tests
Tested with HA JAVA DB2 deployment and HA ABAP DB2 deployment.

## Notes
https://community.sap.com/t5/technology-blogs-by-sap/easier-setup-of-db2-native-encryption-and-ssl-during-sap-system/ba-p/13422883