### PR TITLE
fix: update the management dns subscription id to saplib sub id, pin azurerm version in lanscape, deployer

### DIFF
--- a/deploy/terraform/run/sap_deployer/providers.tf
+++ b/deploy/terraform/run/sap_deployer/providers.tf
@@ -88,7 +88,7 @@ terraform                              {
                                                                          }
                                                               azurerm =  {
                                                                            source  = "hashicorp/azurerm"
-                                                                           version = ">=3.3"
+                                                                           version = "~> 3.3"
                                                                          }
                                                             }
                                        }

--- a/deploy/terraform/run/sap_landscape/output.tf
+++ b/deploy/terraform/run/sap_landscape/output.tf
@@ -210,7 +210,7 @@ output "privatelink_dns_resourcegroup_name"       {
 
 output "privatelink_dns_subscription_id"          {
                                                    description = "Subscription ID for the PrivateLink Private DNS Zones"
-                                                   value       = coalesce(var.privatelink_dns_subscription_id, var.management_dns_subscription_id)
+                                                   value       = coalesce(var.privatelink_dns_subscription_id, var.management_dns_subscription_id, local.saplib_subscription_id)
                                                  }
 
 

--- a/deploy/terraform/run/sap_landscape/output.tf
+++ b/deploy/terraform/run/sap_landscape/output.tf
@@ -200,7 +200,7 @@ output "management_dns_resourcegroup_name"       {
 
 output "management_dns_subscription_id"          {
                                                    description = "Subscription ID for the public Private DNS Zone"
-                                                   value       = coalesce(var.management_dns_subscription_id, local.deployer_subscription_id)
+                                                   value       = coalesce(var.management_dns_subscription_id, local.saplib_subscription_id)
                                                  }
 
 output "privatelink_dns_resourcegroup_name"       {

--- a/deploy/terraform/run/sap_landscape/output.tf
+++ b/deploy/terraform/run/sap_landscape/output.tf
@@ -200,7 +200,7 @@ output "management_dns_resourcegroup_name"       {
 
 output "management_dns_subscription_id"          {
                                                    description = "Subscription ID for the public Private DNS Zone"
-                                                   value       = var.management_dns_subscription_id
+                                                   value       = coalesce(var.management_dns_subscription_id, local.deployer_subscription_id)
                                                  }
 
 output "privatelink_dns_resourcegroup_name"       {

--- a/deploy/terraform/run/sap_landscape/providers.tf
+++ b/deploy/terraform/run/sap_landscape/providers.tf
@@ -116,7 +116,7 @@ terraform                              {
                                                                          }
                                                               azurerm =  {
                                                                            source  = "hashicorp/azurerm"
-                                                                           version = ">=3.3"
+                                                                           version = "~> 3.3"
                                                                          }
                                                               azapi =    {
                                                                            source  = "Azure/azapi"

--- a/deploy/terraform/run/sap_library/providers.tf
+++ b/deploy/terraform/run/sap_library/providers.tf
@@ -108,7 +108,7 @@ terraform                              {
                                                                          }
                                                               azurerm =  {
                                                                            source  = "hashicorp/azurerm"
-                                                                           version = ">=3.3"
+                                                                           version = "~> 3.3"
                                                                          }
                                                             }
                                        }

--- a/deploy/terraform/terraform-units/modules/sap_landscape/providers.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/providers.tf
@@ -3,7 +3,7 @@ terraform {
     azurerm = {
       source                = "hashicorp/azurerm"
       configuration_aliases = [azurerm.main, azurerm.deployer, azurerm.dnsmanagement, azurerm.peering]
-      version               = ">= 3.23"
+      version               = "~> 3.23"
     }
 
     azapi = {


### PR DESCRIPTION
## Problem
If the user has not provided the management dns subscription id and private dns subsricption id, the lanscape and system deployment is failing because of null variables.

## Solution
Use the sap library subscription id as the default subscription id if the user has not defined the management/private dns subscription id.

## Tests
Ran the landscape and system deployment pipeline without defining the management/private dns subscription id. 
