### PR TITLE
Perform az login before the az access token in ams provider creation

### DIFF
--- a/deploy/ansible/roles-misc/0.8-ams-providers/tasks/main.yaml
+++ b/deploy/ansible/roles-misc/0.8-ams-providers/tasks/main.yaml
@@ -8,31 +8,38 @@
     ers_hosts:                         "{{ query('inventory_hostnames', '{{ sap_sid | upper }}_ERS') }}"
     ha_cluster_port_number:            "{{ 9664 if ansible_os_family | upper == 'SUSE' else 44322 }}"
 
-- name:                           "0.8.1 ams provider creation: - Install [AMS] cli extension"
-  delegate_to:                         localhost
+- name:                               "0.8.1 ams provider creation: - Install [AMS] cli extension"
+  delegate_to:                        localhost
   ansible.builtin.shell: >-
-                                  az extension add --name workloads --yes || exit 1
+                                      az extension add --name workloads --yes || exit 1
   tags:
     - skip_ansible_lint
 
-- name:                            "0.8.1 ams provider creation: - Get Access Token"
-  delegate_to:                         localhost
+- name:                               "0.8.1 ams provider creation: - perform az login"
+  delegate_to:                        localhost
+  ansible.builtin.command: >-
+                                      az login --identity --allow-no-subscriptions --output none
+  no_log:                             true
+  changed_when:                       false
+
+- name:                               "0.8.1 ams provider creation: - Get Access Token"
+  delegate_to:                        localhost
   ansible.builtin.shell: >-
-                                    az account get-access-token --resource https://management.azure.com \
-                                    --query accessToken -o tsv
-  register:                        ams_access_token
+                                      az account get-access-token --resource https://management.azure.com \
+                                      --query accessToken -o tsv
+  register:                           ams_access_token
   tags:
     - skip_ansible_lint
 
-- name:                            "0.8.1 ams provider creation: - Generate a guid for the AMS provider instance"
-  delegate_to:                         localhost
-  ansible.builtin.command:         uuidgen
-  register:                        ams_provider_guid
+- name:                               "0.8.1 ams provider creation: - Generate a guid for the AMS provider instance"
+  delegate_to:                        localhost
+  ansible.builtin.command:            uuidgen
+  register:                           ams_provider_guid
   tags:
     - skip_ansible_lint
 
-- name:                                "0.8.1 ams provider creation: - Create PrometheusOS (OS) provider in AMS"
-  delegate_to:                         localhost
+- name:                               "0.8.1 ams provider creation: - Create PrometheusOS (OS) provider in AMS"
+  delegate_to:                        localhost
   when:
                                       - ansible_os_family | upper == 'SUSE' or ansible_os_family | upper == 'REDHAT'
                                       - enable_os_monitoring


### PR DESCRIPTION
## Problem
While acquiring the access token using az cli command, an error occurred `Please run 'az login' to setup account.", "stderr_lines": ["ERROR: Please run 'az login' to setup account."], "stdout": "", "stdout_lines": []}
`
This behavior was not observed during the testing of the feature.

## Solution
Add az login task before acquiring the access token. 
