### PR TITLE
Add SAP on Azure quality chekcs feature to the 05-DB-and-SAP-installation pipeline

### DIFF
--- a/deploy/ansible/playbook_06_02_sap_on_azure_quality_checks.yaml
+++ b/deploy/ansible/playbook_06_02_sap_on_azure_quality_checks.yaml
@@ -1,0 +1,72 @@
+# /*---------------------------------------------------------------------------8
+# |                                                                            |
+# |                 Playbook for SAP on Azure quality checks                   |
+# |                                                                            |
+# +------------------------------------4--------------------------------------*/
+---
+
+- hosts:                               localhost
+  name:                                "SAP on Azure quality checks: - setup deployer"
+  gather_facts:                        true
+  vars_files:
+    - vars/ansible-input-api.yaml                               # API Input template with defaults
+
+  tasks:
+
+    - name:                            "SAP on Azure quality checks: - Create Progress folder"
+      ansible.builtin.file:
+        path:                          "{{ _workspace_directory }}/.progress"
+        state:                         directory
+        mode:                          0755
+
+    - name:                            "SAP on Azure quality checks: - Remove sap-on-azure-quality-checks-done flag"
+      ansible.builtin.file:
+        path:                          "{{ _workspace_directory }}/.progress/sap-on-azure-quality-checks-done"
+        state:                          absent
+
+    - name:                            "SAP on Azure quality checks: - setup prerequisites"
+      ansible.builtin.include_role:
+        name:                          "roles-misc/0.9-sap-on-azure-quality-checks"
+        tasks_from:                    "setup"
+
+
+
+- hosts: "{{ sap_sid | upper }}_DB  :
+    {{ sap_sid | upper }}_SCS :
+    {{ sap_sid | upper }}_ERS :
+    {{ sap_sid | upper }}_PAS :
+    {{ sap_sid | upper }}_APP"
+
+  name:                                "SAP on Azure quality checks: - run checks"
+  remote_user:                         "{{ orchestration_ansible_user }}"
+  gather_facts:                        true # Important to collect hostvars information
+  any_errors_fatal:                    true
+  vars_files:
+    - vars/ansible-input-api.yaml # API Input template with defaults
+
+  tasks:
+
+    - name:                            "SAP on Azure quality checks: - run check"
+      ansible.builtin.include_role:
+        name:                          "roles-misc/0.9-sap-on-azure-quality-checks"
+        tasks_from:                    "run_check"
+
+
+- hosts:                               localhost
+  name:                                "SAP on Azure quality checks: - Done"
+  gather_facts:                        true
+  vars_files:
+    - vars/ansible-input-api.yaml                               # API Input template with defaults
+
+  tasks:
+
+    - name:                            "SAP on Azure quality checks: - Create sap-on-azure-quality-checks-done flag"
+      ansible.builtin.file:
+        path:                          "{{ _workspace_directory }}/.progress/sap-on-azure-quality-checks-done"
+        state:                         touch
+        mode:                          0755
+
+...
+# /*---------------------------------------------------------------------------8
+# |                                    END                                     |
+# +------------------------------------4--------------------------------------*/

--- a/deploy/ansible/playbook_06_02_sap_on_azure_quality_checks.yaml
+++ b/deploy/ansible/playbook_06_02_sap_on_azure_quality_checks.yaml
@@ -30,7 +30,6 @@
         tasks_from:                    "setup"
 
 
-
 - hosts: "{{ sap_sid | upper }}_DB  :
     {{ sap_sid | upper }}_SCS :
     {{ sap_sid | upper }}_ERS :

--- a/deploy/ansible/roles-misc/0.9-sap-on-azure-quality-checks/tasks/run_check.yaml
+++ b/deploy/ansible/roles-misc/0.9-sap-on-azure-quality-checks/tasks/run_check.yaml
@@ -1,0 +1,92 @@
+# /*---------------------------------------------------------------------------8
+# |                                                                            |
+# |                Run quality check                                           |
+# |                                                                            |
+# +------------------------------------4--------------------------------------*/
+---
+
+- name:                            "SAP on Azure quality checks: - Check required Database HA variables"
+  ansible.builtin.set_fact:
+    database_high_availability:    "{{ db_high_availability | default(false) }}"
+  when:
+    - db_high_availability is defined
+    - database_high_availability is not defined
+
+
+- name:                            "SAP on Azure quality checks: - Retrieve Subscription ID and Resource Group Name"
+  ansible.builtin.uri:
+    url:                           http://169.254.169.254/metadata/instance?api-version=2021-02-01
+    use_proxy:                     false
+    headers:
+      Metadata:                    true
+  register:                        azure_metadata
+
+
+# https://github.com/Azure/SAP-on-Azure-Scripts-and-Utilities/blob/main/QualityCheck/Readme.md#login-with-ssh-keys-no-password-required-for-sudo
+- name:                            "SAP on Azure quality checks: - Set common quality check facts"
+  ansible.builtin.set_fact:
+    qc_subscription_id:            "{{ azure_metadata.json.compute.subscriptionId }}"
+    qc_az_vm_resource_group:       "{{ azure_metadata.json.compute.resourceGroupName }}"
+    qc_az_vm_name:                 "{{ azure_metadata.json.compute.name }}"
+    qc_vm_username:                "{{ ansible_user }}"
+    qc_vm_hostname:                "{{ ansible_hostname }}.{{ sap_fqdn }}"
+    qc_vm_operating_system:        "{{ vm_operating_system_map[ansible_os_family | upper] }}"
+    qc_vm_database:                "{{ vm_database_map[platform | upper] }}"
+    qc_vm_role:                    "{{ vm_role_map[node_tier | upper] }}"
+    qc_sid:                        "{{ db_sid if vm_role_map[node_tier | upper] == 'DB' else sap_sid }}"
+    qc_high_availability:          "{{ (vm_role_map[node_tier | upper] == 'DB' and database_high_availability) or (vm_role_map[node_tier | upper] == 'ASCS' and scs_high_availability) }}"
+
+
+- name:                            "SAP on Azure quality checks: - Debug variables"
+  ansible.builtin.debug:
+    msg:
+                                   - "Subscription ID: {{ qc_subscription_id }}"
+                                   - "Resource Group Name: {{ qc_az_vm_resource_group }}"
+                                   - "VM Name: {{ qc_az_vm_name }}"
+                                   - "VM Username: {{ qc_vm_username }}"
+                                   - "VM Hostname: {{ qc_vm_hostname }}"
+                                   - "VM Operating System: {{ qc_vm_operating_system }}"
+                                   - "VM Database: {{ qc_vm_database }}"
+                                   - "VM Role: {{ qc_vm_role }}"
+                                   - "SSH Key path {{ _workspace_directory }}/sshkey"
+                                   - "Output Directory {{ _workspace_directory }}/quality_checks"
+                                   - "SID: {{ qc_sid }}"
+                                   - "High Availability: {{ qc_high_availability }}"
+    verbosity:                     2
+
+
+- name:                            "SAP on Azure quality checks: - Run quality check"
+  ansible.builtin.shell:
+    cmd: >-
+                                    Connect-AzAccount -AccountId $Env:ARM_CLIENT_ID `
+                                                      -AccessToken (az account get-access-token --subscription {{ qc_subscription_id }} | ConvertFrom-Json).accessToken `
+                                                      -Subscription {{ qc_subscription_id }}
+
+                                    ./QualityCheck.ps1 -LogonWithUserSSHKey `
+                                                        -VMOperatingSystem {{ qc_vm_operating_system }} `
+                                                        -VMDatabase {{ qc_vm_database }} `
+                                                        -VMRole {{ qc_vm_role }} `
+                                                        -AzVMResourceGroup {{ qc_az_vm_resource_group }} `
+                                                        -AzVMName {{ qc_az_vm_name }} `
+                                                        -VMHostname {{ qc_vm_hostname }} `
+                                                        -VMUsername {{ qc_vm_username }} `
+                                                        -VMConnectionPort 22 `
+                                                        -SubscriptionId {{ qc_subscription_id }} `
+                                                        -SSHKey {{ _workspace_directory }}/sshkey `
+                                                        -Hardwaretype VM `
+                                                        -SID {{ qc_sid }} `
+                                                        -HighAvailability {{ '$' ~ qc_high_availability }} `
+                                                        -OutputDirName {{ _workspace_directory }}/quality_checks
+  args:
+    executable:                    "/usr/local/bin/pwsh"
+    chdir:                         "/opt/microsoft/quality_check"
+  no_log:                          true
+  delegate_to:                     localhost
+  register:                        quality_check_result
+
+- name:                            "SAP on Azure quality checks: - Debug quality check result"
+  ansible.builtin.debug:
+    msg:                           "{{ quality_check_result.stdout_lines }}"
+    verbosity:                     2
+
+...

--- a/deploy/ansible/roles-misc/0.9-sap-on-azure-quality-checks/tasks/setup.yaml
+++ b/deploy/ansible/roles-misc/0.9-sap-on-azure-quality-checks/tasks/setup.yaml
@@ -1,0 +1,88 @@
+# /*---------------------------------------------------------------------------8
+# |                                                                            |
+# |                Setup quality check prerequisites                           |
+# |                                                                            |
+# +------------------------------------4--------------------------------------*/
+---
+
+- name:                            "SAP on Azure quality checks: - setup directories"
+  become:                          true
+  become_user:                     root
+  ansible.builtin.file:
+    path:                          "{{ item.path }}"
+    state:                         directory
+    mode:                          0755
+    owner:                         "{{ item.owner }}"
+  loop:
+    - { path: "/opt/microsoft/powershell/v{{ powershell_version }}", owner: "root" }
+    - { path: "/opt/microsoft/quality_check", owner: "{{ orchestration_ansible_user }}" }
+    - { path: "{{ _workspace_directory }}/quality_checks", owner: "{{ orchestration_ansible_user }}" }
+
+
+- name:                            "SAP on Azure quality checks: - extract PowerShell binary"
+  become:                          true
+  become_user:                     root
+  ansible.builtin.unarchive:
+    src:                           "https://github.com/PowerShell/PowerShell/releases/download/v{{ powershell_version }}/powershell-{{ powershell_version }}-linux-x64.tar.gz"
+    dest:                          "/opt/microsoft/powershell/v{{ powershell_version }}"
+    creates:                       "/opt/microsoft/powershell/v{{ powershell_version }}/pwsh"
+    remote_src:                    true
+
+
+- name:                            "SAP on Azure quality checks: - create PowerShell symbolic link"
+  become:                          true
+  become_user:                     root
+  ansible.builtin.file:
+    src:                           "/opt/microsoft/powershell/v{{ powershell_version }}/pwsh"
+    dest:                          "/usr/local/bin/pwsh"
+    state:                         link
+    mode:                          0755
+
+
+- name:                            "SAP on Azure quality checks: - fetch quality check config"
+  become:                          true
+  become_user:                     root
+  ansible.builtin.get_url:
+    url:                           "{{ azure_utility_repo }}/main/QualityCheck/QualityCheck.json"
+    dest:                          "/opt/microsoft/quality_check/QualityCheck.json"
+    owner:                         "{{ orchestration_ansible_user }}"
+    timeout:                       30
+  register:                        qc_json_result
+  until:                           qc_json_result is succeeded or not qc_json_result.changed
+  retries:                         2
+  delay:                           5
+
+
+- name:                            "SAP on Azure quality checks: - fetch quality check script"
+  become:                          true
+  become_user:                     root
+  ansible.builtin.get_url:
+    url:                           "{{ azure_utility_repo }}/main/QualityCheck/QualityCheck.ps1"
+    dest:                          "/opt/microsoft/quality_check/QualityCheck.ps1"
+    owner:                         "{{ orchestration_ansible_user }}"
+    mode:                          0755
+    timeout:                       30
+  register:                        qc_ps_result
+  until:                           qc_ps_result is succeeded or not qc_ps_result.changed
+  retries:                         2
+  delay:                           5
+
+- name:                            "SAP on Azure quality checks: - run PowerShell setup"
+  become:                          true
+  become_user:                     root
+  ansible.builtin.shell: >-
+                                   Update-AzConfig -EnableLoginByWam $false
+
+                                   $modules = @("Az", "Az.NetAppFiles", "Posh-SSH")
+
+                                   foreach ($module in $modules) {
+                                     if (-not (Get-Module -ListAvailable -Name $module)) {
+                                       Install-Module $module -Force -Scope AllUsers -Confirm:$false
+                                     }
+                                   }
+  register:                        qc_modules_result
+  failed_when:                     qc_modules_result.rc != 0
+  args:
+    chdir:                         "/opt/microsoft/quality_check"
+    executable:                    "/usr/local/bin/pwsh"
+...

--- a/deploy/ansible/roles-misc/0.9-sap-on-azure-quality-checks/tasks/setup.yaml
+++ b/deploy/ansible/roles-misc/0.9-sap-on-azure-quality-checks/tasks/setup.yaml
@@ -46,6 +46,7 @@
     url:                           "{{ azure_utility_repo }}/main/QualityCheck/QualityCheck.json"
     dest:                          "/opt/microsoft/quality_check/QualityCheck.json"
     owner:                         "{{ orchestration_ansible_user }}"
+    mode:                          0755
     timeout:                       30
   register:                        qc_json_result
   until:                           qc_json_result is succeeded or not qc_json_result.changed

--- a/deploy/ansible/roles-misc/0.9-sap-on-azure-quality-checks/vars/main.yaml
+++ b/deploy/ansible/roles-misc/0.9-sap-on-azure-quality-checks/vars/main.yaml
@@ -1,4 +1,3 @@
-
 azure_utility_repo: https://raw.githubusercontent.com/Azure/SAP-on-Azure-Scripts-and-Utilities
 powershell_version: 7.3.12
 

--- a/deploy/ansible/roles-misc/0.9-sap-on-azure-quality-checks/vars/main.yaml
+++ b/deploy/ansible/roles-misc/0.9-sap-on-azure-quality-checks/vars/main.yaml
@@ -1,0 +1,35 @@
+
+azure_utility_repo: https://raw.githubusercontent.com/Azure/SAP-on-Azure-Scripts-and-Utilities
+powershell_version: 7.3.12
+
+# https://github.com/Azure/SAP-on-Azure-Scripts-and-Utilities/blob/main/QualityCheck/QualityCheck.ps1
+vm_operating_system_map:
+  SUSE: "SUSE"
+  REDHAT: "RedHat"
+  ORACLELINUX: "OracleLinux"
+  WINDOWS: "Windows"
+
+vm_database_map:
+  HANA: HANA
+  DB2: Db2
+  SYBASE: ASE
+  SQLSERVER: MSSQL
+  ORACLE: Oracle
+  ORACLE-ASM: Oracle
+
+vm_role_map:
+  HANA: DB
+  DB2: DB
+  SYBASE: DB
+  SQLSERVER: DB
+  ORACLE: DB
+  ORACLE-ASM: DB
+  SCS: ASCS
+  ERS: ASCS
+  PAS: APP
+  APP: APP
+
+high_availability_agent_map:
+  AFA: FencingAgent
+  SBD: SBD
+  ISCSI: SBD

--- a/deploy/pipelines/05-DB-and-SAP-installation.yaml
+++ b/deploy/pipelines/05-DB-and-SAP-installation.yaml
@@ -77,6 +77,11 @@ parameters:
     type:                              boolean
     default:                           false
 
+  - name:                              sap_on_azure_quality_checks
+    displayName:                       SAP on Azure Quality Checks
+    type:                              boolean
+    default:                           false
+
   - name:                              post_configuration_actions
     displayName:                       Post Configuration Actions
     type:                              boolean
@@ -525,6 +530,24 @@ stages:
                   azureTenantId:             $(ARM_TENANT_ID)
                   azureSubscriptionId:       $(ARM_SUBSCRIPTION_ID)
                   USE_MSI:                   $(USE_MSI)
+          - ${{ if eq(parameters.sap_on_azure_quality_checks, true) }}:
+              - template:                    templates\run-ansible.yaml
+                parameters:
+                  displayName:               SAP on Azure quality checks
+                  ansibleFilePath:           ${{ parameters.sap_automation_repo_path }}/deploy/ansible/playbook_06_02_sap_on_azure_quality_checks.yaml
+                  secretName:                "$(Preparation.SSH_KEY_NAME)"
+                  passwordSecretName:        "$(Preparation.PASSWORD_KEY_NAME)"
+                  userNameSecretName:        "$(Preparation.USERNAME_KEY_NAME)"
+                  vaultName:                 $(Preparation.VAULT_NAME)
+                  parametersFolder:          $(Preparation.FOLDER)
+                  sapParams:                 "${{ parameters.config_repo_path }}/$(Deployment_Configuration_Path)/SYSTEM/${{ parameters.sap_system_configuration_name }}/artifacts/$(Preparation.SAP_PARAMETERS)"
+                  sidHosts:                  $(Preparation.HOSTS)
+                  extraParams:               "$(Preparation.NEW_PARAMETERS)"
+                  azureClientId:             $(ARM_CLIENT_ID)
+                  azureClientSecret:         $(ARM_CLIENT_SECRET)
+                  azureTenantId:             $(ARM_TENANT_ID)
+                  azureSubscriptionId:       $(ARM_SUBSCRIPTION_ID)
+                  USE_MSI:                   $(USE_MSI)
           - ${{ if eq(parameters.post_configuration_actions, true) }}:
               - template:                    templates\run-ansible.yaml
                 parameters:
@@ -580,6 +603,8 @@ stages:
                   azureClientSecret:         $(ARM_CLIENT_SECRET)
                   azureTenantId:             $(ARM_TENANT_ID)
                   azureSubscriptionId:       $(ARM_SUBSCRIPTION_ID)
-          - template:                          templates\collect-log-files.yaml
+          - template:                        templates\collect-log-files.yaml
             parameters:
-              logPath:                         ${{ parameters.config_repo_path }}/$(Deployment_Configuration_Path)/SYSTEM/${{ parameters.sap_system_configuration_name }}/logs
+              logPath:                       ${{ parameters.config_repo_path }}/$(Deployment_Configuration_Path)/SYSTEM/${{ parameters.sap_system_configuration_name }}/logs
+              qualityCheckPath:              ${{ parameters.config_repo_path }}/$(Deployment_Configuration_Path)/SYSTEM/${{ parameters.sap_system_configuration_name }}/quality_checks
+              collectQualityChecks:          ${{ parameters.sap_on_azure_quality_checks }}

--- a/deploy/pipelines/templates/collect-log-files.yaml
+++ b/deploy/pipelines/templates/collect-log-files.yaml
@@ -89,50 +89,6 @@ steps:
       # Treat unset variables as an error when substituting.
       set -eu
 
-      echo "Collecting log files from ${{ parameters.logPath }}"
-
-      if [ -d ${LOG_PATH} ] && [ $(ls ${LOG_PATH}/*.zip | wc -l ) -gt 0 ]; then
-        echo "Found log files in ${LOG_PATH}"
-
-        cd ${LOG_PATH}
-        ls -ltr
-
-        git config --global user.email "${USER_EMAIL}"
-        git config --global user.name "${USER_NAME}"
-
-        echo "Checking out ${SOURCE_BRANCH} branch..."
-        git checkout -q ${SOURCE_BRANCH}
-        echo "Pulling last changes..."
-        git pull
-
-        echo "Adding new logs..."
-        git add --ignore-errors *.zip
-        if [ $(git diff --name-only --cached | wc -l) -gt 0 ]; then
-            echo "Committing changes..."
-            git commit -m "Adding new logs"
-            echo "Pushing changes..."
-            git push
-        else
-            echo "No changes to commit"
-        fi
-      else
-        echo No logs found in "${LOG_PATH}"
-      fi
-    displayName: Store log files in repository
-    enabled: true
-    env:
-      USER_EMAIL: $(Build.RequestedForEmail)
-      USER_NAME: $(Build.RequestedFor)
-      SOURCE_BRANCH: $(Build.SourceBranchName)
-      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-      LOG_PATH: ${{ parameters.logPath }}
-
-  - script: |
-      #!/bin/bash
-      # Exit immediately if a command exits with a non-zero status.
-      # Treat unset variables as an error when substituting.
-      set -eu
-
       echo "Collecting quality check files from ${{ parameters.qualityCheckPath }}"
 
       if [ -d ${QUALITY_CHECK_PATH} ] && [ $(ls ${QUALITY_CHECK_PATH}/*.html | wc -l ) -gt 0 ]; then

--- a/deploy/pipelines/templates/collect-log-files.yaml
+++ b/deploy/pipelines/templates/collect-log-files.yaml
@@ -1,5 +1,7 @@
 parameters:
   logPath: ""
+  qualityCheckPath: ""
+  collectQualityChecks: false
 steps:
   - script: |
       #!/bin/bash
@@ -80,3 +82,92 @@ steps:
     condition: always()
     env:
       LOG_PATH: ${{ parameters.logPath }}
+
+  - script: |
+      #!/bin/bash
+      # Exit immediately if a command exits with a non-zero status.
+      # Treat unset variables as an error when substituting.
+      set -eu
+
+      echo "Collecting log files from ${{ parameters.logPath }}"
+
+      if [ -d ${LOG_PATH} ] && [ $(ls ${LOG_PATH}/*.zip | wc -l ) -gt 0 ]; then
+        echo "Found log files in ${LOG_PATH}"
+
+        cd ${LOG_PATH}
+        ls -ltr
+
+        git config --global user.email "${USER_EMAIL}"
+        git config --global user.name "${USER_NAME}"
+
+        echo "Checking out ${SOURCE_BRANCH} branch..."
+        git checkout -q ${SOURCE_BRANCH}
+        echo "Pulling last changes..."
+        git pull
+
+        echo "Adding new logs..."
+        git add --ignore-errors *.zip
+        if [ $(git diff --name-only --cached | wc -l) -gt 0 ]; then
+            echo "Committing changes..."
+            git commit -m "Adding new logs"
+            echo "Pushing changes..."
+            git push
+        else
+            echo "No changes to commit"
+        fi
+      else
+        echo No logs found in "${LOG_PATH}"
+      fi
+    displayName: Store log files in repository
+    enabled: true
+    env:
+      USER_EMAIL: $(Build.RequestedForEmail)
+      USER_NAME: $(Build.RequestedFor)
+      SOURCE_BRANCH: $(Build.SourceBranchName)
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+      LOG_PATH: ${{ parameters.logPath }}
+
+  - script: |
+      #!/bin/bash
+      # Exit immediately if a command exits with a non-zero status.
+      # Treat unset variables as an error when substituting.
+      set -eu
+
+      echo "Collecting quality check files from ${{ parameters.qualityCheckPath }}"
+
+      if [ -d ${QUALITY_CHECK_PATH} ] && [ $(ls ${QUALITY_CHECK_PATH}/*.html | wc -l ) -gt 0 ]; then
+        echo "Found new quality check files in ${QUALITY_CHECK_PATH}"
+
+        cd ${QUALITY_CHECK_PATH}
+        ls -ltr
+
+        git config --global user.email "${USER_EMAIL}"
+        git config --global user.name "${USER_NAME}"
+
+        echo "Checking out ${SOURCE_BRANCH} branch..."
+        git checkout -q ${SOURCE_BRANCH}
+        echo "Pulling last changes..."
+        git pull
+
+        echo "Adding new quality check files..."
+        git add --ignore-errors *.html
+        if [ $(git diff --name-only --cached | wc -l) -gt 0 ]; then
+            echo "Committing changes..."
+            git commit -m "Adding new quality check files"
+            echo "Pushing changes..."
+            git push
+        else
+            echo "No changes to commit"
+        fi
+      else
+        echo No quality check files found in "${QUALITY_CHECK_PATH}"
+      fi
+    displayName: Store quality check files in repository
+    enabled: true
+    condition: ${{ eq(parameters.collectQualityChecks, true) }}
+    env:
+      USER_EMAIL: $(Build.RequestedForEmail)
+      USER_NAME: $(Build.RequestedFor)
+      SOURCE_BRANCH: $(Build.SourceBranchName)
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+      QUALITY_CHECK_PATH: ${{ parameters.qualityCheckPath }}


### PR DESCRIPTION
## Problem

Azure provides a SAP on Azure quality check script in it's https://github.com/Azure/SAP-on-Azure-Scripts-and-Utilities repository
Running this quality check, ensures that misconfigurations on infrastructure might be caught earlier.

## Solution

Implement the Quality Check script, to run against target VMs from the deployer as a separate step in the DB and installation pipeline.

*FIX*: a duplicate code block from a merge has been removed from the 05 pipeline.

*BE AWARE* this PR is closely linked with a [PR](https://github.com/Azure/sap-automation-bootstrap/pull/2) in sap-automation-bootstrap