### PR TITLE
Allow the deployment to use the sap library and the state file storage account using User delegated SAS keys

### DIFF
--- a/deploy/ansible/roles-misc/0.3.sap-installation-media-storage-details/tasks/main.yaml
+++ b/deploy/ansible/roles-misc/0.3.sap-installation-media-storage-details/tasks/main.yaml
@@ -80,6 +80,7 @@
 - name:                                "0.4 Installation Media: - Save SAP Binaries Storage Account information"
   ansible.builtin.set_fact:
     account_name:                      "{{ sapbits_location_base_path.rpartition('//')[2].split('.')[0] }}"
+    container_name:                    "{{ sapbits_location_base_path.rpartition('//')[2].split('/')[1] }}"
   when:                                sapbits_location_base_path is defined
 
 - name:                                "0.4 Installation Media: - Extract Shared Key Access token flag"
@@ -232,6 +233,7 @@
       ansible.builtin.command: >-
                                        az storage account generate-sas \
                                          --account-name {{ account_name }} \
+                                         --name {{ container_name }} \
                                          --expiry {{ expiry.stdout }} \
                                          --permissions lr \
                                          --auth-mode login \

--- a/deploy/ansible/roles-misc/0.3.sap-installation-media-storage-details/tasks/main.yaml
+++ b/deploy/ansible/roles-misc/0.3.sap-installation-media-storage-details/tasks/main.yaml
@@ -229,9 +229,9 @@
       ansible.builtin.command:          "date +'%Y-%m-%d' -d '+3 days'"
       register:                         expiry
 
-    - name:                            "0.4 Installation Media: - Create SAP Binaries Storage Account SAS in Control Plane subscription"
+    - name:                            "0.4 Installation Media: - Create USer delegation SAP Binaries Storage Account SAS in Control Plane subscription"
       ansible.builtin.command: >-
-                                       az storage account generate-sas \
+                                       az storage container generate-sas \
                                          --account-name {{ account_name }} \
                                          --name {{ container_name }} \
                                          --expiry {{ expiry.stdout }} \

--- a/deploy/pipelines/02-sap-workload-zone.yaml
+++ b/deploy/pipelines/02-sap-workload-zone.yaml
@@ -123,6 +123,16 @@ stages:
                 if [ ! -f /etc/profile.d/deploy_server.sh ]; then
                   echo -e "$green --- Install dos2unix ---$reset"
                   sudo apt-get -qq install dos2unix
+                  echo -e "$green --- Install terraform ---$reset"
+
+                  wget -q $(tf_url)
+                  return_code=$?
+                  if [ 0 != $return_code ]; then
+                    echo "##vso[task.logissue type=error]Unable to download Terraform version $(tf_version)."
+                    exit 2
+                  fi
+                  unzip -qq terraform_$(tf_version)_linux_amd64.zip ; sudo mv terraform /bin/
+                  rm -f terraform_$(tf_version)_linux_amd64.zip
                 else
                   source /etc/profile.d/deploy_server.sh
                 fi
@@ -190,9 +200,18 @@ stages:
                 ENVIRONMENT=$(grep "^environment" LANDSCAPE/$(workload_zone_folder)/$(workload_zone_configuration_file) | awk -F'=' '{print $2}' | xargs)
                    LOCATION=$(grep "^location" LANDSCAPE/$(workload_zone_folder)/$(workload_zone_configuration_file) | awk -F'=' '{print $2}' | xargs | tr 'A-Z' 'a-z')
                     NETWORK=$(grep "^network_logical_name" LANDSCAPE/$(workload_zone_folder)/$(workload_zone_configuration_file) | awk -F'=' '{print $2}' | xargs)
-                echo Environment: ${ENVIRONMENT}
-                echo Location:    ${LOCATION}
-                echo Network:     ${NETWORK}
+                echo Environment:     ${ENVIRONMENT}
+                echo Location:        ${LOCATION}
+                echo Network:         ${NETWORK}
+                echo "TFvars          $workload_zone_configuration_file"
+                echo ""
+                echo "Agent:          $(this_agent)"
+                echo "Organization:   $(System.CollectionUri)"
+                echo "Project:        $(System.TeamProject)"
+                echo ""
+                echo "Azure CLI version:"
+                echo "-------------------------------------------------"
+                az --version
 
                 ENVIRONMENT_IN_FILENAME=$(echo $(workload_zone_folder) | awk -F'-' '{print $1}' | xargs )
                           LOCATION_CODE=$(echo $(workload_zone_folder) | awk -F'-' '{print $2}' | xargs )
@@ -381,42 +400,17 @@ stages:
                 fi
 
               secrets_set=1
-              if [ ! -f /etc/profile.d/deploy_server.sh ]; then
-                echo -e "$green --- Install terraform ---$reset"
-
-                wget -q $(tf_url)
-                return_code=$?
-                if [ 0 != $return_code ]; then
-                  echo "##vso[task.logissue type=error]Unable to download Terraform version $(tf_version)."
-                  exit 2
-                fi
-                unzip -qq terraform_$(tf_version)_linux_amd64.zip ; sudo mv terraform /bin/
-                rm -f terraform_$(tf_version)_linux_amd64.zip
-
-                if [ $USE_MSI != "true" ]; then
-                  export ARM_CLIENT_ID=$WL_ARM_CLIENT_ID
-                  export ARM_CLIENT_SECRET=$WL_ARM_CLIENT_SECRET
-                  export ARM_TENANT_ID=$WL_ARM_TENANT_ID
-                  export ARM_SUBSCRIPTION_ID=$WL_ARM_SUBSCRIPTION_ID
-                  export ARM_USE_MSI=false
-
-                  echo -e "$green--- az login ---$reset"
-                    az login --service-principal --username $CP_ARM_CLIENT_ID --password=$CP_ARM_CLIENT_SECRET --tenant $CP_ARM_TENANT_ID --output none
-                    return_code=$?
-                    if [ 0 != $return_code ]; then
-                      echo -e "$boldred--- Login failed ---$reset"
-                      echo "##vso[task.logissue type=error]az login failed."
-                      exit $return_code
-                    fi
-                  fi
-
-              else
-                echo -e "$green--- az login ---$reset"
+              echo -e "$green--- az login ---$reset"
 
                   if [ $LOGON_USING_SPN == "true" ]; then
                     echo "Using SPN"
                     az login --service-principal --username $CP_ARM_CLIENT_ID --password=$CP_ARM_CLIENT_SECRET --tenant $CP_ARM_TENANT_ID --output none
                   else
+                    echo "Using MSI"
+                    export ARM_USE_MSI=true
+                    export ARM_SUBSCRIPTION_ID=$WL_ARM_SUBSCRIPTION_ID
+                    unset ARM_TENANT_ID
+
                     az login --identity --allow-no-subscriptions --output none
                   fi
 

--- a/deploy/pipelines/02-sap-workload-zone.yaml
+++ b/deploy/pipelines/02-sap-workload-zone.yaml
@@ -402,34 +402,33 @@ stages:
               secrets_set=1
               echo -e "$green--- az login ---$reset"
 
-                  if [ $LOGON_USING_SPN == "true" ]; then
-                    echo "Using SPN"
-                    az login --service-principal --username $CP_ARM_CLIENT_ID --password=$CP_ARM_CLIENT_SECRET --tenant $CP_ARM_TENANT_ID --output none
-                  else
-                    echo "Using MSI"
-                    export ARM_USE_MSI=true
-                    export ARM_SUBSCRIPTION_ID=$WL_ARM_SUBSCRIPTION_ID
-                    unset ARM_TENANT_ID
+                if [ $LOGON_USING_SPN == "true" ]; then
+                  echo "Using SPN"
+                  az login --service-principal --username $CP_ARM_CLIENT_ID --password=$CP_ARM_CLIENT_SECRET --tenant $CP_ARM_TENANT_ID --output none
+                else
+                  echo "Using MSI"
+                  export ARM_USE_MSI=true
+                  export ARM_SUBSCRIPTION_ID=$WL_ARM_SUBSCRIPTION_ID
+                  unset ARM_TENANT_ID
 
-                    az login --identity --allow-no-subscriptions --output none
-                  fi
-
-                  return_code=$?
-                  if [ 0 != $return_code ]; then
-                    echo -e "$boldred--- Login failed ---$reset"
-                    echo "##vso[task.logissue type=error]az login failed."
-                    exit $return_code
-                  fi
-
-                if [ $USE_MSI != "true" ]; then
-                  echo -e "$green --- Set secrets ---$reset"
-
-                  $SAP_AUTOMATION_REPO_PATH/deploy/scripts/set_secrets.sh --workload --vault "${key_vault}" --environment "${ENVIRONMENT}"  \
-                    --region "${LOCATION}" --subscription $WL_ARM_SUBSCRIPTION_ID --spn_id $WL_ARM_CLIENT_ID --spn_secret "${WL_ARM_CLIENT_SECRET}"      \
-                    --tenant_id $WL_ARM_TENANT_ID --keyvault_subscription $STATE_SUBSCRIPTION
-                  secrets_set=$? ; echo -e "$cyan Set Secrets returned $secrets_set $reset"
-                  az keyvault set-policy --name "${key_vault}" --object-id $WL_ARM_OBJECT_ID --secret-permissions get list  --subscription $STATE_SUBSCRIPTION --output none
+                  az login --identity --allow-no-subscriptions --output none
                 fi
+
+                return_code=$?
+                if [ 0 != $return_code ]; then
+                  echo -e "$boldred--- Login failed ---$reset"
+                  echo "##vso[task.logissue type=error]az login failed."
+                  exit $return_code
+                fi
+
+              if [ $USE_MSI != "true" ]; then
+                echo -e "$green --- Set secrets ---$reset"
+
+                $SAP_AUTOMATION_REPO_PATH/deploy/scripts/set_secrets.sh --workload --vault "${key_vault}" --environment "${ENVIRONMENT}"  \
+                  --region "${LOCATION}" --subscription $WL_ARM_SUBSCRIPTION_ID --spn_id $WL_ARM_CLIENT_ID --spn_secret "${WL_ARM_CLIENT_SECRET}"      \
+                  --tenant_id $WL_ARM_TENANT_ID --keyvault_subscription $STATE_SUBSCRIPTION
+                secrets_set=$? ; echo -e "$cyan Set Secrets returned $secrets_set $reset"
+                az keyvault set-policy --name "${key_vault}" --object-id $WL_ARM_OBJECT_ID --secret-permissions get list  --subscription $STATE_SUBSCRIPTION --output none
               fi
 
               debug_variable='--output none'

--- a/deploy/scripts/install_workloadzone.sh
+++ b/deploy/scripts/install_workloadzone.sh
@@ -418,13 +418,14 @@ fi
 
 useSAS=$(az storage account show  --name  "${REMOTE_STATE_SA}"   --query allowSharedKeyAccess --subscription "${STATE_SUBSCRIPTION}" --out tsv)
 
-echo "Use SAS: " $useSAS
-
 if [ "$useSAS" = "true" ] ; then
+  echo "Authenticate storage using SAS"
   export ARM_USE_AZUREAD=false
 else
+  echo "Authenticate storage using Entra ID"
   export ARM_USE_AZUREAD=true
 fi
+
 
 if [ 1 = "${deploy_using_msi_only:-}" ]; then
   if [ -n "${keyvault}" ]

--- a/deploy/scripts/install_workloadzone.sh
+++ b/deploy/scripts/install_workloadzone.sh
@@ -416,6 +416,16 @@ else
     fi
 fi
 
+useSAS=$(az storage account show  --name  "${REMOTE_STATE_SA}"   --query allowSharedKeyAccess --subscription "${STATE_SUBSCRIPTION}" --out tsv)
+
+echo "Use SAS: " $useSAS
+
+if [ "$useSAS" = "true" ] ; then
+  export ARM_USE_AZUREAD=false
+else
+  export ARM_USE_AZUREAD=true
+fi
+
 if [ 1 = "${deploy_using_msi_only:-}" ]; then
   if [ -n "${keyvault}" ]
   then

--- a/deploy/scripts/installer.sh
+++ b/deploy/scripts/installer.sh
@@ -263,8 +263,10 @@ fi
 useSAS=$(az storage account show  --name  "${REMOTE_STATE_SA}"   --query allowSharedKeyAccess --subscription "${STATE_SUBSCRIPTION}" --out tsv)
 
 if [ "$useSAS" = "true" ] ; then
+  echo "Authenticate storage using SAS"
   export ARM_USE_AZUREAD=false
 else
+  echo "Authenticate storage using Entra ID"
   export ARM_USE_AZUREAD=true
 fi
 

--- a/deploy/scripts/remove_controlplane.sh
+++ b/deploy/scripts/remove_controlplane.sh
@@ -241,6 +241,16 @@ fi
 
 key=$(echo "${deployer_file_parametername}" | cut -d. -f1)
 
+useSAS=$(az storage account show  --name  "${REMOTE_STATE_SA}"   --query allowSharedKeyAccess --subscription "${STATE_SUBSCRIPTION}" --out tsv)
+
+if [ "$useSAS" = "true" ] ; then
+  echo "Authenticate storage using SAS"
+  export ARM_USE_AZUREAD=false
+else
+  echo "Authenticate storage using Entra ID"
+  export ARM_USE_AZUREAD=true
+fi
+
 # Reinitialize
 echo ""
 echo "#########################################################################################"

--- a/deploy/scripts/remover.sh
+++ b/deploy/scripts/remover.sh
@@ -299,6 +299,17 @@ if [ -f backend.tf ]; then
     rm backend.tf
 fi
 
+useSAS=$(az storage account show  --name  "${REMOTE_STATE_SA}"   --query allowSharedKeyAccess --subscription "${STATE_SUBSCRIPTION}" --out tsv)
+
+if [ "$useSAS" = "true" ] ; then
+  echo "Authenticate storage using SAS"
+  export ARM_USE_AZUREAD=false
+else
+  echo "Authenticate storage using Entra ID"
+  export ARM_USE_AZUREAD=true
+fi
+
+
 echo ""
 echo "#########################################################################################"
 echo "#                                                                                       #"

--- a/deploy/terraform/bootstrap/sap_library/tfvar_variables.tf
+++ b/deploy/terraform/bootstrap/sap_library/tfvar_variables.tf
@@ -220,7 +220,7 @@ variable "spn_keyvault_id"                      {
 
 variable "shared_access_key_enabled"            {
                                                   description = "Indicates whether the storage account permits requests to be authorized with the account access key via Shared Key."
-                                                  default     = true
+                                                  default     = false
                                                   type        = bool
                                                 }
 

--- a/deploy/terraform/run/sap_landscape/providers.tf
+++ b/deploy/terraform/run/sap_landscape/providers.tf
@@ -68,7 +68,7 @@ provider "azurerm"                     {
                                          client_secret              = var.use_spn ? local.cp_spn.client_secret : null
                                          tenant_id                  = var.use_spn ? local.cp_spn.tenant_id : null
                                          use_msi                    = var.use_spn ? false : true
-                                         storage_use_azuread = true
+                                         storage_use_azuread        = true
 
                                        }
 
@@ -80,7 +80,7 @@ provider "azurerm"                     {
                                          client_secret              = var.use_spn ? local.cp_spn.client_secret : null
                                          tenant_id                  = var.use_spn ? local.cp_spn.tenant_id : null
                                          alias                      = "peering"
-                                         storage_use_azuread = true
+                                         storage_use_azuread        = true
 
                                        }
 

--- a/deploy/terraform/run/sap_landscape/providers.tf
+++ b/deploy/terraform/run/sap_landscape/providers.tf
@@ -38,8 +38,8 @@ provider "azurerm"                     {
                                          use_msi             = var.use_spn ? false : true
                                          storage_use_azuread = true
 
-                                         partner_id = "25c87b5f-716a-4067-bcd8-116956916dd6"
-                                         alias      = "workload"
+                                         partner_id          = "25c87b5f-716a-4067-bcd8-116956916dd6"
+                                         alias               = "workload"
 
                                        }
 
@@ -51,6 +51,7 @@ provider "azurerm"                     {
                                          client_secret              = var.use_spn ? local.cp_spn.client_secret : null
                                          tenant_id                  = var.use_spn ? local.cp_spn.tenant_id : null
                                          use_msi                    = var.use_spn ? false : true
+                                         storage_use_azuread = true
 
                                        }
 
@@ -67,6 +68,7 @@ provider "azurerm"                     {
                                          client_secret              = var.use_spn ? local.cp_spn.client_secret : null
                                          tenant_id                  = var.use_spn ? local.cp_spn.tenant_id : null
                                          use_msi                    = var.use_spn ? false : true
+                                         storage_use_azuread = true
 
                                        }
 
@@ -78,6 +80,7 @@ provider "azurerm"                     {
                                          client_secret              = var.use_spn ? local.cp_spn.client_secret : null
                                          tenant_id                  = var.use_spn ? local.cp_spn.tenant_id : null
                                          alias                      = "peering"
+                                         storage_use_azuread = true
 
                                        }
 

--- a/deploy/terraform/run/sap_library/tfvar_variables.tf
+++ b/deploy/terraform/run/sap_library/tfvar_variables.tf
@@ -224,7 +224,7 @@ variable "deployment"                           {
 
 variable "shared_access_key_enabled"            {
                                                   description = "Indicates whether the storage account permits requests to be authorized with the account access key via Shared Key."
-                                                  default     = true
+                                                  default     = false
                                                   type        = bool
                                                 }
 

--- a/deploy/terraform/run/sap_system/providers.tf
+++ b/deploy/terraform/run/sap_system/providers.tf
@@ -14,7 +14,8 @@
 
 provider "azurerm"                     {
                                          features {}
-                                         subscription_id = length(local.deployer_subscription_id) > 0 ? local.deployer_subscription_id : null
+                                         subscription_id     = length(local.deployer_subscription_id) > 0 ? local.deployer_subscription_id : null
+                                         storage_use_azuread = true
                                        }
 
 provider "azurerm"                     {
@@ -29,38 +30,40 @@ provider "azurerm"                     {
                                                                  purge_soft_deleted_certificates_on_destroy = !var.enable_purge_control_for_keyvaults
                                                               }
                                                   }
-                                         subscription_id = data.azurerm_key_vault_secret.subscription_id.value
-                                         client_id       = try(data.terraform_remote_state.landscape.outputs.use_spn, true) && var.use_spn ? local.spn.client_id : null
-                                         client_secret   = try(data.terraform_remote_state.landscape.outputs.use_spn, true) && var.use_spn ? local.spn.client_secret : null
-                                         tenant_id       = try(data.terraform_remote_state.landscape.outputs.use_spn, true) && var.use_spn ? local.spn.tenant_id : null
-                                         use_msi         = try(data.terraform_remote_state.landscape.outputs.use_spn, true) && var.use_spn ? false : true
+                                         subscription_id     = data.azurerm_key_vault_secret.subscription_id.value
+                                         client_id           = try(data.terraform_remote_state.landscape.outputs.use_spn, true) && var.use_spn ? local.spn.client_id : null
+                                         client_secret       = try(data.terraform_remote_state.landscape.outputs.use_spn, true) && var.use_spn ? local.spn.client_secret : null
+                                         tenant_id           = try(data.terraform_remote_state.landscape.outputs.use_spn, true) && var.use_spn ? local.spn.tenant_id : null
+                                         use_msi             = try(data.terraform_remote_state.landscape.outputs.use_spn, true) && var.use_spn ? false : true
 
-                                         partner_id = "3179cd51-f54b-4c73-ac10-8e99417efce7"
+                                         partner_id          = "3179cd51-f54b-4c73-ac10-8e99417efce7"
                                          storage_use_azuread = true
-                                         alias      = "system"
+                                         alias               = "system"
 
                                        }
 
 provider "azurerm"                     {
                                          features {}
-                                         alias                      = "dnsmanagement"
-                                         subscription_id            = coalesce(try(data.terraform_remote_state.landscape.outputs.management_dns_subscription_id,""), var.management_dns_subscription_id, length(local.deployer_subscription_id) > 0 ? local.deployer_subscription_id : "")
-                                         client_id                  = try(data.terraform_remote_state.landscape.outputs.use_spn, true) && var.use_spn ? local.cp_spn.client_id : null
-                                         client_secret              = try(data.terraform_remote_state.landscape.outputs.use_spn, true) && var.use_spn ? local.cp_spn.client_secret : null
-                                         tenant_id                  = try(data.terraform_remote_state.landscape.outputs.use_spn, true) && var.use_spn ? local.cp_spn.tenant_id : null
-                                         use_msi                    = try(data.terraform_remote_state.landscape.outputs.use_spn, true) && var.use_spn ? false : true
+                                         alias               = "dnsmanagement"
+                                         subscription_id     = coalesce(try(data.terraform_remote_state.landscape.outputs.management_dns_subscription_id,""), var.management_dns_subscription_id, length(local.deployer_subscription_id) > 0 ? local.deployer_subscription_id : "")
+                                         client_id           = try(data.terraform_remote_state.landscape.outputs.use_spn, true) && var.use_spn ? local.cp_spn.client_id : null
+                                         client_secret       = try(data.terraform_remote_state.landscape.outputs.use_spn, true) && var.use_spn ? local.cp_spn.client_secret : null
+                                         tenant_id           = try(data.terraform_remote_state.landscape.outputs.use_spn, true) && var.use_spn ? local.cp_spn.tenant_id : null
+                                         use_msi             = try(data.terraform_remote_state.landscape.outputs.use_spn, true) && var.use_spn ? false : true
+                                         storage_use_azuread = true
                                        }
 
 
 
 provider "azuread"                     {
-                                         client_id     = try(data.terraform_remote_state.landscape.outputs.use_spn, true) && var.use_spn ? local.spn.client_id : null
-                                         client_secret = try(data.terraform_remote_state.landscape.outputs.use_spn, true) && var.use_spn ? local.spn.client_secret : null
-                                         tenant_id     = local.spn.tenant_id
-                                         use_msi                    = try(data.terraform_remote_state.landscape.outputs.use_spn, true) && var.use_spn ? false : true
+                                         client_id           = try(data.terraform_remote_state.landscape.outputs.use_spn, true) && var.use_spn ? local.spn.client_id : null
+                                         client_secret       = try(data.terraform_remote_state.landscape.outputs.use_spn, true) && var.use_spn ? local.spn.client_secret : null
+                                         tenant_id           = local.spn.tenant_id
+                                         use_msi             = try(data.terraform_remote_state.landscape.outputs.use_spn, true) && var.use_spn ? false : true
                                        }
+
 terraform                              {
-                                         required_version = ">= 1.0"
+                                         required_version   = ">= 1.0"
                                          required_providers {
                                                               external = {
                                                                            source = "hashicorp/external"

--- a/deploy/terraform/terraform-units/modules/sap_library/key_vault.tf
+++ b/deploy/terraform/terraform-units/modules/sap_library/key_vault.tf
@@ -14,7 +14,7 @@ resource "time_offset" "secret_expiry_date" {
 resource "azurerm_key_vault_secret" "saplibrary_access_key" {
   provider                             = azurerm.deployer
 
-  count                                = length(var.key_vault.kv_spn_id) > 0  ? 1 : 0
+  count                                = length(var.key_vault.kv_spn_id) > 0 && var.storage_account_sapbits.shared_access_key_enable ? 1 : 0
   depends_on                           = [azurerm_private_endpoint.kv_user]
   name                                 = "sapbits-access-key"
   value                                = local.sa_sapbits_exists ? (

--- a/deploy/terraform/terraform-units/modules/sap_library/key_vault.tf
+++ b/deploy/terraform/terraform-units/modules/sap_library/key_vault.tf
@@ -14,7 +14,7 @@ resource "time_offset" "secret_expiry_date" {
 resource "azurerm_key_vault_secret" "saplibrary_access_key" {
   provider                             = azurerm.deployer
 
-  count                                = length(var.key_vault.kv_spn_id) > 0 && var.storage_account_sapbits.shared_access_key_enable ? 1 : 0
+  count                                = length(var.key_vault.kv_spn_id) > 0 && var.storage_account_sapbits.shared_access_key_enabled ? 1 : 0
   depends_on                           = [azurerm_private_endpoint.kv_user]
   name                                 = "sapbits-access-key"
   value                                = local.sa_sapbits_exists ? (

--- a/deploy/terraform/terraform-units/modules/sap_library/storage_accounts.tf
+++ b/deploy/terraform/terraform-units/modules/sap_library/storage_accounts.tf
@@ -308,6 +308,7 @@ resource "azurerm_storage_account" "storage_sapbits" {
 
   cross_tenant_replication_enabled     = false
   public_network_access_enabled        = var.storage_account_sapbits.public_network_access_enabled
+  shared_access_key_enabled            = var.storage_account_sapbits.shared_access_key_enabled
 
   routing {
             publish_microsoft_endpoints = true


### PR DESCRIPTION
## Problem
Currently the Control Plane storage accounts require Storage account key access.

## Solution

Change the default of shared_access_key_enabled variable for the SAP Library to false.

Leverage ARM_USE_AZUREAD environment variable to instruct Terraform to use Entra Id authentication for the storage account.

## Tests
Redeploy the control plane, the workload zone, the SAP System and remove the SAP system

## Notes
<Additional comments for the PR>