### PR TITLE
Remove code to stop the secondary node in Oracle DB before restart

### DIFF
--- a/deploy/ansible/roles-db/4.1.3-ora-dg/tasks/ora-dg-setup-secondary.yaml
+++ b/deploy/ansible/roles-db/4.1.3-ora-dg/tasks/ora-dg-setup-secondary.yaml
@@ -42,28 +42,28 @@
 
 # Restart the Listener on Secondary node.
 
-- name:                                "Oracle Data Guard - Setup Secondary: stop lsnrctl on Secondary"
-  become:                              true
-  become_user:                         "oracle"
-  ansible.builtin.shell:               lsnrctl stop
-  register:                            lsnrctl_stop_secondary_results
-  failed_when:                         lsnrctl_stop_secondary_results.rc > 0
-  args:
-    creates:                           /etc/sap_deployment_automation/dgscripts/lsnrctl_stopped_sec.txt
-    chdir:                             /etc/sap_deployment_automation/dgscripts
-    executable:                        /bin/csh
-  when:                                current_host == ora_secondary
+# - name:                                "Oracle Data Guard - Setup Secondary: stop lsnrctl on Secondary"
+#   become:                              true
+#   become_user:                         "oracle"
+#   ansible.builtin.shell:               lsnrctl stop
+#   register:                            lsnrctl_stop_secondary_results
+#   failed_when:                         lsnrctl_stop_secondary_results.rc > 0
+#   args:
+#     creates:                           /etc/sap_deployment_automation/dgscripts/lsnrctl_stopped_sec.txt
+#     chdir:                             /etc/sap_deployment_automation/dgscripts
+#     executable:                        /bin/csh
+#   when:                                current_host == ora_secondary
 
-- name:                                "Oracle Data Guard - Setup Secondary: Create lsnrctl_stopped_sec.txt"
-  become:                              true
-  become_user:                         "oracle"
-  ansible.builtin.file:
-    path:                              /etc/sap_deployment_automation/dgscripts/lsnrctl_stopped_sec.txt
-    state:                             touch
-    mode:                              '0755'
-  when:
-    - current_host == ora_secondary
-    - lsnrctl_stop_secondary_results.rc == 0
+# - name:                                "Oracle Data Guard - Setup Secondary: Create lsnrctl_stopped_sec.txt"
+#   become:                              true
+#   become_user:                         "oracle"
+#   ansible.builtin.file:
+#     path:                              /etc/sap_deployment_automation/dgscripts/lsnrctl_stopped_sec.txt
+#     state:                             touch
+#     mode:                              '0755'
+#   when:
+#     - current_host == ora_secondary
+#     - lsnrctl_stop_secondary_results.rc == 0
 
 - name:                                "Oracle Data Guard - Setup Secondary: restart lsnrctl on Secondary"
   become:                              true

--- a/deploy/ansible/roles-db/4.1.3-ora-dg/tasks/ora-dg-setup-secondary.yaml
+++ b/deploy/ansible/roles-db/4.1.3-ora-dg/tasks/ora-dg-setup-secondary.yaml
@@ -40,31 +40,6 @@
     mode:                              "{{ '0777' | int - (custom_umask | default('022') | int) }}"
   when: current_host == ora_secondary
 
-# Restart the Listener on Secondary node.
-
-# - name:                                "Oracle Data Guard - Setup Secondary: stop lsnrctl on Secondary"
-#   become:                              true
-#   become_user:                         "oracle"
-#   ansible.builtin.shell:               lsnrctl stop
-#   register:                            lsnrctl_stop_secondary_results
-#   failed_when:                         lsnrctl_stop_secondary_results.rc > 0
-#   args:
-#     creates:                           /etc/sap_deployment_automation/dgscripts/lsnrctl_stopped_sec.txt
-#     chdir:                             /etc/sap_deployment_automation/dgscripts
-#     executable:                        /bin/csh
-#   when:                                current_host == ora_secondary
-
-# - name:                                "Oracle Data Guard - Setup Secondary: Create lsnrctl_stopped_sec.txt"
-#   become:                              true
-#   become_user:                         "oracle"
-#   ansible.builtin.file:
-#     path:                              /etc/sap_deployment_automation/dgscripts/lsnrctl_stopped_sec.txt
-#     state:                             touch
-#     mode:                              '0755'
-#   when:
-#     - current_host == ora_secondary
-#     - lsnrctl_stop_secondary_results.rc == 0
-
 - name:                                "Oracle Data Guard - Setup Secondary: restart lsnrctl on Secondary"
   become:                              true
   become_user:                         "oracle"


### PR DESCRIPTION
## Problem
<Please describe what problem this PR is trying to resolve>
During the testing of Oracle HA DB deployment, I found that the listener is not running on the secondary node, so stopping it would result in exception. Additionally, we are already performing the restart operation in the next step, so I think this step can be skipped.

## Solution
Skip stopping listener on secondary node.

## Tests
I performed 2 HA deployments with this change, and it was successful. 

## Notes
<Additional comments for the PR>