### PR TITLE
Add Post Configuration Actions step to DB and SAP installation pipeline

### DIFF
--- a/deploy/ansible/playbook_08_00_00_post_configuration_actions.yaml
+++ b/deploy/ansible/playbook_08_00_00_post_configuration_actions.yaml
@@ -1,0 +1,55 @@
+# /*---------------------------------------------------------------------------8
+# |                                                                            |
+# |                 Playbook for Post Configuration                            |
+# |                                                                            |
+# +------------------------------------4--------------------------------------*/
+
+---
+
+- hosts:                               localhost
+  name:                                "Post Configuration Actions Playbook: - Initialization"
+  gather_facts:                        true
+  vars_files:
+    - vars/ansible-input-api.yaml                               # API Input template with defaults
+
+  tasks:
+
+    - name:                            "Post Configuration Actions Playbook: - Create Progress folder"
+      ansible.builtin.file:
+        path:                          "{{ _workspace_directory }}/.progress"
+        state:                         directory
+        mode:                          0755
+
+    - name:                            "Post Configuration Actions Playbook: - Remove post-configuration-actions-done flag"
+      ansible.builtin.file:
+        path:                          "{{ _workspace_directory }}/.progress/post-configuration-actions-done"
+        state:                          absent
+
+
+# /*---------------------------------------------------------------------------8
+# |                                                                            |
+# |      Currently this playbook does nothing, it's here to ensure that        |
+# |      custom ansible hooks in the Config Repo can be run after              |
+# |      the full installation and configuration of VMs for a system           |
+# |                                                                            |
+# +------------------------------------4--------------------------------------*/
+
+
+- hosts:                               localhost
+  name:                                "Post Configuration Actions Playbook: - Done"
+  gather_facts:                        true
+  vars_files:
+    - vars/ansible-input-api.yaml                               # API Input template with defaults
+
+  tasks:
+
+    - name:                            "Post Configuration Actions Playbook: - Create post-configuration-actions-done flag"
+      ansible.builtin.file:
+        path:                          "{{ _workspace_directory }}/.progress/post-configuration-actions-done"
+        state:                         touch
+        mode:                          0755
+
+...
+# /*---------------------------------------------------------------------------8
+# |                                    END                                     |
+# +------------------------------------4--------------------------------------*/

--- a/deploy/pipelines/05-DB-and-SAP-installation.yaml
+++ b/deploy/pipelines/05-DB-and-SAP-installation.yaml
@@ -77,6 +77,11 @@ parameters:
     type:                              boolean
     default:                           false
 
+  - name:                              post_configuration_actions
+    displayName:                       Post Configuration Actions
+    type:                              boolean
+    default:                           false
+
 # 20220929 MKD - ACSS Registration <BEGIN>
   - name:                             acss_registration
     displayName:                      Register System in ACSS
@@ -492,6 +497,24 @@ stages:
                 parameters:
                   displayName:               Web Dispatcher
                   ansibleFilePath:           ${{ parameters.sap_automation_repo_path }}/deploy/ansible/playbook_05_04_sap_web_install.yaml
+                  secretName:                "$(Preparation.SSH_KEY_NAME)"
+                  passwordSecretName:        "$(Preparation.PASSWORD_KEY_NAME)"
+                  userNameSecretName:        "$(Preparation.USERNAME_KEY_NAME)"
+                  vaultName:                 $(Preparation.VAULT_NAME)
+                  parametersFolder:          $(Preparation.FOLDER)
+                  sapParams:                 "${{ parameters.config_repo_path }}/$(Deployment_Configuration_Path)/SYSTEM/${{ parameters.sap_system_configuration_name }}/artifacts/$(Preparation.SAP_PARAMETERS)"
+                  sidHosts:                  $(Preparation.HOSTS)
+                  extraParams:               "$(Preparation.NEW_PARAMETERS)"
+                  azureClientId:             $(ARM_CLIENT_ID)
+                  azureClientSecret:         $(ARM_CLIENT_SECRET)
+                  azureTenantId:             $(ARM_TENANT_ID)
+                  azureSubscriptionId:       $(ARM_SUBSCRIPTION_ID)
+                  USE_MSI:                   $(USE_MSI)
+          - ${{ if eq(parameters.post_configuration_actions, true) }}:
+              - template:                    templates\run-ansible.yaml
+                parameters:
+                  displayName:               Post Configuration Actions
+                  ansibleFilePath:           ${{ parameters.sap_automation_repo_path }}/deploy/ansible/playbook_08_00_00_post_configuration_actions.yaml
                   secretName:                "$(Preparation.SSH_KEY_NAME)"
                   passwordSecretName:        "$(Preparation.PASSWORD_KEY_NAME)"
                   userNameSecretName:        "$(Preparation.USERNAME_KEY_NAME)"


### PR DESCRIPTION
## Problem
Some custom configurations of VMs are needed after systems have been fully installed and configured by SDAF.

## Solution
Add a new Post Configuration Actions step in the 05-DB-and-SAP-installation pipeline.
This will faciliate SDAF users to create `_pre` and `_post` ansible hooks in their Config Repoistory, after a system has been fully configured and installed by SDAF.

This has a dependency with a [PR](https://github.com/Azure/sap-automation-bootstrap/pull/1) in the `sap-automation-bootstrap` repository.
