### PR TITLE
Hotfix/scaleout anf multi-node standby  (optional )

### DIFF
--- a/deploy/ansible/roles-db/4.0.3-hdb-install-scaleout/tasks/main.yaml
+++ b/deploy/ansible/roles-db/4.0.3-hdb-install-scaleout/tasks/main.yaml
@@ -7,7 +7,13 @@
 # |                  deploy hdblcm password file                               |
 # |                                                                            |
 # +------------------------------------4--------------------------------------*/
-
+# /*---------------------------------------------------------------------------8
+# |                                                                            |
+# |    This code contains references to terms that Microsoft no longer uses.   |
+# |    When these terms are removed from the SAP software and documentation,   |
+# |    we’ll remove them from this codebase.                                   |
+# |                                                                            |
+# +------------------------------------4--------------------------------------*/
 ---
 
 # +------------------------------------4--------------------------------------*/

--- a/deploy/ansible/roles-db/4.0.3-hdb-install-scaleout/tasks/main.yaml
+++ b/deploy/ansible/roles-db/4.0.3-hdb-install-scaleout/tasks/main.yaml
@@ -109,7 +109,11 @@
         # This is the way !!!
         _rsp_additional_hosts:         "{% for item in db_hosts[1:] %}
                                         {% if loop.index == db_hosts | length -1 %}
+                                        {% if db_no_standby %}
+                                        {{ item }}:role=worker:group=default:workergroup=default
+                                        {% else %}
                                         {{ item }}:role=standby:group=default:workergroup=default
+                                        {% endif %}
                                         {% else %}
                                         {{ item }}:role=worker:group=default:workergroup=default,
                                         {% endif %}

--- a/deploy/ansible/vars/ansible-input-api.yaml
+++ b/deploy/ansible/vars/ansible-input-api.yaml
@@ -215,6 +215,7 @@ use_simple_mount:                       false
 # database_high_availability:            false
 db_scale_out:                          false
 database_cluster_type:                 "AFA"
+db_no_standby:                         false                                    # when set to true, will deploy the scale out - ANF cluster without a standby node.
 # scs_high_availability:                 false
 scs_cluster_type:                      "AFA"
 # Configure pacemaker for Azure scheduled events

--- a/deploy/terraform/run/sap_system/module.tf
+++ b/deploy/terraform/run/sap_system/module.tf
@@ -434,6 +434,7 @@ module "output_files" {
   use_simple_mount                              = local.validated_use_simple_mount
   upgrade_packages                              = var.upgrade_packages
   scale_out                                     = var.database_HANA_use_ANF_scaleout_scenario
+  scale_out_no_standby_role                     = var.database_HANA_no_standby_role
 
   #########################################################################################
   #  iSCSI                                                                                #

--- a/deploy/terraform/run/sap_system/tfvar_variables.tf
+++ b/deploy/terraform/run/sap_system/tfvar_variables.tf
@@ -1347,6 +1347,11 @@ variable "database_HANA_use_ANF_scaleout_scenario" {
                                                   default = false
                                                 }
 
+variable "database_HANA_no_standby_role"        {
+                                                  description = "If true, the database scale out tier will not have a standby role"
+                                                  default = false
+                                                }
+
 variable "stand_by_node_count"                  {
                                                   description = "The number of standby nodes"
                                                   default = 0

--- a/deploy/terraform/terraform-units/modules/sap_system/output_files/inventory.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/output_files/inventory.tf
@@ -222,6 +222,7 @@ resource "local_file" "sap-parameters_yml" {
                                             )
               asd_disks                   = concat(var.scs_shared_disks, var.database_shared_disks)
               scale_out                   = var.scale_out
+              scale_out_no_standby_role   = var.scale_out_no_standby_role
               scs_cluster_loadbalancer_ip = try(format("%s/%s", var.scs_cluster_loadbalancer_ip, var.app_subnet_netmask), "")
               scs_cluster_type            = var.scs_cluster_type
               scs_high_availability       = var.scs_high_availability

--- a/deploy/terraform/terraform-units/modules/sap_system/output_files/sap-parameters.tmpl
+++ b/deploy/terraform/terraform-units/modules/sap_system/output_files/sap-parameters.tmpl
@@ -78,7 +78,7 @@ platform:                       ${platform}
 
 # Scale out defines if the database is to be deployed in a scale out configuration
 db_scale_out:                   ${scale_out}
-
+db_no_standby:                  ${scale_out_no_standby_role}
 # db_high_availability is a boolean flag indicating if the
 # SAP database servers are deployed using high availability
 db_high_availability:           ${database_high_availability}

--- a/deploy/terraform/terraform-units/modules/sap_system/output_files/variables_global.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/output_files/variables_global.tf
@@ -141,6 +141,7 @@ variable "save_naming_information"              {
                                                   default     = false
                                                 }
 variable "scale_out"                            { description = "If true, the SAP System will be scale out" }
+variable "scale_out_no_standby_role"            { description = "If true, the SAP Scale out system will not have a standby-node. Only applicable for shared storage based deployment" }
 variable "scs_shared_disks"                     { description = "SCS Azure Shared Disk" }
 
 


### PR DESCRIPTION
## Problem
current deployment of Scale out - ANF deploys a N+1 configuration where one node is always standby. This causes issues for customers where the on-prem/source HANA setup is 'N' node setup with no standby, causing HSR setup to fail.
Also, once HANA scale out is deployed, we cannot remove/change assigned roles to existing nodes, only new node addition can be done.

## Solution
Added a flag "database_HANA_no_standby_role" in terraform in addition to existing "database_HANA_use_ANF_scaleout_scenario" that will configure hdblcm setup to not add any standby role to any nodes during setup.
This variable adds an ansible variable "db_no_standby" that controls how "_rsp_additional_hosts" is passed to the HANA parameter file, i.e last node is worker/standby based on the value of this flag.

## Tests
Run a standard deployment with >2 nodes for HANA scale out - ANF based storage. Validate using python /usr/sap/<SID>/HDB<InstanceID>/exe/python_support/landscapeHostConfiguration.py post deployment of Scale out setup.


