### PR TITLE
Fix regex necessary to comment lines in /usr/sap/sapservices

### DIFF
--- a/deploy/ansible/roles-sap/5.6-scsers-pacemaker/tasks/5.6.4.1-scsersprofile.yaml
+++ b/deploy/ansible/roles-sap/5.6-scsers-pacemaker/tasks/5.6.4.1-scsersprofile.yaml
@@ -75,7 +75,7 @@
   ansible.builtin.replace:
     backup:                            true
     path:                              /usr/sap/sapservices
-    regexp:                            '^([^#\n].+{{ sapservice }}.+)$'
+    regexp:                            '^(?!#)(.*{{ sapservice }}.*)$'
     replace:                           '# \1'
   loop:
     - "{{ sap_sid | upper }}_{{ instance_type | upper }}{{ scs_instance_number }}_{{ scs_virtual_hostname }}"


### PR DESCRIPTION
## Problem

Using the current regex, the framework doesn't actually comment the necessary lines in /usr/sap/sapservices on the (A)SCS/ERS nodes. Below you can see two such examples:

[root@\***] root # cat /usr/sap/sapservices
systemctl --no-ask-password start SAP\<SID\>_00 # sapstartsrv pf=/usr/sap/\<SID\>/SYS/profile/\<SID\>_ASCS00_\***

[root@\***] root # cat /usr/sap/sapservices
systemctl --no-ask-password start SAP\<SID\>_02 # sapstartsrv pf=/usr/sap/\<SID\>/ERS02/profile/\<SID\>_ERS02_\***

## Solution

Adjusting the regex solves this.

## Tests

Local tests successful, complete deployments currently being worked on.

## Notes

Azure documentation on this --> https://learn.microsoft.com/en-us/azure/sap/workloads/high-availability-guide-rhel-nfs-azure-files?tabs=lb-portal%2Censa1#sap-netweaver-application-server-preparation 

Chapter: 8. [A] Update the /usr/sap/sapservices file