### PR TITLE
Configure constraint HANA ANF mounts only when HANA mountpoints are used

### DIFF
--- a/deploy/ansible/roles-sap/5.5-hanadb-pacemaker/tasks/5.5.4.1-cluster-RedHat.yml
+++ b/deploy/ansible/roles-sap/5.5-hanadb-pacemaker/tasks/5.5.4.1-cluster-RedHat.yml
@@ -158,6 +158,12 @@
         - database_high_availability
         - NFS_provider == "ANF"
         - ansible_hostname == primary_instance_name
+        - hana_data_mountpoint is defined
+        - hana_data_mountpoint | length > 1
+        - hana_log_mountpoint is defined
+        - hana_log_mountpoint | length > 1
+        - hana_shared_mountpoint is defined
+        - hana_shared_mountpoint | length > 1
       block:
         - name:                        "5.5.4.1 HANA Cluster configuration - configure constraints between SAP HANA resources and NFS mounts"
           ansible.builtin.shell:       pcs constraint location SAPHanaTopology_{{ db_sid | upper }}_{{ db_instance_number }}-clone rule score=-INFINITY attr_hana_{{ db_sid | upper }}_NFS_1_active ne true and attr_hana_{{ db_sid | upper }}_NFS_2_active ne true
@@ -168,18 +174,16 @@
           ansible.builtin.shell:       pcs constraint location SAPHana_{{ db_sid | upper }}_{{ db_instance_number }}-master rule score=-INFINITY attr_hana_{{ db_sid | upper }}_NFS_1_active ne true and attr_hana_{{ db_sid | upper }}_NFS_2_active ne true
           register:                    constraint
           failed_when:                 constraint.rc > 1
-          when:
-            - ansible_distribution_major_version == "7"
+          when: ansible_distribution_major_version == "7"
 
         - name:                        "5.5.4.1 HANA Cluster configuration - configure constraints on RHEL 8.x or 9.x"
-          when:
-            - ansible_distribution_major_version in ["8", "9"]
+          when: ansible_distribution_major_version in ["8", "9"]
           block:
             - name:                    "5.5.4.1 HANA Cluster configuration - configure location constraints on RHEL 8.x or 9.x"
               ansible.builtin.shell: >
                                        pcs constraint location SAPHana_{{ db_sid | upper }}_{{ db_instance_number }}-clone rule score=-INFINITY attr_hana_{{ db_sid | upper }}_NFS_1_active ne true and attr_hana_{{ db_sid | upper }}_NFS_2_active ne true
-              register:                    constraint
-              failed_when:                 constraint.rc > 1
+              register:                constraint
+              failed_when:             constraint.rc > 1
 
             - name:                    "5.5.4.1 HANA Cluster configuration - configure ordering constraints for SAPHana clone RHEL 8.x or 9.x"
               ansible.builtin.shell: >


### PR DESCRIPTION
## Problem
When using ANF for the deployment without data, log and shared mountpoint on ANF the constraint shouldn't be configured. Otherwise HANA won't start.

## Solution
Check for valid hana_*_mountpoint variables.

## Tests

## Notes
