### PR TITLE
Bugfix - constraint Azure scheduled events agent installation

### DIFF
--- a/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.2.0-cluster-RedHat.yml
+++ b/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.2.0-cluster-RedHat.yml
@@ -348,6 +348,7 @@
 
 - name:                                "1.17 Generic Pacemaker - Ensure Azure scheduled events is configured"
   when:
+                                      - cluster_use_scheduled_events_agent
                                       - inventory_hostname == primary_instance_name
                                       - is_rhel_84_or_newer
   block:


### PR DESCRIPTION
## Problem
cluster_use_scheduled_events_agent variable (default true) was added and is still in main. However the when statement disappeared - #532 

## Solution
Re-add when condition to constraint Azure scheduled events agent installation - #532 