### PR TITLE
Add support for HANA only deployments

### DIFF
--- a/deploy/ansible/playbook_00_validate_parameters.yaml
+++ b/deploy/ansible/playbook_00_validate_parameters.yaml
@@ -522,7 +522,7 @@
           - "scs_instance_number != db_instance_number"
         fail_msg:                      "Please ensure that the scs_instance_number is different from the db_instance_number when performing a standalone installation"
       when:
-        - (ansible_play_hosts_all | length) == 1
+        - single_server
         - platform == "HANA"
       tags:
                                        - always
@@ -530,7 +530,7 @@
 
     - name:                            "0.0 Validations - Validate SCS and HDB SIDs"
       when:
-        - (ansible_play_hosts_all | length) == 1
+        - single_server
         - platform != "ORACLE"
       ansible.builtin.assert:
         that:
@@ -554,7 +554,7 @@
         that:
           - scs_instance_number != pas_instance_number
         fail_msg:                      "Please ensure that the pas_instance_number is different from the scs_instance_number on standalone installation"
-      when:                            (ansible_play_hosts_all | length) == 1
+      when:                            single_server
       tags:
                                        - always
                                        - 0.0-scs-pas-single
@@ -564,7 +564,7 @@
         that:
           - db_instance_number != pas_instance_number
         fail_msg:                      "Please ensure that the pas_instance_number is different from the db_instance_number on standalone installation"
-      when:                            (ansible_play_hosts_all | length) == 1
+      when:                            single_server
       tags:
                                        - always
                                        - 0.0-scs-pas-db-single

--- a/deploy/ansible/playbook_01_os_base_config.yaml
+++ b/deploy/ansible/playbook_01_os_base_config.yaml
@@ -77,13 +77,6 @@
       become:                          true
       become_user:                     "root"
       block:
-
-        - name:                        "OS configuration playbook: - Set deployment type"
-          ansible.builtin.set_fact:
-            single_server:              "{{ (ansible_play_hosts_all | length) == 1 }}"
-          tags:
-            - always
-
         - name:                        "OS configuration playbook: - Set os fact"
           ansible.builtin.set_fact:
             tier: os

--- a/deploy/ansible/playbook_02_os_sap_specific_config.yaml
+++ b/deploy/ansible/playbook_02_os_sap_specific_config.yaml
@@ -80,13 +80,6 @@
 #
 # -------------------------------------+---------------------------------------8
   tasks:
-
-    - name:                            "SAP OS Configuration: - Set deployment type"
-      ansible.builtin.set_fact:
-        single_server:                 "{{ (ansible_play_hosts_all | length) == 1 }}"
-      tags:
-        - always
-
     - name:                            "SAP OS Configuration - Linux based systems"
       become:                          true
       become_user:                     "root"

--- a/deploy/ansible/playbook_03_bom_processing.yaml
+++ b/deploy/ansible/playbook_03_bom_processing.yaml
@@ -59,7 +59,12 @@
 # -------------------------------------+---------------------------------------8
     - name:                            "Perform BoM processing"
       when:
-        - "'scs' in supported_tiers"
+        # run on SCS or the when no SCS is defined run on the first DB server to support HANA only install
+        - "'scs' in supported_tiers or (
+            platform == 'HANA' and
+            (groups[sap_sid | upper ~ '_SCS'] is not defined or groups[sap_sid | upper ~ '_SCS'] | length == 0) and
+            inventory_hostname == (groups[sap_sid | upper ~ '_DB'] | sort)[0]
+          )"
       block:
 
         - name:                        Set facts

--- a/deploy/ansible/playbook_05_00_00_sap_scs_install.yaml
+++ b/deploy/ansible/playbook_05_00_00_sap_scs_install.yaml
@@ -239,7 +239,7 @@
                   - "scs_instance_number != db_instance_number"
                 fail_msg:              "Please ensure that the scs_instance_number is different from the db_instance_number"
           when:
-            - (ansible_play_hosts_all | length) == 1
+            - single_server
             - platform == "HANA"
 
         - name:                        "SCS Installation Playbook: - Set 'scs' tier facts"

--- a/deploy/ansible/playbook_05_01_sap_dbload.yaml
+++ b/deploy/ansible/playbook_05_01_sap_dbload.yaml
@@ -91,13 +91,6 @@
           tags:
             - always
 
-        - name:                        "DBLoad Playbook: - Set deployment type"
-          ansible.builtin.set_fact:
-            single_server:              "{{ (ansible_play_hosts_all | length) == 1 }}"
-          tags:
-            - always
-
-
         - name:                    "DBLoad Playbook: - Mounting"
           ansible.builtin.include_role:
             name:                  roles-sap-os/2.6-sap-mounts

--- a/deploy/ansible/playbook_05_02_sap_pas_install.yaml
+++ b/deploy/ansible/playbook_05_02_sap_pas_install.yaml
@@ -156,12 +156,6 @@
       tags:
         - always
 
-    - name:                            "PAS Installation Playbook: - Set deployment type"
-      ansible.builtin.set_fact:
-        single_server:                  "{{ (ansible_play_hosts_all | length) == 1 }}"
-      tags:
-        - always
-
     - name:                            "PAS Installation Playbook: Define this SID"
       ansible.builtin.set_fact:
         this_sid:

--- a/deploy/ansible/playbook_05_03_sap_app_install.yaml
+++ b/deploy/ansible/playbook_05_03_sap_app_install.yaml
@@ -96,13 +96,6 @@
           ansible.builtin.set_fact:
             all_sids:                      "{% if MULTI_SIDS is defined %}{{ MULTI_SIDS }}{% else %}{{ all_sids | default([]) + [this_sid] }}{% endif %}"
 
-        - name:                            "APP Installation Playbook: - Set deployment type"
-          ansible.builtin.set_fact:
-            single_server:                  "{{ (ansible_play_hosts_all | length) == 1 }}"
-          tags:
-            - always
-
-
         - name:                            Generic Users and Groups for SAP Installation
           ansible.builtin.include_role:
             name:                          roles-sap-os/2.5-sap-users

--- a/deploy/ansible/roles-sap-os/2.4-hosts-file/tasks/main.yaml
+++ b/deploy/ansible/roles-sap-os/2.4-hosts-file/tasks/main.yaml
@@ -153,7 +153,7 @@
         pas_virtualhost_from_inventory: "{{ pas_server_temp | first }}"
         pas_virtual_hostname:           "{{ custom_pas_virtual_hostname | default( pas_server_temp | first , true) }}"
       when:
-        - pas_server_temp | length > 0
+        - pas_server_temp | default([]) | length > 0
 
     - name:                            "2.4 Hosts: - Display the variables being used"
       ansible.builtin.debug:
@@ -162,7 +162,7 @@
           - "custom_pas_hostname:      {{ custom_pas_virtual_hostname }} "
           - "virtualhost_in_inventory: {{ pas_virtualhost_from_inventory }}"
       when:
-        - pas_server_temp | length > 0
+        - pas_server_temp | default([]) | length > 0
 
     - name:                            "2.4 Hosts: - Get the line from /etc/hosts with virtual_host"
       ansible.builtin.slurp:


### PR DESCRIPTION
## Problem
It should be possible to deploy HANA only (both single as high available) deployments with SDAF.

## Solution
Add support for HANA only deployments where only HANA is installed and with the high available deployment HSR is set-up.

## Tests
- Tested with RHEL 8.10 single HANA deployment
- Tested with RHEL 8.10 HA HANA deployment

## Notes
For single server deployments SDAF will now only look at the `single_server` variable instead of the amount of hosts in the Ansible inventory.