### PR TITLE
Various Ansible fixes

### DIFF
--- a/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.2.0-cluster-RedHat.yml
+++ b/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.2.0-cluster-RedHat.yml
@@ -123,7 +123,7 @@
     - name:                            "1.17 Generic Pacemaker - Check if the pacemaker package version is greater than pacemaker-2.0.4"
       when:                            ansible_distribution_major_version in ["8", "9"]
       ansible.builtin.set_fact:
-        is_pcmk_ver_gt_204:            "{{ ansible_facts.packages['pacemaker'] is version('2.0.4', '>') | default(false) }}"
+        is_pcmk_ver_gt_204:            "{{ ansible_facts.packages['pacemaker'][0].version is version('2.0.4', '>') | default(false) }}"
 
     - name:                            "1.17 Generic Pacemaker - Ensure STONITH timeout is raised"
       ansible.builtin.command:         pcs property set stonith-timeout=900

--- a/deploy/ansible/roles-os/1.17-generic-pacemaker/vars/main.yml
+++ b/deploy/ansible/roles-os/1.17-generic-pacemaker/vars/main.yml
@@ -83,6 +83,9 @@ package_versions:
   redhat8.9:
     - {name: "pacemaker",               version: "2.0.5",   compare_operator: ">=", version_type: "loose"}
     - {name: "resource-agents",         version: "4.9.0",   compare_operator: ">=", version_type: "loose"}
+  redhat8.10:
+    - {name: "pacemaker",               version: "2.0.5",   compare_operator: ">=", version_type: "loose"}
+    - {name: "resource-agents",         version: "4.9.0",   compare_operator: ">=", version_type: "loose"}
   redhat9.0:
     - {name: "pacemaker",               version: "2.0.5",   compare_operator: ">=", version_type: "loose"}
     - {name: "resource-agents-cloud",   version: "4.10.0",  compare_operator: ">=", version_type: "loose"}

--- a/deploy/ansible/roles-os/1.3-repository/vars/repos.yaml
+++ b/deploy/ansible/roles-os/1.3-repository/vars/repos.yaml
@@ -26,6 +26,7 @@ repos:
 #     - { tier:   'ha', repo: 'epel', url: 'https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm', state: 'present' }
   redhat8.9:
 #    - { tier:   'ha', repo: 'epel', url: 'https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm', state: 'present' }
+  redhat8.10:
   redhat9.0:
   redhat9.2:
   # do not have any repos that are needed for RedHat at the moment.

--- a/deploy/ansible/roles-os/1.4-packages/tasks/1.4.1-packages.yaml
+++ b/deploy/ansible/roles-os/1.4-packages/tasks/1.4.1-packages.yaml
@@ -48,7 +48,8 @@
         state:                         "{{ item.state }}"
       register:                        package_result
       loop:
-        - { state: 'present' }  # First install required packages
+        - { state: 'latest' }  # Update necessary packages
+        - { state: 'present' }  # Install required packages
         - { state: 'absent' }   # Then remove packages that we don't want
   rescue:
     - name:                            "1.4 Packages: - Show result from packages module"
@@ -71,7 +72,8 @@
             state:                         "{{ item.state }}"
           register:                        package_result
           loop:
-            - { state: 'present' }  # First install required packages
+            - { state: 'latest' }  # Update necessary packages
+            - { state: 'present' }  # Install required packages
             - { state: 'absent' }   # Then remove packages that we don't want
       rescue:
         - name:                           "Print stderr before getting error code"
@@ -93,7 +95,8 @@
         state:                         "{{ item.state }}"
       register:                        package_result
       loop:
-        - { state: 'present' }  # First install required packages
+        - { state: 'latest' }  # Update necessary packages
+        - { state: 'present' }  # Install required packages
         - { state: 'absent' }   # Then remove packages that we don't want
 
   rescue:
@@ -116,7 +119,8 @@
             state:                         "{{ item.state }}"
           register:                         package_result
           loop:
-            - { state: 'present' }  # First install required packages
+            - { state: 'latest' }  # Update necessary packages
+            - { state: 'present' }  # Install required packages
             - { state: 'absent' }   # Then remove packages that we don't want
       rescue:
         - name:                         "Print stderr before getting error code"
@@ -140,7 +144,8 @@
         state:                         "{{ item.state }}"
       register:                        package_result
       loop:
-        - { state: 'present' }  # First install required packages
+        - { state: 'latest' }  # Update necessary packages
+        - { state: 'present' }  # Install required packages
         - { state: 'absent' }   # Then remove packages that we don't want
   rescue:
     - name:                            "1.4 Packages: - Show result from packages module"
@@ -163,7 +168,8 @@
             state:                         "{{ item.state }}"
           register:                        package_result
           loop:
-            - { state: 'present' }  # First install required packages
+            - { state: 'latest' }  # Update necessary packages
+            - { state: 'present' }  # Install required packages
             - { state: 'absent' }   # Then remove packages that we don't want
       rescue:
         - name:                         "Print stderr before getting error code"
@@ -186,7 +192,8 @@
         state:                         "{{ item.state }}"
       register:                        package_result
       loop:
-        - { state: 'present' }  # First install required packages
+        - { state: 'latest' }  # Update necessary packages
+        - { state: 'present' }  # Install required packages
         - { state: 'absent' }   # Then remove packages that we don't want
 
   rescue:
@@ -208,7 +215,8 @@
                                               list }}"
             state:                         "{{ item.state }}"
           loop:
-            - { state: 'present' }  # First install required packages
+            - { state: 'latest' }  # Update necessary packages
+            - { state: 'present' }  # Install required packages
             - { state: 'absent' }   # Then remove packages that we don't want
       rescue:
         - name:                        "Print stderr before getting error code"

--- a/deploy/ansible/roles-os/1.4-packages/vars/os-packages.yaml
+++ b/deploy/ansible/roles-os/1.4-packages/vars/os-packages.yaml
@@ -159,6 +159,7 @@ packages:
     - { tier: 'os',    package: 'mksh',                                         node_tier: 'db2',     state: 'present' }
     - { tier: 'os',    package: 'libstdc++.so.6',                               node_tier: 'db2',     state: 'present' }
     - { tier: 'os',    package: 'unzip',                                        node_tier: 'db2',     state: 'present' }
+    - { tier: 'os',    package: 'pam',                                          node_tier: 'db2',     state: 'latest'  }
     - { tier: 'os',    package: 'libpam.so.0',                                  node_tier: 'db2',     state: 'present' }
     - { tier: 'db2',   package: 'acl',                                          node_tier: 'db2',     state: 'present' }
     # --------------------------- End - Packages required for DB2 -------------------------------------------8

--- a/deploy/ansible/roles-os/1.4-packages/vars/os-packages.yaml
+++ b/deploy/ansible/roles-os/1.4-packages/vars/os-packages.yaml
@@ -264,6 +264,9 @@ packages:
   redhat8.9:
     - { tier: 'os',    package: 'NetworkManager-cloud-setup',                   node_tier: 'all',    state: 'present' }
     - { tier: 'ha',    package: 'NetworkManager-cloud-setup',                   node_tier: 'all',    state: 'absent'  }
+  redhat8.10:
+    - { tier: 'os',    package: 'NetworkManager-cloud-setup',                   node_tier: 'all',    state: 'present' }
+    - { tier: 'ha',    package: 'NetworkManager-cloud-setup',                   node_tier: 'all',    state: 'absent'  }
   redhat9.0:
     - { tier: 'os',    package: 'NetworkManager-cloud-setup',                   node_tier: 'all',    state: 'present' }
     - { tier: 'ha',    package: 'NetworkManager-cloud-setup',                   node_tier: 'all',    state: 'absent'  }

--- a/deploy/ansible/roles-sap/5.5-hanadb-pacemaker/tasks/5.5.4.1-cluster-RedHat.yml
+++ b/deploy/ansible/roles-sap/5.5-hanadb-pacemaker/tasks/5.5.4.1-cluster-RedHat.yml
@@ -29,7 +29,7 @@
     - name:                            "5.5.4.1 HANA Cluster configuration - Check if the pacemaker package version is greater than pacemaker-2.0.4"
       when:                            ansible_distribution_major_version in ["8", "9"]
       ansible.builtin.set_fact:
-        is_pcmk_ver_gt_204:            "{{ ansible_facts.packages['pacemaker'] is version('2.0.4', '>') | default(false) }}"
+        is_pcmk_ver_gt_204:            "{{ ansible_facts.packages['pacemaker'][0].version is version('2.0.4', '>') | default(false) }}"
 
     - name:                            "5.5.4.1 HANA Cluster configuration - Ensure the SAP HANA Topology resource is created"
       ansible.builtin.shell: >

--- a/deploy/ansible/roles-sap/5.6-scsers-pacemaker/tasks/5.6.4.2-sap-resources-RedHat.yml
+++ b/deploy/ansible/roles-sap/5.6-scsers-pacemaker/tasks/5.6.4.2-sap-resources-RedHat.yml
@@ -109,7 +109,7 @@
 - name:                                "5.6 SCSERS - RHEL - Check if the pacemaker package version is greater than pacemaker-2.0.4"
   when:                                ansible_distribution_major_version in ["8", "9"]
   ansible.builtin.set_fact:
-    is_pcmk_ver_gt_204:                "{{ ansible_facts.packages['pacemaker'] is version('2.0.4', '>') | default(false) }}"
+    is_pcmk_ver_gt_204:                "{{ ansible_facts.packages['pacemaker'][0].version is version('2.0.4', '>') | default(false) }}"
 
 - name:                                "5.6 SCSERS - RHEL - Set properties for two node clusters"
   when:


### PR DESCRIPTION
## Problems

1. RHEL8.10 was released and the Framework doesn't support it

2. Cluster version check syntax is incorrect in roles  1.17-generic-pacemaker, 5.5-hanadb-pacemaker and 5.6-scsers-pacemaker, which also impedes a correct run of the installation process.

3. For DB2 deployments, the OS packages list contains libpam.so.0 and for this the i686 version of the pam package is a dependency. However, on RHEL8.9 VMs the x86_64 version of the pam package is also already present. Result is that 1.4-packages will error out for the DB2 nodes with:

```
  file /usr/share/man/man5/faillock.conf.5.gz from install of pam-1.3.1-33.el8.i686 conflicts with file from package pam-1.3.1-27.el8.x86_64
  file /usr/share/man/man5/limits.conf.5.gz from install of pam-1.3.1-33.el8.i686 conflicts with file from package pam-1.3.1-27.el8.x86_64
  file /usr/share/man/man5/namespace.conf.5.gz from install of pam-1.3.1-33.el8.i686 conflicts with file from package pam-1.3.1-27.el8.x86_64
...
  file /usr/share/man/man8/pam_usertype.8.gz from install of pam-1.3.1-33.el8.i686 conflicts with file from package pam-1.3.1-27.el8.x86_64
  file /usr/share/man/man8/pam_wheel.8.gz from install of pam-1.3.1-33.el8.i686 conflicts with file from package pam-1.3.1-27.el8.x86_64
  file /usr/share/man/man8/pwhistory_helper.8.gz from install of pam-1.3.1-33.el8.i686 conflicts with file from package pam-1.3.1-27.el8.x86_64
```

## Solutions

1. Variable added to the corresponding vars files to add support for RHEL8.10

2. Task that's setting the fact has been adjusted

3. To avoid the conflict, the existing x86_64 pam package needs to be updated first. Thus, it has been added to the package list with status 'latest', which is also now the first item in the loops  in deploy/ansible/roles-os/1.4-packages/tasks/1.4.1-packages.yaml. This results in the correct order of steps for this particular situation and should be a good mechanism for other similar conflicts.

## Tests

DB2 ABAP HA deployment

## Notes

Circumventing the pam conflict was also analyzed and tested with Red Hat by means of a case we opened.

Please incorporate these changes into a release ASAP because we need the RHEL8.10 support to create new systems.