### PR TITLE
Re-add storage_type.name_offset for append_disk of hdb_node

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
@@ -231,7 +231,7 @@ locals {
                                                for idx, disk_count in range(storage_type.count) : {
                                                  suffix = format("-%s%02d",
                                                    storage_type.name,
-                                                   disk_count + var.options.resource_offset
+                                                   storage_type.name_offset + disk_count + var.options.resource_offset
                                                  )
                                                  storage_account_type      = storage_type.disk_type,
                                                  disk_size_gb              = storage_type.size_gb,


### PR DESCRIPTION
Was removed in version 3.9.3 but should be present like with anydb_node and app_tier. Append disk isn't working atm.

https://github.com/Azure/sap-automation/pull/499/files#diff-f3f0cacc6c65c102bd1d82eb6bf30c1b485d6e272375d92855dcb7664e4bf35bL220