### PR TITLE
Add optional extended log collection, fix kdump_enabled undefined variable error

### DIFF
--- a/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.2.0-cluster-RedHat.yml
+++ b/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.2.0-cluster-RedHat.yml
@@ -222,7 +222,7 @@
 
 - name:                                "1.17 Generic Pacemaker - Install fence-agents-kdump package"
   when:
-                                       - kdump_enabled == "enabled"
+                                       - kdump_enabled | default("disabled") == "enabled"
   ansible.builtin.yum:
     name:                              fence-agents-kdump
     state:                             present
@@ -232,7 +232,7 @@
 - name:                                 "1.17 Generic Pacemaker - configure the special fencing device fence_kdump"
   when:
                                       - inventory_hostname == primary_instance_name
-                                      - kdump_enabled == "enabled"
+                                      - kdump_enabled | default("disabled") == "enabled"
   block:
 
     # we can assume that the stonith:fence_azure_rm is already configured
@@ -263,7 +263,7 @@
 
 - name:                               "1.17 Generic Pacemaker - Ensure that the kdump service is enabled"
   when:
-                                      - kdump_enabled == "enabled"
+                                      - kdump_enabled | default("disabled") == "enabled"
   block:
 
     # Perform the fence_kdump_nodes configuration in /etc/kdump.conf
@@ -276,7 +276,7 @@
       register:                        kdump_conf_file
       failed_when:                     kdump_conf_file.rc != 0
       when:
-                                       - kdump_enabled == "enabled"
+                                       - kdump_enabled | default("disabled") == "enabled"
                                        - inventory_hostname == primary_instance_name
 
     # Perform the fence_kdump_nodes configuration in /etc/kdump.conf
@@ -289,7 +289,7 @@
       register:                        kdump_conf_file
       failed_when:                     kdump_conf_file.rc != 0
       when:
-                                       - kdump_enabled == "enabled"
+                                       - kdump_enabled | default("disabled") == "enabled"
                                        - inventory_hostname == secondary_instance_name
 
     # set the kdump path to /usr/crash in /etc/kdump.conf
@@ -302,7 +302,7 @@
       register:                        kdump_conf_file_path
       failed_when:                     kdump_conf_file_path.rc != 0
       when:
-                                       - kdump_enabled == "enabled"
+                                       - kdump_enabled | default("disabled") == "enabled"
 
     # restart kdump service as we made changes to the configuration
     - name:                            "1.17 Generic Pacemaker - Restart kdump service"

--- a/deploy/ansible/roles-sap/7.0.0-post-install/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/7.0.0-post-install/tasks/main.yaml
@@ -190,6 +190,57 @@
     - tier != 'oracle'
     - sapinst_list_of_files is defined
 
+- name:                                "Post Installation (optional): check if sapinst_instdir exists"
+  become_user:                         root
+  become:                              true
+  ansible.builtin.stat:
+    path:                              "{{ tmp_directory }}/{{ this_sid }}/sapinst_instdir"
+  register:                            sapinst_instdir_exists
+  when:
+    - tier not in ['hana', 'oracle']
+    - all_sapinst_instdir_logs | default(false)
+
+- name:                                "Post Installation (optional): Find all log files in {{ tmp_directory }}/{{ this_sid }}/sapinst_instdir/"
+  become_user:                         root
+  become:                              true
+  ansible.builtin.find:
+    paths:                             "{{ tmp_directory }}/{{ this_sid }}/sapinst_instdir/"
+    file_type:                         file
+    patterns:                          '*.log'
+    recurse:                           true
+  register:                            sapinst_instdir_logs
+  when:
+    - tier not in ['hana', 'oracle']
+    - sapinst_instdir_exists.stat.exists
+    - all_sapinst_instdir_logs | default(false)
+
+- name:                                "Post Installation (optional): Compress all log files from {{ tmp_directory }}/{{ this_sid }}/sapinst_instdir/"
+  become_user:                         root
+  become:                              true
+  community.general.archive:
+    path:                              "{{ sapinst_instdir_logs.files | map(attribute='path') | list }}"
+    dest:                              "{{ tmp_directory }}/{{ this_sid }}/{{ this_sid }}{{ suffix }}_{{ inventory_hostname }}_all_logs.zip"
+    format:                            zip
+    mode:                              0755
+  when:
+    - tier not in ['hana', 'oracle']
+    - sapinst_instdir_logs.files is defined
+    - sapinst_instdir_logs.files | length > 0
+    - all_sapinst_instdir_logs | default(false)
+
+- name:                                "Post Installation (optional): Copy the zipped sapinst_instdir installation logs"
+  become_user:                         root
+  become:                              true
+  ansible.builtin.fetch:
+    src:                               "{{ tmp_directory }}/{{ this_sid }}/{{ this_sid }}{{ suffix }}_{{ inventory_hostname }}_all_logs.zip"
+    dest:                              "{{ _workspace_directory }}/logs/{{ this_sid }}{{ suffix }}_{{ inventory_hostname }}_all_logs.zip"
+    flat:                              true
+  when:
+    - tier not in ['hana', 'oracle']
+    - sapinst_instdir_logs.files is defined
+    - sapinst_instdir_logs.files | length > 0
+    - all_sapinst_instdir_logs | default(false)
+
 - name:                                "Post Installation: HANA"
   when:
     - tier == 'hana'


### PR DESCRIPTION
## Problem
SAP Team needs more logs than the framework usually collects. 
kdump_enabled variable setting can error out with 'undefined'.

## Solution
Collect all *.log files from sapinst_instdir if 'all_sapinst_instdir_logs' variable is set.
Use default filter for kdump_enabled in when statements.

## Tests
Tested with DB2 ABAP/JAVA HA deployments.
