### PR TITLE
Add ability to deploy the Monitoring extension

### DIFF
--- a/Webapp/SDAF/Models/LandscapeModel.cs
+++ b/Webapp/SDAF/Models/LandscapeModel.cs
@@ -47,7 +47,11 @@ namespace AutomationForm.Models
     public bool? place_delete_lock_on_resources { get; set; } = false;
 
     public string controlPlaneLocation { get; set; }
+
     public Tag[] tags { get; set; }
+
+
+    public bool? deploy_monitoring_extension { get; set; } = false;
 
     /*---------------------------------------------------------------------------8
     |                                                                            |
@@ -186,8 +190,6 @@ namespace AutomationForm.Models
     public string storage_subnet_nsg_arm_id { get; set; }
 
     public string storage_subnet_nsg_name { get; set; }
-
-
 
 
     /*---------------------------------------------------------------------------8

--- a/Webapp/SDAF/Models/SystemModel.cs
+++ b/Webapp/SDAF/Models/SystemModel.cs
@@ -74,6 +74,8 @@ namespace AutomationForm.Models
 
     public bool? deploy_v1_monitoring_extension { get; set; } = true;
 
+    public bool? deploy_monitoring_extension { get; set; } = false;
+
     public bool? use_scalesets_for_deployment { get; set; } = false;
 
     public bool? database_use_premium_v2_storage { get; set; } = false;

--- a/Webapp/SDAF/ParameterDetails/LandscapeDetails.json
+++ b/Webapp/SDAF/ParameterDetails/LandscapeDetails.json
@@ -111,11 +111,26 @@
         "Options": [],
         "Overrules": "",
         "Display": 2
+      }
+    ]
+  },
+  {
+    "Section": "Infrastructure settings",
+    "Link": "https://learn.microsoft.com/en-us/azure/sap/automation/automation-configure-workload-zone#environment-parameters",
+    "Parameters": [
+      {
+        "Name": "deploy_monitoring_extension",
+        "Required": false,
+        "Description": "If defined, will add the Microsoft.Azure.Monitor.AzureMonitorLinuxAgent extension to the virtual machines",
+        "Type": "checkbox",
+        "Options": [],
+        "Overrules": "",
+        "Display": 2
       },
       {
         "Name": "place_delete_lock_on_resources",
         "Required": false,
-        "Description": " If defined, a delete lock will be placed on the key resources (virtual network and key vault)",
+        "Description": "If defined, a delete lock will be placed on the key resources (virtual network and key vault)",
         "Type": "checkbox",
         "Options": [],
         "Overrules": "",
@@ -124,7 +139,7 @@
       {
         "Name": "use_spn",
         "Required": false,
-        "Description": " If set, the deployment is performed using the Service Principal defined for the workload zone, otherwise the managed identity of the deployer is used",
+        "Description": "If set, the deployment is performed using the Service Principal defined for the workload zone, otherwise the managed identity of the deployer is used",
         "Type": "checkbox",
         "Options": [],
         "Overrules": "",

--- a/Webapp/SDAF/ParameterDetails/LandscapeTemplate.txt
+++ b/Webapp/SDAF/ParameterDetails/LandscapeTemplate.txt
@@ -36,6 +36,8 @@ $$Description$$
 #If you want to provide a custom naming json use the following parameter.
 $$name_override_file$$
 
+# If defined, will add the Microsoft.Azure.Monitor.AzureMonitorLinuxAgent extension to the virtual machines
+$$deploy_monitoring_extension$$
 
 #########################################################################################
 #                                                                                       #

--- a/Webapp/SDAF/ParameterDetails/SystemDetails.json
+++ b/Webapp/SDAF/ParameterDetails/SystemDetails.json
@@ -270,6 +270,15 @@
         "Display": 3
       },
       {
+        "Name": "deploy_monitoring_extension",
+        "Required": false,
+        "Description": "If defined, will add the Microsoft.Azure.Monitor.AzureMonitorLinuxAgent extension to the virtual machines",
+        "Type": "checkbox",
+        "Options": [],
+        "Overrules": "",
+        "Display": 3
+      },
+      {
         "Name": "vm_disk_encryption_set_id",
         "Required": false,
         "Description": "Azure resource identifier for custom encryption key to use for disk encryption.",

--- a/Webapp/SDAF/ParameterDetails/SystemTemplate.txt
+++ b/Webapp/SDAF/ParameterDetails/SystemTemplate.txt
@@ -486,6 +486,9 @@ $$deploy_application_security_groups$$
 # deploy_v1_monitoring_extension Defines if the Microsoft.AzureCAT.AzureEnhancedMonitoring extension will be deployed
 $$deploy_v1_monitoring_extension$$
 
+# If defined, will add the Microsoft.Azure.Monitor.AzureMonitorLinuxAgent extension to the virtual machines
+$$deploy_monitoring_extension$$
+
 # dns_a_records_for_secondary_names defines if DNS records should be created for the virtual host names
 $$dns_a_records_for_secondary_names$$
 

--- a/Webapp/SDAF/Views/Landscape/Edit.cshtml
+++ b/Webapp/SDAF/Views/Landscape/Edit.cshtml
@@ -112,6 +112,12 @@
                     Deploy
                 </fluent-anchor>
             </td>
+            <td>
+                &nbsp
+                <fluent-anchor appearance="accent" style="margin-top: 15px" href="@Url.Action("Download", "Landscape", new { id = @Model.SapObject.Id, partitionKey = @Model.SapObject.environment })">
+                    Download
+                </fluent-anchor>
+            </td>
         </tr>
 
     </form>

--- a/deploy/terraform/run/sap_landscape/tfvar_variables.tf
+++ b/deploy/terraform/run/sap_landscape/tfvar_variables.tf
@@ -412,6 +412,12 @@ variable "user_assigned_identity_id"            {
                                                   default     = ""
                                                 }
 
+variable "deploy_monitoring_extension"          {
+                                                  description = "If defined, will add the Microsoft.Azure.Monitor.AzureMonitorLinuxAgent extension to the virtual machines"
+                                                  default     = true
+                                                }
+
+
 #########################################################################################
 #                                                                                       #
 #  Storage Account variables                                                            #

--- a/deploy/terraform/run/sap_landscape/tfvar_variables.tf
+++ b/deploy/terraform/run/sap_landscape/tfvar_variables.tf
@@ -414,7 +414,7 @@ variable "user_assigned_identity_id"            {
 
 variable "deploy_monitoring_extension"          {
                                                   description = "If defined, will add the Microsoft.Azure.Monitor.AzureMonitorLinuxAgent extension to the virtual machines"
-                                                  default     = true
+                                                  default     = false
                                                 }
 
 

--- a/deploy/terraform/run/sap_landscape/transform.tf
+++ b/deploy/terraform/run/sap_landscape/transform.tf
@@ -173,6 +173,7 @@ locals {
                                            codename                     = try(var.infrastructure.codename, var.codename)
                                            tags                         = try(merge(var.resourcegroup_tags, try(var.infrastructure.tags, {})), {})
                                            deploy_monitoring_extension  = var.deploy_monitoring_extension
+                                           user_assigned_identity_id    = var.user_assigned_identity_id
                                          }
 
   authentication                       = {

--- a/deploy/terraform/run/sap_landscape/transform.tf
+++ b/deploy/terraform/run/sap_landscape/transform.tf
@@ -168,10 +168,11 @@ locals {
                                         }
 
   temp_infrastructure                  = {
-                                           environment = coalesce(var.environment, try(var.infrastructure.environment, ""))
-                                           region      = lower(coalesce(var.location, try(var.infrastructure.region, "")))
-                                           codename    = try(var.infrastructure.codename, var.codename)
-                                           tags        = try(merge(var.resourcegroup_tags, try(var.infrastructure.tags, {})), {})
+                                           environment                  = coalesce(var.environment, try(var.infrastructure.environment, ""))
+                                           region                       = lower(coalesce(var.location, try(var.infrastructure.region, "")))
+                                           codename                     = try(var.infrastructure.codename, var.codename)
+                                           tags                         = try(merge(var.resourcegroup_tags, try(var.infrastructure.tags, {})), {})
+                                           deploy_monitoring_extension  = var.deploy_monitoring_extension
                                          }
 
   authentication                       = {

--- a/deploy/terraform/run/sap_system/tfvar_variables.tf
+++ b/deploy/terraform/run/sap_system/tfvar_variables.tf
@@ -1378,11 +1378,6 @@ variable "deploy_monitoring_extension"          {
                                                 }
 
 
-variable "deploy_security_extension"            {
-                                                  description = "If defined, will add the Microsoft.Azure.Security.Monitoring.AzureSecurityLinuxAgent extension to the virtual machines"
-                                                  default     = true
-                                                }
-
 
 #########################################################################################
 #                                                                                       #

--- a/deploy/terraform/run/sap_system/tfvar_variables.tf
+++ b/deploy/terraform/run/sap_system/tfvar_variables.tf
@@ -1372,6 +1372,17 @@ variable "tags"                                 {
                                                   default     = {}
                                                 }
 
+variable "deploy_monitoring_extension"          {
+                                                  description = "If defined, will add the Microsoft.Azure.Monitor.AzureMonitorLinuxAgent extension to the virtual machines"
+                                                  default     = true
+                                                }
+
+
+variable "deploy_security_extension"            {
+                                                  description = "If defined, will add the Microsoft.Azure.Security.Monitoring.AzureSecurityLinuxAgent extension to the virtual machines"
+                                                  default     = true
+                                                }
+
 
 #########################################################################################
 #                                                                                       #

--- a/deploy/terraform/run/sap_system/transform.tf
+++ b/deploy/terraform/run/sap_system/transform.tf
@@ -10,7 +10,6 @@ locals {
                                             tags                             = try(merge(var.resourcegroup_tags, try(var.infrastructure.tags, {})), {})
                                             use_app_proximityplacementgroups = var.use_app_proximityplacementgroups
                                             deploy_monitoring_extension      = var.deploy_monitoring_extension
-                                            deploy_security_extension        = var.deploy_security_extension
                                          }
 
 

--- a/deploy/terraform/run/sap_system/transform.tf
+++ b/deploy/terraform/run/sap_system/transform.tf
@@ -9,6 +9,8 @@ locals {
                                             codename                         = try(var.codename, try(var.infrastructure.codename, ""))
                                             tags                             = try(merge(var.resourcegroup_tags, try(var.infrastructure.tags, {})), {})
                                             use_app_proximityplacementgroups = var.use_app_proximityplacementgroups
+                                            deploy_monitoring_extension      = var.deploy_monitoring_extension
+                                            deploy_security_extension        = var.deploy_security_extension
                                          }
 
 

--- a/deploy/terraform/terraform-units/modules/sap_landscape/iscsi.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/iscsi.tf
@@ -314,3 +314,28 @@ resource "tls_private_key" "iscsi" {
   rsa_bits                             = 2048
 }
 
+
+resource "azurerm_virtual_machine_extension" "monitoring_extension_iscsi_lnx" {
+  provider                             = azurerm.main
+  count                                = local.deploy_monitoring_extension ? (
+                                           local.iscsi_count) : (
+                                           0
+                                         )
+  virtual_machine_id                   = azurerm_linux_virtual_machine.iscsi[count.index].id
+  name                                 = "AzureMonitorLinuxAgent"
+  publisher                            = "Microsoft.Azure.Monitor"
+  type                                 = "AzureMonitorLinuxAgent"
+  type_handler_version                 = "1.0"
+  auto_upgrade_minor_version           = "true"
+
+  settings                             = jsonencode(
+                                           {
+                                              "authentication"  =  {
+                                                   "managedIdentity" = {
+                                                        "identifier-name" : "mi_res_id",
+                                                        "identifier-value": var.infrastructure.iscsi.user_assigned_identity_id
+                                                      }
+                                                }
+                                            }
+                                            )
+}

--- a/deploy/terraform/terraform-units/modules/sap_landscape/nsg.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/nsg.tf
@@ -172,7 +172,7 @@ resource "azurerm_network_security_rule" "nsr_controlplane_app" {
   source_port_range                    = "*"
   destination_port_ranges              = [22, 443, 3389, 5985, 5986, 5404, 5405, 7630]
   source_address_prefixes              = compact(concat(var.deployer_tfstate.subnet_mgmt_address_prefixes, var.deployer_tfstate.subnet_bastion_address_prefixes))
-  destination_address_prefixes         = azurerm_subnet.app[0].address_prefixes
+  destination_address_prefixes         = local.application_subnet_existing ? data.azurerm_subnet.app[0].address_prefixes : azurerm_subnet.app[0].address_prefixes
 }
 
 // Add SSH network security rule
@@ -196,7 +196,7 @@ resource "azurerm_network_security_rule" "nsr_controlplane_web" {
   source_port_range                    = "*"
   destination_port_ranges              = [22, 443, 3389, 5985, 5986]
   source_address_prefixes              = compact(concat(var.deployer_tfstate.subnet_mgmt_address_prefixes, var.deployer_tfstate.subnet_bastion_address_prefixes))
-  destination_address_prefixes         = azurerm_subnet.web[0].address_prefixes
+  destination_address_prefixes         = local.web_subnet_existing ? data.azurerm_subnet.web[0].address_prefixes : azurerm_subnet.web[0].address_prefixes
 }
 
 // Add SSH network security rule
@@ -220,7 +220,7 @@ resource "azurerm_network_security_rule" "nsr_controlplane_storage" {
   source_port_range                    = "*"
   destination_port_ranges              = [22, 443, 3389, 5985, 5986, 111, 635, 2049, 4045, 4046, 4049]
   source_address_prefixes              = compact(concat(var.deployer_tfstate.subnet_mgmt_address_prefixes, var.deployer_tfstate.subnet_bastion_address_prefixes))
-  destination_address_prefixes         = azurerm_subnet.storage[0].address_prefixes
+  destination_address_prefixes         = local.storage_subnet_existing ? data.azurerm_subnet.storage[0].address_prefixes : azurerm_subnet.storage[0].address_prefixes
 }
 
 // Add SSH network security rule
@@ -247,7 +247,7 @@ resource "azurerm_network_security_rule" "nsr_controlplane_db" {
                                            var.deployer_tfstate.subnet_mgmt_address_prefixes,
                                            var.deployer_tfstate.subnet_bastion_address_prefixes)
                                          )
-  destination_address_prefixes         = azurerm_subnet.db[0].address_prefixes
+  destination_address_prefixes         = local.database_subnet_existing ? data.azurerm_subnet.db[0].address_prefixes : azurerm_subnet.db[0].address_prefixes
 }
 
 // Add network security rule
@@ -269,10 +269,10 @@ resource "azurerm_network_security_rule" "nsr_controlplane_admin" {
   access                               = "Allow"
   protocol                             = "Tcp"
   source_port_range                    = "*"
-  destination_port_ranges              = [22, 443, 3389, 5985, 5986]
+  destination_port_ranges              = [22, 443, 3389, 5985, 5986,111, 635, 2049, 4045, 4046, 4049]
   source_address_prefixes              = compact(concat(
                                            var.deployer_tfstate.subnet_mgmt_address_prefixes,
                                            var.deployer_tfstate.subnet_bastion_address_prefixes)
                                          )
-  destination_address_prefixes         = azurerm_subnet.admin[0].address_prefixes
+  destination_address_prefixes         = local.admin_subnet_existing ? data.azurerm_subnet.admin[0]address_prefixes : azurerm_subnet.admin[0].address_prefixes
 }

--- a/deploy/terraform/terraform-units/modules/sap_landscape/nsg.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/nsg.tf
@@ -202,6 +202,7 @@ resource "azurerm_network_security_rule" "nsr_controlplane_web" {
 // Add SSH network security rule
 resource "azurerm_network_security_rule" "nsr_controlplane_storage" {
   provider                             = azurerm.main
+
   count                                = local.storage_subnet_defined ? local.storage_subnet_nsg_exists ? 0 : 1 : 0
   depends_on                           = [
                                            azurerm_network_security_group.storage

--- a/deploy/terraform/terraform-units/modules/sap_landscape/nsg.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/nsg.tf
@@ -274,5 +274,6 @@ resource "azurerm_network_security_rule" "nsr_controlplane_admin" {
                                            var.deployer_tfstate.subnet_mgmt_address_prefixes,
                                            var.deployer_tfstate.subnet_bastion_address_prefixes)
                                          )
-  destination_address_prefixes         = local.admin_subnet_existing ? data.azurerm_subnet.admin[0]address_prefixes : azurerm_subnet.admin[0].address_prefixes
+
+  destination_address_prefixes         = local.admin_subnet_existing ? data.azurerm_subnet.admin[0].address_prefixes : azurerm_subnet.admin[0].address_prefixes
 }

--- a/deploy/terraform/terraform-units/modules/sap_landscape/subnets.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/subnets.tf
@@ -16,6 +16,15 @@ resource "azurerm_subnet" "admin" {
                                          )
 }
 
+data "azurerm_subnet" "admin" {
+  provider                             = azurerm.main
+  count                                = local.admin_subnet_existing ? 1 : 0
+  name                                 = split("/", local.admin_subnet_arm_id)[10]
+  resource_group_name                  = split("/", local.admin_subnet_arm_id)[4]
+  virtual_network_name                 = split("/", local.admin_subnet_arm_id)[8]
+}
+
+
 // Creates db subnet of SAP VNET
 resource "azurerm_subnet" "db" {
   provider                             = azurerm.main
@@ -31,6 +40,14 @@ resource "azurerm_subnet" "db" {
                                            ) : (
                                            null
                                          )
+}
+
+data "azurerm_subnet" "db" {
+  provider                             = azurerm.main
+  count                                = local.database_subnet_existing ? 1 : 0
+  name                                 = split("/", local.database_subnet_arm_id)[10]
+  resource_group_name                  = split("/", local.database_subnet_arm_id)[4]
+  virtual_network_name                 = split("/", local.database_subnet_arm_id)[8]
 }
 
 // Creates app subnet of SAP VNET
@@ -51,6 +68,15 @@ resource "azurerm_subnet" "app" {
                                          )
 }
 
+data "azurerm_subnet" "app" {
+  provider                             = azurerm.main
+  count                                = local.application_subnet_existing ? 1 : 0
+  name                                 = split("/", local.application_subnet_arm_id)[10]
+  resource_group_name                  = split("/", local.application_subnet_arm_id)[4]
+  virtual_network_name                 = split("/", local.application_subnet_arm_id)[8]
+}
+
+
 // Creates web subnet of SAP VNET
 resource "azurerm_subnet" "web" {
   provider                             = azurerm.main
@@ -68,6 +94,16 @@ resource "azurerm_subnet" "web" {
                                            null
                                          )
 }
+
+data "azurerm_subnet" "web" {
+  provider                             = azurerm.main
+  count                                = local.web_subnet_existing ? 1 : 0
+  name                                 = split("/", local.web_subnet_arm_id)[10]
+  resource_group_name                  = split("/", local.web_subnet_arm_id)[4]
+  virtual_network_name                 = split("/", local.web_subnet_arm_id)[8]
+}
+
+
 
 // Creates storage subnet of SAP VNET
 resource "azurerm_subnet" "storage" {

--- a/deploy/terraform/terraform-units/modules/sap_landscape/subnets.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/subnets.tf
@@ -123,6 +123,16 @@ resource "azurerm_subnet" "storage" {
                                          )
 }
 
+data "azurerm_subnet" "storage" {
+  provider                             = azurerm.main
+  count                                = local.storage_subnet_existing ? 1 : 0
+  name                                 = split("/", local.storage_subnet_arm_id)[10]
+  resource_group_name                  = split("/", local.storage_subnet_arm_id)[4]
+  virtual_network_name                 = split("/", local.storage_subnet_arm_id)[8]
+}
+
+
+
 // Creates anf subnet of SAP VNET
 resource "azurerm_subnet" "anf" {
   provider                             = azurerm.main

--- a/deploy/terraform/terraform-units/modules/sap_landscape/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/variables_local.tf
@@ -788,4 +788,8 @@ locals {
 
   use_AFS_for_shared                             = (var.NFS_provider == "ANF" && var.use_AFS_for_shared_storage) || var.NFS_provider == "AFS"
 
+
+  deploy_monitoring_extension                    = var.infrastructure.deploy_monitoring_extension && length(var.infrastructure.iscsi.user_assigned_identity_id) > 0
+
 }
+

--- a/deploy/terraform/terraform-units/modules/sap_landscape/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/variables_local.tf
@@ -789,7 +789,7 @@ locals {
   use_AFS_for_shared                             = (var.NFS_provider == "ANF" && var.use_AFS_for_shared_storage) || var.NFS_provider == "AFS"
 
 
-  deploy_monitoring_extension                    = var.infrastructure.deploy_monitoring_extension && length(var.infrastructure.iscsi.user_assigned_identity_id) > 0
+  deploy_monitoring_extension                    = var.infrastructure.deploy_monitoring_extension && length(try(var.infrastructure.user_assigned_identity_id,"")) > 0
 
 }
 

--- a/deploy/terraform/terraform-units/modules/sap_landscape/vm.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/vm.tf
@@ -173,7 +173,7 @@ resource "azurerm_linux_virtual_machine" "utility_vm" {
 
 resource "azurerm_virtual_machine_extension" "monitoring_extension_utility_lnx" {
   provider                             = azurerm.main
-  count                                = upper(var.vm_settings.image.os_type) == "LINUX" ? var.vm_settings.count : 0
+  count                                = local.deploy_monitoring_extension && upper(var.vm_settings.image.os_type) == "LINUX" ? var.vm_settings.count : 0
   virtual_machine_id                   = azurerm_linux_virtual_machine.utility_vm[count.index].id
   name                                 = "AzureMonitorLinuxAgent"
   publisher                            = "Microsoft.Azure.Monitor"
@@ -195,7 +195,7 @@ resource "azurerm_virtual_machine_extension" "monitoring_extension_utility_lnx" 
 
 resource "azurerm_virtual_machine_extension" "monitoring_extension_utility_win" {
   provider                             = azurerm.main
-  count                                = upper(var.vm_settings.image.os_type) == "WINDOWS" ? var.vm_settings.count : 0
+  count                                = local.deploy_monitoring_extension && upper(var.vm_settings.image.os_type) == "WINDOWS" ? var.vm_settings.count : 0
 
   virtual_machine_id                   = azurerm_windows_virtual_machine.utility_vm[count.index].id
   name                                 = "AzureMonitorWindowsAgent"

--- a/deploy/terraform/terraform-units/modules/sap_landscape/vm.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/vm.tf
@@ -171,7 +171,7 @@ resource "azurerm_linux_virtual_machine" "utility_vm" {
 }
 
 
-resource "azurerm_virtual_machine_extension" "monitoring_extension_scs_lnx" {
+resource "azurerm_virtual_machine_extension" "monitoring_extension_utility_lnx" {
   provider                             = azurerm.main
   count                                = upper(var.vm_settings.image.os_type) == "LINUX" ? var.vm_settings.count : 0
   virtual_machine_id                   = azurerm_linux_virtual_machine.utility_vm[count.index].id
@@ -185,7 +185,7 @@ resource "azurerm_virtual_machine_extension" "monitoring_extension_scs_lnx" {
                                               "authentication"  =  {
                                                    "managedIdentity" = {
                                                         "identifier-name" : "mi_res_id",
-                                                        "identifier-value": var.application_tier.user_assigned_identity_id
+                                                        "identifier-value": var.infrastructure.user_assigned_identity_id
                                                       }
                                                 }
                                             }
@@ -193,7 +193,7 @@ resource "azurerm_virtual_machine_extension" "monitoring_extension_scs_lnx" {
 }
 
 
-resource "azurerm_virtual_machine_extension" "monitoring_extension_scs_win" {
+resource "azurerm_virtual_machine_extension" "monitoring_extension_utility_win" {
   provider                             = azurerm.main
   count                                = upper(var.vm_settings.image.os_type) == "WINDOWS" ? var.vm_settings.count : 0
 
@@ -208,7 +208,7 @@ resource "azurerm_virtual_machine_extension" "monitoring_extension_scs_win" {
                                               "authentication"  =  {
                                                    "managedIdentity" = {
                                                         "identifier-name" : "mi_res_id",
-                                                        "identifier-value": var.application_tier.user_assigned_identity_id
+                                                        "identifier-value": var.infrastructure.user_assigned_identity_id
                                                       }
                                                 }
                                             }

--- a/deploy/terraform/terraform-units/modules/sap_landscape/vm.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/vm.tf
@@ -86,6 +86,14 @@ resource "azurerm_windows_virtual_machine" "utility_vm" {
                            sku        = var.vm_settings.image.sku
                            version    = var.vm_settings.image.version
                          }
+  dynamic "identity"     {
+                           for_each = range(length(var.infrastructure.user_assigned_identity_id) > 0 ? 1 : 0)
+                           content {
+                                   type         = "UserAssigned"
+                                   identity_ids = [var.infrastructure.user_assigned_identity_id]
+                                 }
+                          }
+
 
   lifecycle {
     ignore_changes = [
@@ -149,8 +157,62 @@ resource "azurerm_linux_virtual_machine" "utility_vm" {
                            offer      = var.vm_settings.image.offer
                            sku        = var.vm_settings.image.sku
                            version    = var.vm_settings.image.version
+
                          }
+  dynamic "identity"     {
+                           for_each = range(length(var.infrastructure.user_assigned_identity_id) > 0 ? 1 : 0)
+                           content {
+                                   type         = "UserAssigned"
+                                   identity_ids = [var.infrastructure.user_assigned_identity_id]
+                                 }
+                          }
 
 
 }
+
+
+resource "azurerm_virtual_machine_extension" "monitoring_extension_scs_lnx" {
+  provider                             = azurerm.main
+  count                                = upper(var.vm_settings.image.os_type) == "LINUX" ? var.vm_settings.count : 0
+  virtual_machine_id                   = azurerm_linux_virtual_machine.utility_vm[count.index].id
+  name                                 = "AzureMonitorLinuxAgent"
+  publisher                            = "Microsoft.Azure.Monitor"
+  type                                 = "AzureMonitorLinuxAgent"
+  type_handler_version                 = "1.0"
+  auto_upgrade_minor_version           = "true"
+  settings                             = jsonencode(
+                                           {
+                                              "authentication"  =  {
+                                                   "managedIdentity" = {
+                                                        "identifier-name" : "mi_res_id",
+                                                        "identifier-value": var.application_tier.user_assigned_identity_id
+                                                      }
+                                                }
+                                            }
+                                            )
+}
+
+
+resource "azurerm_virtual_machine_extension" "monitoring_extension_scs_win" {
+  provider                             = azurerm.main
+  count                                = upper(var.vm_settings.image.os_type) == "WINDOWS" ? var.vm_settings.count : 0
+
+  virtual_machine_id                   = azurerm_windows_virtual_machine.utility_vm[count.index].id
+  name                                 = "AzureMonitorWindowsAgent"
+  publisher                            = "Microsoft.Azure.Monitor"
+  type                                 = "AzureMonitorWindowsAgent"
+  type_handler_version                 = "1.0"
+  auto_upgrade_minor_version           = "true"
+  settings                             = jsonencode(
+                                           {
+                                              "authentication"  =  {
+                                                   "managedIdentity" = {
+                                                        "identifier-name" : "mi_res_id",
+                                                        "identifier-value": var.application_tier.user_assigned_identity_id
+                                                      }
+                                                }
+                                            }
+                                            )
+}
+
 

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/variables_local.tf
@@ -480,5 +480,6 @@ locals {
                                            "value" = var.database.user_assigned_identity_id
                                          }] : []
 
+  deploy_monitoring_extension          = local.enable_deployment && var.infrastructure.deploy_monitoring_extension && length(var.database.user_assigned_identity_id) > 0
 
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/vm-anydb.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/vm-anydb.tf
@@ -699,3 +699,53 @@ resource "azurerm_virtual_machine_data_disk_attachment" "kdump" {
   caching                              = "None"
   lun                                  = var.database.fence_kdump_lun_number
 }
+
+resource "azurerm_virtual_machine_extension" "monitoring_extension_db_lnx" {
+  provider                             = azurerm.main
+  count                                = local.deploy_monitoring_extension  && upper(var.database.app_os.os_type) == "LINUX" ? (
+                                           var.database_server_count) : (
+                                           0                                           )
+  virtual_machine_id                   = azurerm_linux_virtual_machine.dbserver[count.index].id
+  name                                 = "AzureMonitorLinuxAgent"
+  publisher                            = "Microsoft.Azure.Monitor"
+  type                                 = "AzureMonitorLinuxAgent"
+  type_handler_version                 = "1.0"
+  auto_upgrade_minor_version           = "true"
+
+  settings                             = jsonencode(
+                                           {
+                                              "authentication"  =  {
+                                                   "managedIdentity" = {
+                                                        "identifier-name" : "mi_res_id",
+                                                        "identifier-value": var.database.user_assigned_identity_id
+                                                      }
+                                                }
+                                            }
+                                            )
+}
+
+
+resource "azurerm_virtual_machine_extension" "monitoring_extension_db_win" {
+  provider                             = azurerm.main
+  count                                = local.deploy_monitoring_extension  && upper(var.database.app_os.os_type) == "WINDOWS" ? (
+                                           var.database_server_count) : (
+                                           0                                           )
+  virtual_machine_id                   = azurerm_windows_virtual_machine.dbserver[count.index].id
+  name                                 = "AzureMonitorWindowsAgent"
+  publisher                            = "Microsoft.Azure.Monitor"
+  type                                 = "AzureMonitorWindowsAgent"
+  type_handler_version                 = "1.0"
+  auto_upgrade_minor_version           = "true"
+  settings                             = jsonencode(
+                                           {
+                                              "authentication"  =  {
+                                                   "managedIdentity" = {
+                                                        "identifier-name" : "mi_res_id",
+                                                        "identifier-value": var.database.user_assigned_identity_id
+                                                      }
+                                                }
+                                            }
+                                            )
+
+}
+

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/vm-anydb.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/vm-anydb.tf
@@ -702,7 +702,7 @@ resource "azurerm_virtual_machine_data_disk_attachment" "kdump" {
 
 resource "azurerm_virtual_machine_extension" "monitoring_extension_db_lnx" {
   provider                             = azurerm.main
-  count                                = local.deploy_monitoring_extension  && upper(var.database.app_os.os_type) == "LINUX" ? (
+  count                                = local.deploy_monitoring_extension  && upper(var.database.os.os_type) == "LINUX" ? (
                                            var.database_server_count) : (
                                            0                                           )
   virtual_machine_id                   = azurerm_linux_virtual_machine.dbserver[count.index].id
@@ -727,7 +727,7 @@ resource "azurerm_virtual_machine_extension" "monitoring_extension_db_lnx" {
 
 resource "azurerm_virtual_machine_extension" "monitoring_extension_db_win" {
   provider                             = azurerm.main
-  count                                = local.deploy_monitoring_extension  && upper(var.database.app_os.os_type) == "WINDOWS" ? (
+  count                                = local.deploy_monitoring_extension  && upper(var.database.os.os_type) == "WINDOWS" ? (
                                            var.database_server_count) : (
                                            0                                           )
   virtual_machine_id                   = azurerm_windows_virtual_machine.dbserver[count.index].id

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
@@ -621,4 +621,7 @@ locals {
                                            "value" = var.application_tier.user_assigned_identity_id
                                          }] : []
 
+  deploy_monitoring_extension          = local.enable_deployment && var.infrastructure.deploy_monitoring_extension && length(var.application_tier.user_assigned_identity_id) > 0
+
+
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-app.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-app.tf
@@ -500,7 +500,7 @@ resource "azurerm_virtual_machine_extension" "monitoring_extension_app_lnx" {
   count                                = local.deploy_monitoring_extension  && upper(var.application_tier.app_os.os_type) == "LINUX" ? (
                                            local.application_server_count) : (
                                            0                                           )
-  virtual_machine_id                   = azurerm_windows_virtual_machine.app[count.index].id
+  virtual_machine_id                   = azurerm_linux_virtual_machine.app[count.index].id
   name                                 = "AzureMonitorLinuxAgent"
   publisher                            = "Microsoft.Azure.Monitor"
   type                                 = "AzureMonitorLinuxAgent"

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-app.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-app.tf
@@ -506,6 +506,17 @@ resource "azurerm_virtual_machine_extension" "monitoring_extension_app_lnx" {
   type                                 = "AzureMonitorLinuxAgent"
   type_handler_version                 = "1.0"
   auto_upgrade_minor_version           = "true"
+
+  settings                             = jsonencode(
+                                           {
+                                              "authentication"  =  {
+                                                   "managedIdentity" = {
+                                                        "identifier-name" : "mi_res_id",
+                                                        "identifier-value": var.application_tier.user_assigned_identity_id
+                                                      }
+                                                }
+                                            }
+                                            )
 }
 
 
@@ -520,5 +531,16 @@ resource "azurerm_virtual_machine_extension" "monitoring_extension_app_win" {
   type                                 = "AzureMonitorWindowsAgent"
   type_handler_version                 = "1.0"
   auto_upgrade_minor_version           = "true"
+  settings                             = jsonencode(
+                                           {
+                                              "authentication"  =  {
+                                                   "managedIdentity" = {
+                                                        "identifier-name" : "mi_res_id",
+                                                        "identifier-value": var.application_tier.user_assigned_identity_id
+                                                      }
+                                                }
+                                            }
+                                            )
+
 }
 

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-app.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-app.tf
@@ -493,3 +493,32 @@ resource "azurerm_virtual_machine_extension" "configure_ansible_app" {
                                          )
   tags                                 = var.tags
 }
+
+
+resource "azurerm_virtual_machine_extension" "monitoring_extension_app_lnx" {
+  provider                             = azurerm.main
+  count                                = local.deploy_monitoring_extension  && upper(var.application_tier.app_os.os_type) == "LINUX" ? (
+                                           local.application_server_count) : (
+                                           0                                           )
+  virtual_machine_id                   = azurerm_windows_virtual_machine.app[count.index].id
+  name                                 = "AzureMonitorLinuxAgent"
+  publisher                            = "Microsoft.Azure.Monitor"
+  type                                 = "AzureMonitorLinuxAgent"
+  type_handler_version                 = "1.0"
+  auto_upgrade_minor_version           = "true"
+}
+
+
+resource "azurerm_virtual_machine_extension" "monitoring_extension_app_win" {
+  provider                             = azurerm.main
+  count                                = local.deploy_monitoring_extension  && upper(var.application_tier.app_os.os_type) == "WINDOWS" ? (
+                                           local.application_server_count) : (
+                                           0                                           )
+  virtual_machine_id                   = azurerm_windows_virtual_machine.app[count.index].id
+  name                                 = "AzureMonitorWindowsAgent"
+  publisher                            = "Microsoft.Azure.Monitor"
+  type                                 = "AzureMonitorWindowsAgent"
+  type_handler_version                 = "1.0"
+  auto_upgrade_minor_version           = "true"
+}
+

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-scs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-scs.tf
@@ -702,7 +702,7 @@ resource "azurerm_virtual_machine_extension" "monitoring_extension_scs_lnx" {
   count                                = local.deploy_monitoring_extension  && upper(var.application_tier.scs_os.os_type) == "LINUX" ? (
                                            local.scs_server_count) : (
                                            0                                           )
-  virtual_machine_id                   = azurerm_windows_virtual_machine.scs[count.index].id
+  virtual_machine_id                   = azurerm_linux_virtual_machine.scs[count.index].id
   name                                 = "AzureMonitorLinuxAgent"
   publisher                            = "Microsoft.Azure.Monitor"
   type                                 = "AzureMonitorLinuxAgent"

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-scs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-scs.tf
@@ -696,3 +696,32 @@ resource "azurerm_virtual_machine_data_disk_attachment" "kdump" {
   caching                              = "None"
   lun                                  = var.application_tier.fence_kdump_lun_number
 }
+
+resource "azurerm_virtual_machine_extension" "monitoring_extension_scs_lnx" {
+  provider                             = azurerm.main
+  count                                = local.deploy_monitoring_extension  && upper(var.application_tier.scs_os.os_type) == "LINUX" ? (
+                                           local.scs_server_count) : (
+                                           0                                           )
+  virtual_machine_id                   = azurerm_windows_virtual_machine.scs[count.index].id
+  name                                 = "AzureMonitorLinuxAgent"
+  publisher                            = "Microsoft.Azure.Monitor"
+  type                                 = "AzureMonitorLinuxAgent"
+  type_handler_version                 = "1.0"
+  auto_upgrade_minor_version           = "true"
+}
+
+
+resource "azurerm_virtual_machine_extension" "monitoring_extension_scs_win" {
+  provider                             = azurerm.main
+  count                                = local.deploy_monitoring_extension  && upper(var.application_tier.scs_os.os_type) == "WINDOWS" ? (
+                                           local.scs_server_count) : (
+                                           0                                           )
+  virtual_machine_id                   = azurerm_windows_virtual_machine.scs[count.index].id
+  name                                 = "AzureMonitorWindowsAgent"
+  publisher                            = "Microsoft.Azure.Monitor"
+  type                                 = "AzureMonitorWindowsAgent"
+  type_handler_version                 = "1.0"
+  auto_upgrade_minor_version           = "true"
+}
+
+

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-scs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-scs.tf
@@ -708,6 +708,16 @@ resource "azurerm_virtual_machine_extension" "monitoring_extension_scs_lnx" {
   type                                 = "AzureMonitorLinuxAgent"
   type_handler_version                 = "1.0"
   auto_upgrade_minor_version           = "true"
+  settings                             = jsonencode(
+                                           {
+                                              "authentication"  =  {
+                                                   "managedIdentity" = {
+                                                        "identifier-name" : "mi_res_id",
+                                                        "identifier-value": var.application_tier.user_assigned_identity_id
+                                                      }
+                                                }
+                                            }
+                                            )
 }
 
 
@@ -722,6 +732,16 @@ resource "azurerm_virtual_machine_extension" "monitoring_extension_scs_win" {
   type                                 = "AzureMonitorWindowsAgent"
   type_handler_version                 = "1.0"
   auto_upgrade_minor_version           = "true"
+  settings                             = jsonencode(
+                                           {
+                                              "authentication"  =  {
+                                                   "managedIdentity" = {
+                                                        "identifier-name" : "mi_res_id",
+                                                        "identifier-value": var.application_tier.user_assigned_identity_id
+                                                      }
+                                                }
+                                            }
+                                            )
 }
 
 

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-webdisp.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-webdisp.tf
@@ -634,6 +634,16 @@ resource "azurerm_virtual_machine_extension" "monitoring_extension_web_lnx" {
   type                                 = "AzureMonitorLinuxAgent"
   type_handler_version                 = "1.0"
   auto_upgrade_minor_version           = "true"
+  settings                             = jsonencode(
+                                           {
+                                              "authentication"  =  {
+                                                   "managedIdentity" = {
+                                                        "identifier-name" : "mi_res_id",
+                                                        "identifier-value": var.application_tier.user_assigned_identity_id
+                                                      }
+                                                }
+                                            }
+                                            )
 }
 
 
@@ -648,4 +658,14 @@ resource "azurerm_virtual_machine_extension" "monitoring_extension_web_win" {
   type                                 = "AzureMonitorWindowsAgent"
   type_handler_version                 = "1.0"
   auto_upgrade_minor_version           = "true"
+  settings                             = jsonencode(
+                                           {
+                                              "authentication"  =  {
+                                                   "managedIdentity" = {
+                                                        "identifier-name" : "mi_res_id",
+                                                        "identifier-value": var.application_tier.user_assigned_identity_id
+                                                      }
+                                                }
+                                            }
+                                            )
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-webdisp.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-webdisp.tf
@@ -622,3 +622,30 @@ resource "azurerm_availability_set" "web" {
   tags                                 = var.tags
 
 }
+
+resource "azurerm_virtual_machine_extension" "monitoring_extension_web_lnx" {
+  provider                             = azurerm.main
+  count                                = local.deploy_monitoring_extension  && upper(var.application_tier.web_os.os_type) == "LINUX" ? (
+                                           local.webdispatcher_count) : (
+                                           0                                           )
+  virtual_machine_id                   = azurerm_windows_virtual_machine.web[count.index].id
+  name                                 = "AzureMonitorLinuxAgent"
+  publisher                            = "Microsoft.Azure.Monitor"
+  type                                 = "AzureMonitorLinuxAgent"
+  type_handler_version                 = "1.0"
+  auto_upgrade_minor_version           = "true"
+}
+
+
+resource "azurerm_virtual_machine_extension" "monitoring_extension_web_win" {
+  provider                             = azurerm.main
+  count                                = local.deploy_monitoring_extension  && upper(var.application_tier.web_os.os_type) == "WINDOWS" ? (
+                                           local.webdispatcher_count) : (
+                                           0                                           )
+  virtual_machine_id                   = azurerm_windows_virtual_machine.web[count.index].id
+  name                                 = "AzureMonitorWindowsAgent"
+  publisher                            = "Microsoft.Azure.Monitor"
+  type                                 = "AzureMonitorWindowsAgent"
+  type_handler_version                 = "1.0"
+  auto_upgrade_minor_version           = "true"
+}

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-webdisp.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-webdisp.tf
@@ -628,7 +628,7 @@ resource "azurerm_virtual_machine_extension" "monitoring_extension_web_lnx" {
   count                                = local.deploy_monitoring_extension  && upper(var.application_tier.web_os.os_type) == "LINUX" ? (
                                            local.webdispatcher_count) : (
                                            0                                           )
-  virtual_machine_id                   = azurerm_windows_virtual_machine.web[count.index].id
+  virtual_machine_id                   = azurerm_linux_virtual_machine.web[count.index].id
   name                                 = "AzureMonitorLinuxAgent"
   publisher                            = "Microsoft.Azure.Monitor"
   type                                 = "AzureMonitorLinuxAgent"

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
@@ -396,4 +396,5 @@ locals {
                                            "value" = var.database.user_assigned_identity_id
                                          }] : []
 
+  deploy_monitoring_extension          = local.enable_deployment && var.infrastructure.deploy_monitoring_extension && length(var.database.user_assigned_identity_id) > 0
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/vm-hdb.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/vm-hdb.tf
@@ -553,3 +553,27 @@ resource "azurerm_virtual_machine_data_disk_attachment" "kdump" {
   caching                              = "None"
   lun                                  = var.database.fence_kdump_lun_number
 }
+
+resource "azurerm_virtual_machine_extension" "monitoring_extension_db_lnx" {
+  provider                             = azurerm.main
+  count                                = local.deploy_monitoring_extension ? (
+                                           var.database_server_count) : (
+                                           0                                           )
+  virtual_machine_id                   = azurerm_linux_virtual_machine.vm_dbnode[count.index].id
+  name                                 = "AzureMonitorLinuxAgent"
+  publisher                            = "Microsoft.Azure.Monitor"
+  type                                 = "AzureMonitorLinuxAgent"
+  type_handler_version                 = "1.0"
+  auto_upgrade_minor_version           = "true"
+
+  settings                             = jsonencode(
+                                           {
+                                              "authentication"  =  {
+                                                   "managedIdentity" = {
+                                                        "identifier-name" : "mi_res_id",
+                                                        "identifier-value": var.database.user_assigned_identity_id
+                                                      }
+                                                }
+                                            }
+                                            )
+}


### PR DESCRIPTION
## Problem
There is no capability to deploy the Monitoring extension

## Solution
Provide a way to deploy the "Microsoft.Azure.Monitor" extension

The variable 'deploy_monitoring_extension' controls if the extension is deployed

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>