### PR TITLE
Enable setting custom local mountpoint options for HANA/DB2

### DIFF
--- a/deploy/ansible/roles-os/1.5-disk-setup/tasks/main.yml
+++ b/deploy/ansible/roles-os/1.5-disk-setup/tasks/main.yml
@@ -67,7 +67,7 @@
 
 - name:                                "1.5 Disk setup - Append 'hanashared' if needed"
   ansible.builtin.set_fact:
-    logical_volumes:                   "{{ logical_volumes_hanashared + logical_volumes }}"
+    logical_volumes:                   "{{ logical_volumes_hanashared | default([]) + logical_volumes }}"
   when:
     - hana_shared_mountpoint is undefined or hana_shared_mountpoint | length == 0
 

--- a/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.4-db2-mounts.yaml
+++ b/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.4-db2-mounts.yaml
@@ -52,7 +52,7 @@
                                         {%- endif -%}
                                         {{- _path -}}
     fstype:                            "{{ item.fstype }}"
-    opts:                              defaults
+    opts:                              "{{ item.mntopts | default('defaults') }}"
     state:                             mounted
   loop:                                "{{ logical_volumes | sort(attribute='lv') }}"
   register:  db2fsmounts

--- a/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/main.yaml
+++ b/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/main.yaml
@@ -71,7 +71,7 @@
     src:                               /dev/vg_sap/lv_usrsap
     path:                              /usr/sap
     fstype:                            xfs
-    opts:                              defaults
+    opts:                              "{{ logical_volumes | selectattr('lv', 'equalto', 'lv_usrsap') | map(attribute='mntopts') | first | default('defaults') }}"
     state:                             mounted
   when:
     - sap_disk_exists == '1'
@@ -95,7 +95,7 @@
     src:                               "{{ sharedpath }}"
     path:                              /hana/shared
     fstype:                            xfs
-    opts:                              defaults
+    opts:                              "{{ logical_volumes | selectattr('lv', 'equalto', 'lv_hana_shared') | map(attribute='mntopts') | first | default('defaults') }}"
     state:                             mounted
   when:
     - node_tier == 'hana'
@@ -106,7 +106,7 @@
     src:                               /dev/vg_hana_backup/lv_hana_backup
     path:                              '{{ hana_backup_path }}'
     fstype:                            xfs
-    opts:                              defaults
+    opts:                              "{{ logical_volumes | selectattr('lv', 'equalto', 'lv_hana_backup') | map(attribute='mntopts') | first | default('defaults') }}"
     state:                             mounted
   when:
     - node_tier == 'hana'
@@ -126,7 +126,7 @@
     src:                               /dev/vg_hana_data/lv_hana_data
     path:                              /hana/data
     fstype:                            xfs
-    opts:                              defaults
+    opts:                              "{{ logical_volumes | selectattr('lv', 'equalto', 'lv_hana_data') | map(attribute='mntopts') | first | default('defaults') }}"
     state:                             mounted
   when:
     - node_tier == 'hana'
@@ -137,7 +137,7 @@
     src:                               /dev/vg_hana_log/lv_hana_log
     path:                              /hana/log
     fstype:                            xfs
-    opts:                              defaults
+    opts:                              "{{ logical_volumes | selectattr('lv', 'equalto', 'lv_hana_log') | map(attribute='mntopts') | first | default('defaults') }}"
     state:                             mounted
   when:
     - node_tier == 'hana'


### PR DESCRIPTION
## Problem
Due to RHEL 8 security baseline requirements, we need to set custom mountpoint options for HANA and DB2 local filesystems and `/usr/sap`. Currently, the Framework doesn't support this, mountpoint options for said filesystems being hardcoded to `defaults`.

## Solution
Relevant tasks in role 2.6-sap-mounts have been adjusted, so that, when the variable `mntopts` is present in the disk config, the desired options are set, otherwise they default to `defaults`.

## Tests
Tested with non-HA HANA and DB2 ABAP deployments.

## Notes
none