### PR TITLE
Extend 'root' and 'tmp' logical volumes for SAP CAL integration on RHEL

### DIFF
--- a/deploy/ansible/playbook_sapcal_integration.yaml
+++ b/deploy/ansible/playbook_sapcal_integration.yaml
@@ -1,20 +1,25 @@
 ---
 
-- name:                                   "SAP CAL Integration"
-  hosts:                                  "{{ sap_sid | upper }}_DB  :
-                                           {{ sap_sid | upper }}_SCS :
-                                           {{ sap_sid | upper }}_PAS :
-                                           {{ sap_sid | upper }}_APP"
+- name:                                    "SAP CAL Integration"
+  hosts:                                   "{{ sap_sid | upper }}_DB  :
+                                            {{ sap_sid | upper }}_SCS :
+                                            {{ sap_sid | upper }}_PAS :
+                                            {{ sap_sid | upper }}_APP"
   become:                                  true
   gather_facts:                            true
   vars_files:                              vars/ansible-input-api.yaml
   tasks:
-    - name:                                6.0.0-sapcal-install - Retrieve Resourced Data
+    - name:                                "SAP-CAL Integration"
       become:                              true
       when:
         - ansible_os_family | upper == "SUSE" or ansible_os_family | upper == "REDHAT"
         - enable_sap_cal is defined and enable_sap_cal
       block:
+        - name:                            "6.0.0-sapcal-install - Extend logical volumes"
+          when: ansible_os_family | upper == "REDHAT"
+          ansible.builtin.include_role:
+            name:                          roles-os/1.5.3-disk-setup-sapcal
+
         - name:                            "Retrieve Resource Group Name and ResourceID"
           ansible.builtin.uri:
             url:                           http://169.254.169.254/metadata/instance?api-version=2021-02-01
@@ -114,9 +119,9 @@
             - { key: 'app_physical_hostname',   value: 'APP' }
             - { key: 'app_virtual_hostname',    value: 'APP' }
 
-    - name:                                6.0.0-sapcal-install - CALL SAP CAL API
+    - name:                                "6.0.0-sapcal-install - CALL SAP CAL API"
       when:                                enable_sap_cal is defined and enable_sap_cal
       block:
-        - name:                            Import the 6.0.0-sapcal-install role
+        - name:                            "Import the 6.0.0-sapcal-install role"
           ansible.builtin.import_role:
             name:                          "roles-sap/6.0.0-sapcal-install"

--- a/deploy/ansible/roles-os/1.5.3-disk-setup-sapcal/tasks/main.yml
+++ b/deploy/ansible/roles-os/1.5.3-disk-setup-sapcal/tasks/main.yml
@@ -19,17 +19,17 @@
 #
 
 - name:                                   "Get Volume Group information"
-  ansible.builtin.shell:                  "vgdisplay --units g {{ vg_root }} | grep 'Free  PE / Size' | awk '{print $(NF-1)}'"
+  ansible.builtin.shell:                  set -o pipefail && vgdisplay --units g {{ vg_root }} | grep 'Free  PE / Size' | awk '{print $(NF-1)}'
   register:                               vg_info
   changed_when:                           false
 
 - name:                                   "Extract free size of the VG"
-  set_fact:
+  ansible.builtin.set_fact:
     vg_free_size:                         "{{ vg_info.stdout | float }}"
   when: vg_info is defined and vg_info.stdout is defined
 
 - name:                                   "Check if free size is more than 20 GB"
-  set_fact:
+  ansible.builtin.set_fact:
                                           sufficient_vg_space: "{{ vg_free_size | default(0) | float > 20.0 }}"
   when: vg_free_size is defined
   failed_when: sufficient_vg_space is not defined or not sufficient_vg_space
@@ -62,6 +62,7 @@
 # ------------------<DEBUGGING>-------------------
 - name:                                   "Print recent Volume Group size and Logical Volume information"
   ansible.builtin.shell: |
+                                          set -o pipefail
                                           vgdisplay --units g {{ vg_root }} | grep 'Free  PE / Size' | awk '{print $(NF-1)}'
                                           lvdisplay {{ vg_root }}
   register:                               recent_info

--- a/deploy/ansible/roles-os/1.5.3-disk-setup-sapcal/tasks/main.yml
+++ b/deploy/ansible/roles-os/1.5.3-disk-setup-sapcal/tasks/main.yml
@@ -1,0 +1,74 @@
+---
+
+# /*---------------------------------------------------------------------------8
+# |                                                                            |
+# |                         OS Base Disk Configuration                         |
+# |                                                                            |
+# +------------------------------------4--------------------------------------*/
+# -------------------------------------+---------------------------------------8
+#
+# Task: 1.5.3     - os-disk-setup SAP-CAL
+#
+# -------------------------------------+---------------------------------------8
+
+# # Check the free size of the volume group
+# Extend the logical volumes [tmplv & rootlv] to the required size and resize the FS
+#
+
+# -------------------------------------+---------------------------------------8
+#
+
+- name:                                   "Get Volume Group information"
+  ansible.builtin.shell:                  "vgdisplay --units g {{ vg_root }} | grep 'Free  PE / Size' | awk '{print $(NF-1)}'"
+  register:                               vg_info
+  changed_when:                           false
+
+- name:                                   "Extract free size of the VG"
+  set_fact:
+    vg_free_size:                         "{{ vg_info.stdout | float }}"
+  when: vg_info is defined and vg_info.stdout is defined
+
+- name:                                   "Check if free size is more than 20 GB"
+  set_fact:
+                                          sufficient_vg_space: "{{ vg_free_size | default(0) | float > 20.0 }}"
+  when: vg_free_size is defined
+  failed_when: sufficient_vg_space is not defined or not sufficient_vg_space
+
+# ------------------<DEBUGGING>-------------------
+- name:                                   "Print volume group details"
+  ansible.builtin.debug:
+    msg:
+      - "vg_info:                         {{ vg_info }}"
+      - "vg_free_size:                    {{ vg_free_size }}"
+      - "sufficient_vg_space:             {{ sufficient_vg_space }}"
+    verbosity:                            2
+# ------------------</DEBUGGING>------------------
+
+- name:                                   "Extend the logical volumes and resize the FS"
+  community.general.lvol:
+    vg:                                   "{{ item.vg }}"
+    lv:                                   "{{ item.lv }}"
+    size:                                 "{{ item.size }}"
+    active:                               true
+    state:                                present
+    shrink:                               false
+    resizefs:                             true
+  loop:
+    - { vg: '{{ vg_root }}',    lv: 'rootlv',    size: '{{ lv_root_size }}' }
+    - { vg: '{{ vg_root }}',    lv: 'tmplv',     size: '{{ lv_tmp_size }}'  }
+  when:
+    - sufficient_vg_space is defined and sufficient_vg_space
+
+# ------------------<DEBUGGING>-------------------
+- name:                                   "Print recent Volume Group size and Logical Volume information"
+  ansible.builtin.shell: |
+                                          vgdisplay --units g {{ vg_root }} | grep 'Free  PE / Size' | awk '{print $(NF-1)}'
+                                          lvdisplay {{ vg_root }}
+  register:                               recent_info
+
+- name:                                   "Print volume group details"
+  ansible.builtin.debug:
+    msg:
+      - "vg_info:                         {{ recent_info | to_nice_json }}"
+    verbosity:                            2
+# ------------------</DEBUGGING>------------------

--- a/deploy/ansible/vars/ansible-input-api.yaml
+++ b/deploy/ansible/vars/ansible-input-api.yaml
@@ -258,6 +258,9 @@ enable_ha_monitoring:                   false
 enable_sap_cal:                         false
 calapi_kv:                              ""
 sap_cal_product_name:                   ""
+vg_root:                                "rootvg"
+lv_root_size:                           10g
+lv_tmp_size:                            10g
 # ------------------- End - SAP CAL Integration variables ----------------------8
 
 python_version:                        "python3"


### PR DESCRIPTION
## Problem
During the SAP CAL installation on RHEL, a "no space left" error was encountered due to insufficient space in the rootlv and tmplv logical volumes. This issue happens while extracting binaries, which impeded the successful completion of the installation process.

## Solution
Extended the "rootlv" and "tmplv" logical volumes to ensure sufficient space for the SAP CAL binaries

## Tests
Re-tested the SAP CAL installation to verify that the space issue was resolved and no additional space-related errors occurred.
