### PR TITLE
Only create/copy SSL cert when DB2 SSL communication is used

### DIFF
--- a/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.0-db2_ha_install_primary.yml
+++ b/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.0-db2_ha_install_primary.yml
@@ -15,8 +15,6 @@
 # TODO: Considerations
 
 ---
-
-# Set BOM facts for SAP DB2 Install - Refer to sap-automation/deploy/ansible/BOM-catalog/ERP6_EHP8_LNX_DB2UDB_11_5_v0001ms
 - name:                                "SAP DB2 Install: Preparation"
   block:
     - name:                            "SAP DB2 Install: Set BOM facts"
@@ -146,8 +144,6 @@
         msg:                           "SAP DB2 Installation succeeded."
 
   # TBC - Add another check to remove the contents of /sapmnt/<SID> if installation fails
-
-
     - name:                            "DB2 Install: flag"
       ansible.builtin.file:
         path:                          "/etc/sap_deployment_automation/{{ sap_sid | upper }}/sap_deployment_db2.txt"
@@ -172,6 +168,28 @@
         state:                         touch
         mode:                          0755
       when:                            db2_lock_escalation.rc == 0
+
+    - name:                            "DB2: Stat if the encryption keystore exists"
+      ansible.builtin.stat:
+        path:                          /db2/db2{{ db_sid | lower }}/keystore/sapdb2{{ db_sid | lower }}_db_encr.p12
+      register:                        db2_encryption_keystore_file_stat
+
+    - name:                            "DB2: Stat if the SSL keystore exists"
+      ansible.builtin.stat:
+        path:                          /db2/db2{{ db_sid | lower }}/keystore/sapdb2{{ db_sid | lower }}_ssl_comm.kdb
+      register:                        db2_ssl_keystore_file_stat
+
+    - name:                            "DB2: create db_encrypted and ssl_communication variables"
+      ansible.builtin.set_fact:
+        db_encrypted:                  "{{ db2_encryption_keystore_file_stat.stat.exists }}"
+        ssl_communication:             "{{ db2_ssl_keystore_file_stat.stat.exists }}"
+
+    - name:                            "DB2: Debug encrypted database and SSL communication"
+      ansible.builtin.debug:
+        msg:
+          - "Database encrypted: {{ db_encrypted }}"
+          - "SSL communication: {{ ssl_communication }}"
+
     - name:                            "DB2 Install: check if ARM Deployment done"
       ansible.builtin.stat:
         path:                          "/etc/sap_deployment_automation/{{ db_sid | upper }}/sap_deployment_db_arm.txt"

--- a/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.3-db2_restore_secondary.yml
+++ b/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.3-db2_restore_secondary.yml
@@ -78,8 +78,7 @@
       failed_when:                     db2_restore_result.rc > 2
       when:
         - db2_started.rc == 0
-        - hostvars[primary_instance_name]['db_encrypted'] is defined
-        - not hostvars[primary_instance_name]['db_encrypted']
+        - not hostvars[primary_instance_name]['db_encrypted'] | default(false)
       # ######### ########### End of Restore without Encryption ####################################
 
       # ##################### Start of Restore with Encryption ##################################
@@ -93,35 +92,9 @@
       failed_when:                     db2_restore_result.rc > 2
       when:
         - db2_started.rc == 0
-        - hostvars[primary_instance_name]['db_encrypted'] is defined
-        - hostvars[primary_instance_name]['db_encrypted']
+        - hostvars[primary_instance_name]['db_encrypted'] | default(false)
       # ######### ########### End of Restore with Encryption ####################################
   when:
     - ansible_hostname == secondary_instance_name
   become:                              true
   become_user:                         db2{{ db_sid | lower }}
-
-# #################Start of Restore with Encryption############################
-# Restore with Encryption - commented now till we decide on the DB2 encrpytion Strategy
-# - name: Import Master Key
-#   shell: >-
-#     gsk8capicmd_64 -cert -import -db {{ db2standby_deployment_source_keystorefile }}.p12 -target \
-#     /db2/db2{{ db2deploy_sid | lower }}/keystore/sapdb2{{ db2deploy_sid | lower }}_db_encr.p12gsk8capicmd_64 -cert -import \
-#     -db {{ db2standby_deployment_source_keystorefile }}.p12 -target /db2/db2{{ db2deploy_sid | lower }}/keystore/sapdb2 \
-#     {{ db2deploy_sid | lower }}_db_encr.p12
-#   become: true
-#   become_user: db2id2
-#   when:
-#     -  db2standby_deployment_encryption == 'true'
-
-# - name: Restore with encryption
-#   shell: >-
-#     db2 restore database {{ db2deploy_sid }} from {{ db2standby_deployment_backupdir }} \
-#     encrypt cipher {{ db2standby_deployment_ciphertype }} key length {{ db2standby_deployment_cipherkeylength }} master key label \
-#     sap_db2{{ db2deploy_sid | lower }}_{{ db2standby_deployment_standbyhostname }}_dbencr_000
-#   become: true
-#   become_user: db2id2
-#   when:
-#    -  db2standby_deployment_encryption == 'true'
-
-# ######### END of Restore with Encryption ################################

--- a/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.4-db2_haparameters.yaml
+++ b/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.4-db2_haparameters.yaml
@@ -194,11 +194,7 @@
 # ################### End of Section for Secondary DB   ######################
 
 - name:                                "DB2 DB - HADR SSL Configuration"
-  when:
-    - db2_instance_type == 'ABAP'
-    - db2_ssl_label is defined
-    - hostvars[primary_instance_name]['db_encrypted'] is defined
-    - hostvars[primary_instance_name]['db_encrypted']
+  when:                                db2_ssl_label is defined
   become:                              true
   become_user:                         db2{{ db_sid | lower }}
   block:

--- a/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.8-db2_copy_keystore_files.yml
+++ b/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.8-db2_copy_keystore_files.yml
@@ -13,35 +13,16 @@
       - sapdb2{{ db_sid | lower }}_db_encr.p12
       - sapdb2{{ db_sid | lower }}_db_encr.sth
 
-- name:                                "DB2: Stat if the keystore files exist on Primary node"
-  ansible.builtin.stat:
-    path:                              "/db2/db2{{ db_sid | lower }}/keystore/{{ item }}"
-  loop:                                "{{ keystore_files }}"
-  register:                            keystore_files_stat
-  when:                                ansible_hostname == primary_instance_name
-
-- name:                                "DB2: Determine if the database is encrypted"
-  ansible.builtin.set_fact:
-    db_encrypted:                     "{{ (keystore_files_stat.results | map(attribute='stat.exists')) is all }}"
-  when:                                ansible_hostname == primary_instance_name
-
-- name:                                "DB2: Debug if the database is encrypted"
-  ansible.builtin.debug:
-    msg:
-      - "Database is encrypted: {{ db_encrypted }}"
-  when:                                ansible_hostname == primary_instance_name
-
 - name:                                "DB2: Fetch keystore files from Primary node to Controller"
+  when:                                ansible_hostname == primary_instance_name
   ansible.builtin.fetch:
     src:                               "/db2/db2{{ db_sid | lower }}/keystore/{{ item }}"
     dest:                              /tmp/keystore_files/
     flat:                              true
   loop:                                "{{ keystore_files }}"
-  when:
-    - ansible_hostname == primary_instance_name
-    - db_encrypted
 
 - name:                                "DB2: Copy keystore files from Controller to Secondary node"
+  when:                                ansible_hostname == secondary_instance_name
   ansible.builtin.copy:
     src:                               /tmp/keystore_files/{{ item }}
     dest:                              /db2/db2{{ db_sid | lower }}/keystore/
@@ -49,7 +30,3 @@
     owner:                             db2{{ db_sid | lower }}
     group:                             db{{ db_sid | lower }}adm
   loop:                                "{{ keystore_files }}"
-  when:
-    - ansible_hostname == secondary_instance_name
-    - hostvars[primary_instance_name]['db_encrypted'] is defined
-    - hostvars[primary_instance_name]['db_encrypted']

--- a/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.9-db2_generate_distribute_ssl.yml
+++ b/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.9-db2_generate_distribute_ssl.yml
@@ -1,29 +1,4 @@
 ---
-
-- name:                                "DB2: Variable for keystore files"
-  ansible.builtin.set_fact:
-    keystore_files:
-      - sapdb2{{ db_sid | lower }}_db_encr.p12
-      - sapdb2{{ db_sid | lower }}_db_encr.sth
-
-- name:                                "DB2: Stat if the keystore files exist on Primary node"
-  ansible.builtin.stat:
-    path:                              "/db2/db2{{ db_sid | lower }}/keystore/{{ item }}"
-  loop:                                "{{ keystore_files }}"
-  register:                            keystore_files_stat
-  when:                                ansible_hostname == primary_instance_name
-
-- name:                                "DB2: Determine if the database is encrypted"
-  ansible.builtin.set_fact:
-    db_encrypted:                     "{{ (keystore_files_stat.results | map(attribute='stat.exists')) is all }}"
-  when:                                ansible_hostname == primary_instance_name
-
-- name:                                "DB2: Debug if the database is encrypted"
-  ansible.builtin.debug:
-    msg:
-      - "Database is encrypted: {{ db_encrypted }}"
-  when:                                ansible_hostname == primary_instance_name
-
 - name:                                "DB2: variables for SSL certificate"
   ansible.builtin.set_fact:
     db2_ssl_cn:                        "{{ custom_db_virtual_hostname | default(db_virtual_hostname, true) }}.{{ sap_fqdn }}"
@@ -31,11 +6,8 @@
     db2_ssl_stash_file:                sapdb2{{ db_sid | lower }}_ssl_comm.sth
     db2_ssl_label:                     sap_db2_{{ custom_db_virtual_hostname | default(db_virtual_hostname, true) }}_ssl_comm_000
 
-
 - name:                                "DB2 Primary DB: Generate SSL"
-  when:
-    - ansible_hostname == primary_instance_name
-    - db_encrypted
+  when:                                ansible_hostname == primary_instance_name
   become:                              true
   become_user:                         db2{{ db_sid | lower }}
   block:
@@ -58,9 +30,7 @@
         LD_LIBRARY_PATH:               /db2/db2{{ db_sid | lower }}/sqllib/lib64:/db2/db2{{ db_sid | lower }}/sqllib/lib64/gskit:/db2/db2{{ db_sid | lower }}/sqllib/lib
 
 - name:                                "DB2 Primary DB - Copy SSL Certificate and Keystore files"
-  when:
-    - ansible_hostname == primary_instance_name
-    - db_encrypted
+  when:                                ansible_hostname == primary_instance_name
   block:
     - name:                            "DB2 Primary DB - Copy SSL certificate to SSL_client directory"
       ansible.builtin.copy:
@@ -80,11 +50,6 @@
         - "{{ db2_ssl_keydb_file }}"
         - "{{ db2_ssl_stash_file }}"
 
-    - name:                            "DB2 Primary DB: Flag to show that copied"
-      ansible.builtin.set_fact:
-        keystore_copied:              true
-
-
     - name:                            "DB2 Primary DB: Update SSL certificate in db2cli.ini"
       ansible.builtin.lineinfile:
         path:                          /sapmnt/{{ sap_sid | upper }}/global/db6/db2cli.ini
@@ -92,9 +57,6 @@
         line:                          SSLServerCertificate=/usr/sap/{{ db_sid | upper }}/SYS/global/SSL_client/{{ db2_ssl_label }}.arm
 
 - name:                                "DB2 DB - Set SSL parameters"
-  when:
-    - hostvars[primary_instance_name]['db_encrypted'] is defined
-    - hostvars[primary_instance_name]['db_encrypted']
   become:                              true
   become_user:                         db2{{ db_sid | lower }}
   ansible.builtin.shell: |
@@ -108,10 +70,7 @@
     PATH:                              "{{ ansible_env.PATH }}:/db2/db2{{ db_sid | lower }}/sqllib/gskit/bin"
 
 - name:                                "DB2: Copy keystore files from Controller to Secondary node"
-  when:
-    - ansible_hostname == secondary_instance_name
-    - hostvars[primary_instance_name]['keystore_copied'] is defined
-    - hostvars[primary_instance_name]['keystore_copied']
+  when:                                ansible_hostname == secondary_instance_name
   ansible.builtin.copy:
     src:                               /tmp/keystore_files/{{ item }}
     dest:                              /db2/db2{{ db_sid | lower }}/keystore/

--- a/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/main.yml
+++ b/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/main.yml
@@ -18,6 +18,7 @@
 # +------------------------------------4--------------------------------------*/
 
 - name:                                "DB2 Primary System Setup"
+  when:                                ansible_hostname == primary_instance_name
   block:
     - name:                            "DB2 Primary System Install"
       ansible.builtin.import_tasks:    4.2.1.0-db2_ha_install_primary.yml
@@ -25,13 +26,14 @@
     - name:                            "DB2 - Take offline backup of Primary DB"
       ansible.builtin.import_tasks:    4.2.1.1-db2_primary_backup.yml
 
-    - name:                            "DB2 - Keystore Setup on Primary node"
+    - name:                            "DB2 - Fetch Keystore from Primary node"
+      when:                            hostvars[primary_instance_name]['db_encrypted'] | default(false)
       ansible.builtin.import_tasks:    4.2.1.8-db2_copy_keystore_files.yml
 
-    # SSL communication via SWPM is only available if you're using AS ABAP
+    # SSL communication via SWPM is only available if you're using AS ABAP and configured UseDb2SSLClientServerComm in the BOM
     # Setting up SSL voor AS JAVA requires manual actions with the J2EE Config tool
     - name:                            "DB2 - Generate SSL on Primary node"
-      when:                            db2_instance_type == 'ABAP'
+      when:                            hostvars[primary_instance_name]['ssl_communication'] | default(false)
       ansible.builtin.import_tasks:    4.2.1.9-db2_generate_distribute_ssl.yml
   always:
     - name:                            "DB2 Primary System Install: result"
@@ -40,28 +42,24 @@
         verbosity:                     4
 
     - name:                            "DB2 Primary System Install: result"
-      ansible.builtin.fail:
-        msg:                           db2_installation.stdout_lines
       when:
         - db2_installation.rc is defined
         - db2_installation.rc != 0
-
-  when:
-    - ansible_hostname == primary_instance_name
+      ansible.builtin.fail:
+        msg:                           db2_installation.stdout_lines
 
 - name:                                "DB2 Secondary System Setup"
+  when:                                ansible_hostname == secondary_instance_name
   block:
-
     - name:                            "DB2 Secondary System Install"
       ansible.builtin.import_tasks:    4.2.1.2-db2_ha_install_secondary.yml
 
-    - name:                            "DB2 - Keystore Setup on Secondary node"
+    - name:                            "DB2 - Copy Keystore to Secondary node"
+      when:                            hostvars[primary_instance_name]['db_encrypted'] | default(false)
       ansible.builtin.import_tasks:    4.2.1.8-db2_copy_keystore_files.yml
 
-    # SSL communication via SWPM is only available if you're using AS ABAP
-    # Setting up SSL voor AS JAVA requires manual actions with the J2EE Config tool
     - name:                            "DB2 - Distribute SSL certificate to Secondary node"
-      when:                            db2_instance_type == 'ABAP'
+      when:                            hostvars[primary_instance_name]['ssl_communication'] | default(false)
       ansible.builtin.import_tasks:    4.2.1.9-db2_generate_distribute_ssl.yml
 
     - name:                            "DB2 - Restore Secondary with backup of Primary DB"
@@ -73,13 +71,11 @@
         verbosity:                     4
 
     - name:                            "DB2 Primary System Install: result"
-      ansible.builtin.fail:
-        msg:                           db2_installation.stdout_lines
       when:
         - db2_installation.rc is defined
         - db2_installation.rc != 0
-  when:
-    - ansible_hostname == secondary_instance_name
+      ansible.builtin.fail:
+        msg:                           db2_installation.stdout_lines
 
 - name:                                "DB2 - Apply high availability database parameters on Primary & Secondary System"
   ansible.builtin.import_tasks:        4.2.1.4-db2_haparameters.yaml

--- a/deploy/ansible/roles-sap-os/2.5-sap-users/tasks/main.yaml
+++ b/deploy/ansible/roles-sap-os/2.5-sap-users/tasks/main.yaml
@@ -40,8 +40,6 @@
     - { group: 'sapsys',    gid: '{{ sapsys_gid }}'  }
     - { group: 'sapinst',   gid: '{{ sapinst_gid }}' }
 
-
-
 # Create Groups for Oracle ASM.
 - name:                                "2.5.1 SAP Users: - Create SAP Groups for Oracle ASM"
   ansible.builtin.group:

--- a/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.3-oracle-observer.yaml
+++ b/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.3-oracle-observer.yaml
@@ -107,4 +107,3 @@
     - tier == 'sapos'
     - usr_sap_install_mountpoint is defined
     - node_tier == 'observer'
-

--- a/deploy/ansible/vars/ansible-input-api.yaml
+++ b/deploy/ansible/vars/ansible-input-api.yaml
@@ -99,9 +99,6 @@ db2sidadm_uid:                         3004
 db2sapsid_uid:                         3005 # Uid of the database connect user
 db2hadr_port1:                         51012
 db2hadr_port2:                         51013
-# Name of the database connect user for ABAP. Default value is 'sap<sapsid>'.
-db2_abap_connect_user:                 ""
-db2_instance_type:                     "ABAP"
 
 tmp_directory:                         "/var/tmp"
 url_internet:                          "https://azure.status.microsoft/en-us/status"                 # URL to use for internet access checks"


### PR DESCRIPTION
## Problem
SSL communication isn't enabled by default for DB2 ABAP installation. This can be managed by setting `db6.UseDb2SSLClientServerComm` to true in the BOM parameters file. Currently the code assumes that all DB2 ABAP installations use SSL Communication and that's the same keystore is used as for the DB2 encryption and that's not right.

## Solution
Check for the existence of the SSL and Encryption keystore and only import the tasks when they exist.

## Tests
- HA ABAP DB2 installation was completed successfully