### PR TITLE
Add flow_timeout_in_minutes to VNETs.

### DIFF
--- a/deploy/terraform/run/sap_deployer/tfvar_variables.tf
+++ b/deploy/terraform/run/sap_deployer/tfvar_variables.tf
@@ -86,6 +86,17 @@ variable "management_network_address_space"     {
                                                   default     = ""
                                                 }
 
+variable "management_network_flow_timeout_in_minutes" {
+                                                        description = "The flow timeout in minutes of the VNet into which the deployer will be deployed"
+                                                        type = number
+                                                        nullable = true
+                                                        default = null
+                                                        validation {
+                                                          condition     = var.management_network_flow_timeout_in_minutes == null ? true : (var.management_network_flow_timeout_in_minutes >= 4 && var.management_network_flow_timeout_in_minutes <= 30)
+                                                          error_message = "The flow timeout in minutes must be between 4 and 30 if set."
+                                                        }
+                                                      }
+
 #######################################4#######################################8
 #                                                                              #
 #                          Management Subnet variables                         #

--- a/deploy/terraform/run/sap_deployer/transform.tf
+++ b/deploy/terraform/run/sap_deployer/transform.tf
@@ -51,6 +51,13 @@ locals {
                                                 ),
                                                 ""
                                               )
+                                              flow_timeout_in_minutes = try(
+                                                coalesce(
+                                                  var.management_network_flow_timeout_in_minutes,
+                                                  try(var.infrastructure.vnets.management.flow_timeout_in_minutes, null)
+                                                ),
+                                                null
+                                              )
 
                                               subnet_mgmt = {
                                                 name = try(

--- a/deploy/terraform/run/sap_landscape/tfvar_variables.tf
+++ b/deploy/terraform/run/sap_landscape/tfvar_variables.tf
@@ -86,6 +86,24 @@ variable "network_arm_id"                       {
                                                   default     = ""
                                                 }
 
+variable "network_flow_timeout_in_minutes"      {
+                                                  description = "The flow timeout in minutes of the virtual network"
+                                                  type = number
+                                                  nullable = true
+                                                  default = null
+                                                  validation {
+                                                    condition     = var.network_flow_timeout_in_minutes == null ? true : (var.network_flow_timeout_in_minutes >= 4 && var.network_flow_timeout_in_minutes <= 30)
+                                                    error_message = "The flow timeout in minutes must be between 4 and 30 if set."
+                                                  }
+                                                }
+
+variable "network_enable_route_propagation"     {
+                                                  description = "Enable network route table propagation"
+                                                  type = bool
+                                                  nullable = false
+                                                  default = true
+                                                }
+
 variable "use_private_endpoint"                 {
                                                   description = "Boolean value indicating if private endpoint should be used for the deployment"
                                                   default     = false

--- a/deploy/terraform/run/sap_landscape/transform.tf
+++ b/deploy/terraform/run/sap_landscape/transform.tf
@@ -247,7 +247,8 @@ locals {
   sap                                  = {
                                            name          = var.network_name
                                            logical_name  = var.network_logical_name
-
+                                           flow_timeout_in_minutes = var.network_flow_timeout_in_minutes
+                                           enable_route_propagation = var.network_enable_route_propagation
                                            arm_id        = var.network_arm_id
                                            address_space = tolist(split(",", var.network_address_space))
                                          }

--- a/deploy/terraform/terraform-units/modules/sap_deployer/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/infrastructure.tf
@@ -58,7 +58,7 @@ resource "azurerm_subnet" "subnet_mgmt" {
   virtual_network_name                 = local.vnet_mgmt_exists ? data.azurerm_virtual_network.vnet_mgmt[0].name : azurerm_virtual_network.vnet_mgmt[0].name
   address_prefixes                     = [local.management_subnet_prefix]
 
-  private_endpoint_network_policies     = !var.use_private_endpoint ? "Enabled" : "Disabled"
+  private_endpoint_network_policies    = !var.use_private_endpoint ? "Enabled" : "Disabled"
 
   service_endpoints                    = var.use_service_endpoint ? (
                                            var.use_webapp ? (
@@ -66,6 +66,8 @@ resource "azurerm_subnet" "subnet_mgmt" {
                                              ["Microsoft.Storage", "Microsoft.KeyVault"]
                                            )) : (
                                          null)
+
+  flow_timeout_in_minutes              = var.infrastructure.vnets.management.flow_timeout_in_minutes
 
 }
 

--- a/deploy/terraform/terraform-units/modules/sap_landscape/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/infrastructure.tf
@@ -36,6 +36,7 @@ resource "azurerm_virtual_network" "vnet_sap" {
                                            azurerm_resource_group.resource_group[0].name
                                          )
   address_space                        = local.network_address_space
+  flow_timeout_in_minutes              = local.network_flow_timeout_in_minutes
   tags                                 = var.tags
 }
 
@@ -146,6 +147,7 @@ resource "azurerm_route_table" "rt" {
                                            var.naming.separator,
                                            local.resource_suffixes.routetable
                                          )
+  bgp_route_propagation_enabled        = local.network_enable_route_propagation
   resource_group_name                  = local.SAP_virtualnetwork_exists ? (
                                            data.azurerm_virtual_network.vnet_sap[0].resource_group_name) : (
                                            azurerm_virtual_network.vnet_sap[0].resource_group_name

--- a/deploy/terraform/terraform-units/modules/sap_landscape/variables_global.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/variables_global.tf
@@ -42,6 +42,11 @@ variable "infrastructure"                               {
                                                              )
                                                              error_message = "Either the arm_id or (name and address_space) of the Virtual Network must be specified in the infrastructure.vnets.sap block."
                                                            }
+
+                                                           validation {
+                                                             condition     = var.infrastructure.vnets.sap.flow_timeout_in_minutes == null ? true : (var.infrastructure.vnets.sap.flow_timeout_in_minutes >= 4 && var.infrastructure.vnets.sap.flow_timeout_in_minutes <= 30)
+                                                             error_message = "The flow timeout in minutes must be between 4 and 30 if set."
+                                                           }
                                                         }
 
 variable "options"                                      { description = "Configuration options" }

--- a/deploy/terraform/terraform-units/modules/sap_landscape/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/variables_local.tf
@@ -96,6 +96,10 @@ locals {
 
   network_address_space                           = local.SAP_virtualnetwork_exists ? [""] : var.infrastructure.vnets.sap.address_space
 
+  network_flow_timeout_in_minutes                 = var.infrastructure.vnets.sap.flow_timeout_in_minutes
+
+  network_enable_route_propagation                = var.infrastructure.vnets.sap.enable_route_propagation
+
   // By default, Ansible ssh key for SID uses generated public key.
   // Provide sshkey.path_to_public_key and path_to_private_key overides it
 


### PR DESCRIPTION
## Problem

When either using a Firewall in a brown field deployment or deploying a firewall through SDAF in a green field deployment. It's important to set the [VNET flow timeout](https://learn.microsoft.com/en-us/azure/network-watcher/nsg-flow-logs-overview#non-default-inbound-tcp-rules) in accordance with the [Firewall idle timeout](https://learn.microsoft.com/en-us/azure/firewall/long-running-sessions#idle-timeout).

As the idle timeout can be increased only by request to Microsoft support, we can't infer the actual value to set and should therefore delegate to the users.

Furthermore, when having a firewall not controlled by SDAF, it should be possible to disable route propagation on route tables manually.


## Solution

Add the option to specify `*_flow_timeout_in_minutes` for management and workload zone VNETs, defaults to `null`.
Add the option to specify `network_enable_route_propagation` for subnet route tables, defaults to `true`.
