### PR TITLE
Suppress SCS install logs

### DIFF
--- a/deploy/ansible/playbook_05_00_00_sap_scs_install.yaml
+++ b/deploy/ansible/playbook_05_00_00_sap_scs_install.yaml
@@ -196,6 +196,9 @@
 #
 # -------------------------------------+---------------------------------------8
     - name:                            "SCS Installation Playbook: - Standalone SCS Setup"
+      when:
+        - not scs_high_availability
+        - "'scs' in supported_tiers"
       block:
         - name:                        "SCS Installation Playbook: Define this SID"
           ansible.builtin.set_fact:
@@ -387,11 +390,6 @@
                     - ansible_os_family == "Windows"
               tags:
                 - 5.0.0-scs-install
-
-      when:
-        - not scs_high_availability
-        - "'scs' in supported_tiers"
-
 
 # /*---------------------------------------------------------------------------8
 # |                                                                            |
@@ -588,6 +586,7 @@
               when:
                 - scs_installation.stdout_lines is defined
                 - scs_installation.rc is defined
+                - scs_installation.rc > 0
                 - '"ERROR" in item'
 
             - name:                    "SCS HA Installation Playbook: - Show errors from SCS installation"
@@ -603,8 +602,8 @@
               when:
                 - ers_installation.stdout_lines is defined
                 - ers_installation.rc is defined
-                - '"ERROR" in item'
                 - ers_installation.rc > 0
+                - '"ERROR" in item'
 
             - name:                    "SCS HA Installation Playbook: - Show errors from ERS installation"
               ansible.builtin.debug:


### PR DESCRIPTION
## Problem
The SCS installation logs are always shown causing thousands off output lines even when the installation is successful.

## Solution
Like with the ERS installation the return code should be greater than zero.