### PR TITLE
Include Red Hat 9 support in setting NFS service name

### DIFF
--- a/deploy/ansible/roles-sap-os/2.3-sap-exports/tasks/main.yaml
+++ b/deploy/ansible/roles-sap-os/2.3-sap-exports/tasks/main.yaml
@@ -264,7 +264,6 @@
   when:
     - custom_exports is defined
 
-
 - name:                                "2.3 Exports: - Local NFS"
   block:
     - name:                            "2.3 Exports: - Set the NFS Service name {{ distribution_id }}"
@@ -272,11 +271,10 @@
         nfs_service:                   'nfsserver'
       when:                            "'SUSE' == ansible_os_family | upper"
 
-
     - name:                            "2.3 Exports: - Set the NFS Service name {{ distribution_id }}"
       ansible.builtin.set_fact:
         nfs_service:                   "nfs-server"
-      when:                            "'redhat8' == distribution_id"
+      when:                            "'redhat8' == distribution_id or 'redhat9' == distribution_id"
 
     - name:                            "2.3 Exports: - Set the NFS Service name oracle {{ distribution_id }}"
       ansible.builtin.set_fact:


### PR DESCRIPTION
## Problem
While using RHEL 9, I encountered an error indicating that the 'nfs_service' variable is undefined.

## Solution
Adding support for RHEL 9 in the relevant Ansible task.

## Tests
Successfully tested after running the pipeline

## Notes
<Additional comments for the PR>