### PR TITLE
Custom LVM striping

### DIFF
--- a/deploy/ansible/roles-os/1.5-disk-setup/tasks/1.5-custom-disks.yml
+++ b/deploy/ansible/roles-os/1.5-disk-setup/tasks/1.5-custom-disks.yml
@@ -47,6 +47,7 @@
     lv:                                "{{ item.lv }}"
     vg:                                "{{ item.vg }}"
     size:                              "{{ item.size }}"
+    opts:                              "{{ lvol_opts_from_lv_item }}"
     active:                            true
     state:                             present
     shrink:                            false

--- a/deploy/ansible/vars/ansible-input-api.yaml
+++ b/deploy/ansible/vars/ansible-input-api.yaml
@@ -83,6 +83,8 @@ sybase_temp_stripe_size:               128
 oracle_data_stripe_size:               256
 oracle_log_stripe_size:                128
 
+default_stripe_size:                   128
+
 # Custom virtual hostnames
 custom_db_virtual_hostname:            ""
 custom_ers_virtual_hostname:           ""

--- a/deploy/ansible/vars/disks_config.yml
+++ b/deploy/ansible/vars/disks_config.yml
@@ -418,9 +418,9 @@ vg_stripecount_from_lv_item: >-
 # '-i <num_vg_pvs> -I <stripesize>' only when the LV 'item' has
 # stripesize specified, otherwise it will be an empty string.
 lvol_opts_from_lv_item: >-
-  {{ ('stripesize' in item) |
+  {{ ('stripesize' in item or vg_stripecount_from_lv_item | int > 1) |
      ternary('-i ' ~ vg_stripecount_from_lv_item ~
-             ' -I ' ~ (item.stripesize | default(0)),
+             ' -I ' ~ (item.stripesize | default(default_stripe_size)),
              '') }}
 
 # Define a dynamic expression based upon the 'item' fact that can


### PR DESCRIPTION
## Problem

When using the extensibility of SDAF to create custom logical volumes, it's currentæy not possible to do LVM striping, which degrades performance of multi-pv LVMs.

## Solution
Use already established pattern from framework specific LVMs to define stripesize on custom logical volumes.The current implementation, ensures that we can do the following in our config repo tfvars file:

```
custom_logical_volumes = [
    {
      tier       = "sapos",
      node_tier  = "hana",
      vg         = "vg_data2",
      lv         = "lv_data2",
      stripesize = "{{ hana_data_stripe_size }}"
      size       = "100%FREE",
      fstype     = "xfs",
      path       = "/hana/data2"
    }
]
```

This will result in a stripesize similar to lv_hana_data. If stripesize is omitted, and the LVM consists of more than one pv, it will result in the `default_stripe_size` value. This has been added to the ansible-input-api.yaml file.