### PR TITLE
When Terraform plan failed, stop the script from executing Terraform apply

### DIFF
--- a/deploy/scripts/installer.sh
+++ b/deploy/scripts/installer.sh
@@ -591,6 +591,7 @@ fi
 allParams=$(printf " -var-file=%s %s %s %s %s %s %s" "${var_file}" "${extra_vars}" "${tfstate_parameter}" "${landscape_tfstate_key_parameter}" "${deployer_tfstate_key_parameter}" "${deployment_parameter}" "${version_parameter}" )
 
 terraform -chdir="$terraform_module_directory" plan -no-color -detailed-exitcode $allParams | tee -a plan_output.log
+return_value=$?
 echo "Plan returned $return_value"
 
 if [ 0 != $return_value ]

--- a/deploy/scripts/installer.sh
+++ b/deploy/scripts/installer.sh
@@ -1,4 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+# Ensure that the exit status of a pipeline command is non-zero if any
+# stage of the pipefile has a non-zero exit status.
+set -euo pipefail
 
 #colors for terminal
 boldreduscore="\e[1;4;31m"

--- a/deploy/scripts/installer.sh
+++ b/deploy/scripts/installer.sh
@@ -2,7 +2,7 @@
 
 # Ensure that the exit status of a pipeline command is non-zero if any
 # stage of the pipefile has a non-zero exit status.
-set -euo pipefail
+set -o pipefail
 
 #colors for terminal
 boldreduscore="\e[1;4;31m"

--- a/deploy/scripts/installer.sh
+++ b/deploy/scripts/installer.sh
@@ -596,10 +596,9 @@ allParams=$(printf " -var-file=%s %s %s %s %s %s %s" "${var_file}" "${extra_vars
 
 terraform -chdir="$terraform_module_directory" plan -no-color -detailed-exitcode $allParams | tee -a plan_output.log
 return_value=$?
-echo "Plan returned $return_value"
+echo "Terraform Plan return code: " $return_value
 
-if [ 0 != $return_value ]
-then
+if [ 1 == $return_value ]: then
     echo ""
     echo "#########################################################################################"
     echo "#                                                                                       #"
@@ -615,7 +614,7 @@ then
 fi
 
 state_path="SYSTEM"
-if [ 0 == $return_value ] ; then
+if [ 1 != $return_value ] ; then
 
     if [ "${deployment_system}" == sap_deployer ]
     then


### PR DESCRIPTION
## Problem
When the Terraform Plan has errors, the script will continue to run.

## Solution
The return_value was not being updated with the return code of the plan, so the check is not working.

## Tests
Before:
![image](https://github.com/Azure/sap-automation/assets/5731724/7aa38ff6-1461-4af4-8ea0-1d1814ea5dd2)

After:
![image](https://github.com/Azure/sap-automation/assets/5731724/ff0b0f03-04b4-48fc-a55c-4e728b267fca)

## Notes
<Additional comments for the PR>