### PR TITLE
Set HDB Schema Name task

### DIFF
--- a/deploy/ansible/roles-db/4.0.4-hdb-schema/tasks/main.yaml
+++ b/deploy/ansible/roles-db/4.0.4-hdb-schema/tasks/main.yaml
@@ -1,0 +1,32 @@
+---
+# /*---------------------------------------------------------------------------8
+# |                                                                            |
+# |     0  Set 'schema_name' fact for HDB Schema Name                      |
+# |                                                                            |
+# +------------------------------------4--------------------------------------*/
+
+- name: "HDB Schema: Get DEFAULT.PFL"
+  ansible.builtin.slurp:
+    src: "/sapmnt/{{ sap_sid | upper }}/profile/DEFAULT.PFL"
+  register: profilefile
+
+- name: "HDB Schema: Get schema name"
+  ignore_errors: true
+  ansible.builtin.set_fact:
+    schema_name: "{{ profilefile['content'] | b64decode | split('\n') | select('search', {{ property_name }} ) | first | split('=') | last | trim }}"
+  loop: "{{ hdb_schema_property_names }}"
+  loop_control:
+    loop_var: property_name
+  when:
+    - schema_name is not defined
+
+- name: "HDB Schema: Set default schema"
+  ansible.builtin.set_fact:
+    schema_name: "{{ hana_schema }}"
+  when:
+    - schema_name is not defined
+
+- name: "HDB Schema: Show schema name"
+  ansible.builtin.debug:
+    msg: "Schema name {{ schema_name }}"
+    verbosity: 2

--- a/deploy/ansible/roles-db/4.0.4-hdb-schema/vars/main.yaml
+++ b/deploy/ansible/roles-db/4.0.4-hdb-schema/vars/main.yaml
@@ -1,0 +1,3 @@
+schema_names:
+  - "dbs/hdb/schema" # ABAP schema
+  - "j2ee/dbschema" # JAVA schema

--- a/deploy/ansible/roles-sap/5.1-dbload/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.1-dbload/tasks/main.yaml
@@ -346,22 +346,12 @@
     #   when:
     #     - node_tier in ["oracle","oracle-asm"]
 
-    - name:                            "DBLoad Install: Get DEFAULT.PFL"
-      ansible.builtin.slurp:
-        src:                           "/sapmnt/{{ sap_sid | upper }}/profile/DEFAULT.PFL"
-      register: profilefile
-
-    - name:                            "DBLoad Install: Get schema name"
-      ansible.builtin.set_fact:
-        schema_name:                   "{{ profilefile['content'] | b64decode | split('\n') | select('search', 'dbs/hdb/schema') | first | split('=') | last | trim | default('{{ hana_schema }}') }}"
+    - name:                            "DBLoad Install: Set Schema Name"
       when:
-        - platform == 'HANA'
-
-    - name:                            "DBLoad Install: Installation results"
-      ansible.builtin.debug:
-        msg:                           "Schema name {{ schema_name }}"
-      when:
-        - platform == 'HANA'
+        - platform == "HANA"
+      ansible.builtin.include_role:
+        name:                          "roles-db/4.0.4-hdb-schema"
+        public:                        true
 
     - name:                            "Backward Compatibility - Check required Database HA variables"
       ansible.builtin.set_fact:
@@ -464,22 +454,12 @@
         - db_high_availability is defined
         - database_high_availability is not defined
 
-    - name:                            "DBLoad Install: Get DEFAULT.PFL"
-      ansible.builtin.slurp:
-        src:                           "/sapmnt/{{ sap_sid | upper }}/profile/DEFAULT.PFL"
-      register: profilefile
-
-    - name:                            "DBLoad Install: Get schema name"
-      ansible.builtin.set_fact:
-        schema_name:                   "{{ profilefile['content'] | b64decode | split('\n') | select('search', 'dbs/hdb/schema') | first | split('=') | last | trim | default('{{ hana_schema }}') }}"
+    - name:                           "DBLoad Install: Set Schema Name"
       when:
-        - platform == 'HANA'
-
-    - name:                            "DBLoad Install: Installation results"
-      ansible.builtin.debug:
-        msg:                           "Schema name {{ schema_name }}"
-      when:
-        - platform == 'HANA'
+        - platform == "HANA"
+      ansible.builtin.include_role:
+        name:                         "roles-db/4.0.4-hdb-schema"
+        public:                       true
 
     - name:                            "DBLoad: Get hdbuserstore path"
       become:                          true

--- a/deploy/ansible/roles-sap/5.2-pas-install/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.2-pas-install/tasks/main.yaml
@@ -129,21 +129,12 @@
     - platform == "HANA"
     - db_port_open.msg is defined
 
-- name:                                "PAS Install: Set schema_name variable for HANA"
-  when: platform == "HANA"
-  block:
-    - name:                            "PAS Install: Get DEFAULT.PFL"
-      ansible.builtin.slurp:
-        src:                           "/sapmnt/{{ sap_sid | upper }}/profile/DEFAULT.PFL"
-      register: profilefile
-
-    - name:                            "PAS Install: Get schema name"
-      ansible.builtin.set_fact:
-        schema_name:                   "{{ profilefile['content'] | b64decode | split('\n') | select('search', 'dbs/hdb/schema') | first | split('=') | last | trim | default('{{ hana_schema }}') }}"
-
-    - name:                            "PAS Install: Show schema name"
-      ansible.builtin.debug:
-        msg:                           "Schema name {{ schema_name }}"
+- name:                               "PAS Install: Set Schema Name"
+  when:
+    - platform == "HANA"
+  ansible.builtin.include_role:
+    name:                             "roles-db/4.0.4-hdb-schema"
+    public:                           true
 
 - name:                                "PAS Install"
   block:

--- a/deploy/ansible/roles-sap/5.3-app-install/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.3-app-install/tasks/main.yaml
@@ -113,21 +113,11 @@
     - platform == "HANA"
     - db_port_open.msg is defined
 
-- name:                                "APP Install: Set schema_name variable for HANA"
-  when: platform == "HANA"
-  block:
-    - name:                            "APP Install: Get DEFAULT.PFL"
-      ansible.builtin.slurp:
-        src:                           "/sapmnt/{{ sap_sid | upper }}/profile/DEFAULT.PFL"
-      register: profilefile
-
-    - name:                            "APP Install: Get schema name"
-      ansible.builtin.set_fact:
-        schema_name:                   "{{ profilefile['content'] | b64decode | split('\n') | select('search', 'dbs/hdb/schema') | first | split('=') | last | trim | default('{{ hana_schema }}') }}"
-
-    - name:                            "APP Install: Show schema name"
-      ansible.builtin.debug:
-        msg:                           "Schema name {{ schema_name }}"
+- name:                               "APP Install: Set Schema Name"
+  when:
+    - platform == "HANA"
+  ansible.builtin.include_role:
+    name:                             "roles-db/4.0.4-hdb-schema"
 
 # *====================================4=======================================8
 #   SAP APP: Install


### PR DESCRIPTION
## Problem
Current setup did not accommodate for JAVA HDB setups, failing trying to determine the HDB schema.

## Solution
Added a loop to determine schema name based on a list of property names, defaulting to `hana_schema` var if none is found. This has been pulled into a seperate `roles-db` role and used in the various locations, `schema_name` was set.