### PR TITLE
Align custom kernel parameters with extensibility documentation

### DIFF
--- a/deploy/ansible/roles-os/1.9-kernelparameters/tasks/main.yaml
+++ b/deploy/ansible/roles-os/1.9-kernelparameters/tasks/main.yaml
@@ -179,7 +179,12 @@
 
 - name:                                "1.9 Kernel parameters - Gather list of custom defined parameters which need to be applied"
   ansible.builtin.set_fact:
-    get_custom_parameters_to_apply:    '{{ ((custom_parameters[distribution_id] | default([]))) | unique }}'
+    get_custom_parameters_to_apply:    '{{
+                                           (
+                                             custom_parameters[distribution_id] | default([]) +
+                                             custom_parameters["common"] | default([])
+                                           ) | unique(attribute="name") | list
+                                        }}'
   when:
     - custom_parameters is defined
 


### PR DESCRIPTION
## Problem
Currently the [extensibility documentation](https://learn.microsoft.com/en-us/azure/sap/automation/extensibility#adding-custom-kernel-parameters-linux) lists that customizations to kernel parameters can be done by

```yaml
custom_parameters:
  common:
    - { ... }
```

This is not the case as the code expects them grouped under the distribtuion_id.

## Solution

This PR ensures that both `common` and `distribution_id` can be utilized to set kernel parameters.
If both `common` and `distribution_id` sets the same property, the `distribution_id` will take precedence.
See the following example:

![image](https://github.com/user-attachments/assets/5a14f297-2c28-41f6-83ed-ceca6b50ee5a)

Which results in parameters being set like the following on the os level

![image](https://github.com/user-attachments/assets/f3b331b0-95f9-4bfc-8611-472672a0ff62)