### PR TITLE
Ensure mount the volumes before sap-notes

### DIFF
--- a/deploy/ansible/playbook_02_os_sap_specific_config.yaml
+++ b/deploy/ansible/playbook_02_os_sap_specific_config.yaml
@@ -241,12 +241,6 @@
           tags:
             - 2.2-sapPermissions
 
-        - name:                        "SAP OS configuration playbook: - Configurations according to SAP Notes"
-          ansible.builtin.include_role:
-            name:                      roles-sap-os/2.10-sap-notes
-          tags:
-            - 2.10-sap-notes
-
         - name:                        "SAP OS configuration playbook: - configure exports"
           ansible.builtin.include_role:
             name:                      roles-sap-os/2.3-sap-exports
@@ -258,6 +252,12 @@
             name:                      roles-sap-os/2.6-sap-mounts
           tags:
             - 2.6-sap-mounts
+
+        - name:                        "SAP OS configuration playbook: - Configurations according to SAP Notes"
+          ansible.builtin.include_role:
+            name:                      roles-sap-os/2.10-sap-notes
+          tags:
+            - 2.10-sap-notes
 
       when:
         - ansible_os_family != "Windows"


### PR DESCRIPTION
## Problem
There's an issue related to compat-sap-c++-x, the link is being created to /usr/sap/lib/libstdc++.so.6 before mounting the volume, and this shouldn't be the case.

## Solution
Ensure mounting the volume before calling sap-notes role.

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>