### PR TITLE
Add two node cluster properties for DB2 on RHEL8

### DIFF
--- a/deploy/ansible/roles-sap/5.7-db2-pacemaker/tasks/5.7.3.0-cluster-RedHat.yml
+++ b/deploy/ansible/roles-sap/5.7-db2-pacemaker/tasks/5.7.3.0-cluster-RedHat.yml
@@ -11,7 +11,7 @@
 # if it is not started, then we do not need to stop it
 # +------------------------------------4--------------------------------------*/
 
-- name:                                "DB2 Cluster: - Find if the databases are active"
+- name:                                "5.7.3.0 DB2 Cluster configuration - Find if the databases are active"
   become:                              true
   become_user:                         db2{{ db_sid | lower }}
   ansible.builtin.shell:               db2 list active databases
@@ -22,7 +22,8 @@
   register:                            db2_list_active_databases
   failed_when:                         db2_list_active_databases.rc not in [0,4]
 
-- name:                                "DB2 Cluster: - Stop the primary DB"
+- name:                                "5.7.3.0 DB2 Cluster configuration - Stop the primary DB"
+  when:                                db2_list_active_databases.rc == 0
   become:                              true
   become_user:                         db2{{ db_sid | lower }}
   ansible.builtin.shell:               db2stop force
@@ -30,20 +31,24 @@
     executable: /bin/csh
   environment:
     PATH: "{{ ansible_env.PATH }}:/db2/db2{{ db_sid | lower }}/sqllib/gskit/bin"
-  when:                                db2_list_active_databases.rc == 0
 
-
-- name:                                "DB2 Cluster: Change to ksh Shell"
+- name:                                "5.7.3.0 DB2 Cluster configuration - Change to ksh Shell"
   ansible.builtin.user:
     user:                              db2{{ db_sid | lower }}
     shell:                             /bin/ksh
 
-- name:                                "DB2 Cluster: Optimise the Pacemaker cluster for SAP DB2"
+- name:                                "5.7.3.0 DB2 Cluster configuration - Optimize the Pacemaker cluster for SAP DB2"
+  when:                                ansible_hostname == primary_instance_name
   block:
-    - name:                            "DB2 Cluster: Enable Maintenance mode for the cluster"
-      ansible.builtin.command:         pcs property set maintenance-mode=true
+    - name:                            "5.7.3.0 DB2 Cluster configuration - Enable Maintenance mode for the cluster"
+      ansible.builtin.shell:           pcs property set maintenance-mode=true
 
-    - name:                            "DB2 Cluster: Ensure SAP DB2 resource is created"
+    - name:                            "5.7.3.0 DB2 Cluster configuration - Check if the pacemaker package version is greater than pacemaker-2.0.4"
+      when:                            ansible_distribution_major_version in ["8", "9"]
+      ansible.builtin.set_fact:
+        is_pcmk_ver_gt_204:            "{{ ansible_facts.packages['pacemaker'][0].version is version('2.0.4', '>') | default(false) }}"
+
+    - name:                            "5.7.3.0 DB2 Cluster configuration - Ensure SAP DB2 resource is created"
       ansible.builtin.shell: >
                                        pcs resource create Db2_HADR_{{ db_sid | upper }} db2 instance='db2{{ db_sid | lower }}' dblist='{{ db_sid | upper }}'
                                        master meta notify=true resource-stickiness=5000
@@ -51,7 +56,7 @@
       failed_when:                     sap_db2.rc > 1
       when:                            ansible_distribution_major_version == "7"
 
-    - name:                            "DB2 Cluster: Ensure SAP DB2 resource is created"
+    - name:                            "5.7.3.0 DB2 Cluster configuration - Ensure SAP DB2  DB2 resource is created"
       ansible.builtin.shell: >
                                        pcs resource create Db2_HADR_{{ db_sid | upper }} db2 instance='db2{{ db_sid | lower }}' dblist='{{ db_sid | upper }}'
                                        meta resource-stickiness=5000 promotable notify=true
@@ -59,91 +64,98 @@
       failed_when:                     sap_db2.rc > 1
       when:                            ansible_distribution_major_version in ["8", "9"]
 
-    - name:                            "DB2 Cluster: Ensure the Virtual IP resource for the Load Balancer Front End IP is created"
-      ansible.builtin.command:         pcs resource create vip_db2{{ db_sid | lower }}_{{ db_sid | upper }} IPaddr2 ip='{{ database_loadbalancer_ip }}'
+    - name:                            "5.7.3.0 DB2 Cluster configuration - Ensure the Virtual IP resource for the Load Balancer Front End IP is created"
+      ansible.builtin.shell:           pcs resource create vip_db2{{ db_sid | lower }}_{{ db_sid | upper }} IPaddr2 ip='{{ database_loadbalancer_ip }}'
       register:                        vip
       failed_when:                     vip.rc > 1
 
-    - name:                            "DB2 Cluster: Ensure the netcat resource for the Load Balancer Healthprobe is created - Probe port for Azure Load Balacer"
-      ansible.builtin.command:         pcs resource create nc_db2{{ db_sid | lower }}_{{ db_sid | upper }} azure-lb port=625{{ db_instance_number }}
+    - name:                            "5.7.3.0 DB2 Cluster configuration - Ensure the netcat resource for the Load Balancer Healthprobe is created - Probe port for Azure Load Balacer"
+      ansible.builtin.shell:           pcs resource create nc_db2{{ db_sid | lower }}_{{ db_sid | upper }} azure-lb port=625{{ db_instance_number }}
       register:                        netcat
       failed_when:                     netcat.rc > 1
 
-    - name:                            "DB2 Cluster: Ensure a group for ip and Azure loadbalancer probe port is created"
-      ansible.builtin.command:         pcs resource group add g_ipnc_db2{{ db_sid | lower }}_{{ db_sid | upper }} vip_db2{{ db_sid | lower }}_{{ db_sid | upper }} nc_db2{{ db_sid | lower }}_{{ db_sid | upper }}
+    - name:                            "5.7.3.0 DB2 Cluster configuration - Ensure a group for ip and Azure loadbalancer probe port is created"
+      ansible.builtin.shell:           pcs resource group add g_ipnc_db2{{ db_sid | lower }}_{{ db_sid | upper }} vip_db2{{ db_sid | lower }}_{{ db_sid | upper }} nc_db2{{ db_sid | lower }}_{{ db_sid | upper }}
       register:                        vip_g
       failed_when:                     vip_g.rc > 1
 
-    - name:                            "DB2 Cluster: Create colocation constraints - keep Db2 HADR Master and Group on same node - Rhel 7"
-      ansible.builtin.command:         pcs constraint colocation add g_ipnc_db2{{ db_sid | lower }}_{{ db_sid | upper }} with master Db2_HADR_{{ db_sid | upper }}-master
+    - name:                            "5.7.3.0 DB2 Cluster configuration - Create colocation constraints - keep Db2 HADR Master and Group on same node - RHEL7"
+      ansible.builtin.shell:           pcs constraint colocation add g_ipnc_db2{{ db_sid | lower }}_{{ db_sid | upper }} with master Db2_HADR_{{ db_sid | upper }}-master
       register:                        constraint
       failed_when:                     constraint.rc > 1
       when:                            ansible_distribution_major_version == "7"
 
-    - name:                            "DB2 Cluster: Create colocation constraints - keep Db2 HADR Master and Group on same node - Rhel 8 & 9"
-      ansible.builtin.command:         pcs constraint colocation add g_ipnc_db2{{ db_sid | lower }}_{{ db_sid | upper }} with Promoted Db2_HADR_{{ db_sid | upper }}-clone
+    - name:                            "5.7.3.0 DB2 Cluster configuration - Create colocation constraints - keep Db2 HADR Master and Group on same node - RHEL8 / RHEL9"
+      ansible.builtin.shell:           pcs constraint colocation add g_ipnc_db2{{ db_sid | lower }}_{{ db_sid | upper }} with master Db2_HADR_{{ db_sid | upper }}-clone
       register:                        constraint
       failed_when:                     constraint.rc > 1
       when:                            ansible_distribution_major_version in ["8", "9"]
 
-    - name:                            "DB2 Cluster: Ensure the order constraint for the SAP DB2 is configured - Rhel - 7"
-      ansible.builtin.command:         pcs constraint order promote Db2_HADR_{{ db_sid | upper }}-master then g_ipnc_db2{{ db_sid | lower }}_{{ db_sid | upper }}
+    - name:                            "5.7.3.0 DB2 Cluster configuration - Ensure the order constraint for the SAP DB2 is configured - RHEL7"
+      ansible.builtin.shell:           pcs constraint order promote Db2_HADR_{{ db_sid | upper }}-master then g_ipnc_db2{{ db_sid | lower }}_{{ db_sid | upper }}
       register:                        constraint
       failed_when:                     constraint.rc > 1
       when:                            ansible_distribution_major_version == "7"
 
-    - name:                            "DB2 Cluster: Ensure the order constraint for the SAP DB2 is configured - Rhel - 8 & 9"
-      ansible.builtin.command:         pcs constraint order promote Db2_HADR_{{ db_sid | upper }}-clone then g_ipnc_db2{{ db_sid | lower }}_{{ db_sid | upper }}
+    - name:                            "5.7.3.0 DB2 Cluster configuration - Ensure the order constraint for the SAP DB2 is configured - RHEL8/RHEL9"
+      ansible.builtin.shell:           pcs constraint order promote Db2_HADR_{{ db_sid | upper }}-clone then g_ipnc_db2{{ db_sid | lower }}_{{ db_sid | upper }}
       register:                        constraint
       failed_when:                     constraint.rc > 1
       when:                            ansible_distribution_major_version in ["8", "9"]
 
-    - name:                            "DB2 Cluster: Disable Maintenance mode for the cluster"
-      ansible.builtin.command:         pcs property set maintenance-mode=false
+    # for two node clusters set properties
+    - name:                            "5.7.3.0 DB2 Cluster configuration - Set the cluster properties for two node clusters"
+      when: is_pcmk_ver_gt_204
+      block:
+        - name:                        "5.7.3.0 DB2 Cluster configuration - set resource defaults 'priority'"
+          ansible.builtin.shell:       pcs resource defaults update priority=1
+          register:                    update_priority
+          failed_when:                 update_priority.rc > 1
 
-    - name:                            "DB2 Cluster: Wait until cluster has stabilized (debug)"
-      ansible.builtin.shell:           "set -o pipefail && pcs status nodes | grep '^ Online: ' | cut -d ':' -f2"
+        - name:                        "5.7.3.0 DB2 Cluster configuration - set Db2_HADR defaults 'priority' to 10"
+          ansible.builtin.shell:       pcs resource update Db2_HADR_{{ db_sid | upper }} meta priority=10
+          register:                    update_priority_db2_hadr
 
-      register:                        cluster_stable_check_debug
+        - name:                        5.7.3.0 DB2 Cluster configuration - set priority-fencing-delay"
+          ansible.builtin.shell:       pcs property set priority-fencing-delay=15s
+          register:                    constraint
+          failed_when:                 constraint.rc > 1
 
-    - name:                            "DB2 Cluster: Wait until cluster has stabilized output"
-      ansible.builtin.debug:
-        var:                           cluster_stable_check_debug
+    - name:                            "5.7.3.0 DB2 Cluster configuration - Disable Maintenance mode for the cluster"
+      ansible.builtin.shell:           pcs property set maintenance-mode=false
 
-
-    - name:                            "DB2 Cluster: Wait until cluster has stabilized"
+    - name:                            "5.7.3.0 DB2 Cluster configuration - Wait until cluster has stabilized"
       ansible.builtin.shell:           set -o pipefail && pcs status | grep '^Online:'
       register:                        cluster_stable_check
       retries:                         12
       delay:                           10
       until:                           "(primary_instance_name + ' ' + secondary_instance_name) in cluster_stable_check.stdout or (secondary_instance_name + ' ' + primary_instance_name) in cluster_stable_check.stdout"
-      when:                            ansible_distribution_major_version not in ["8", "9"]
+      when:                            ansible_distribution_major_version != "8"
 
     # '*' is a special character in regexp and needs to be escaped for literal matching
     # if we are worried about character spacing across distros we can match for '\* Online:'
-    - name:                            "DB2 Cluster: Wait until cluster has stabilized - RHEL 8.x and 9.x"
-      ansible.builtin.shell:           "set -o pipefail && pcs status nodes | grep '^ Online: ' | cut -d ':' -f2"
+    - name:                            "5.7.3.0 DB2 Cluster configuration - Wait until cluster has stabilized - RHEL8 / RHEL9"
+      ansible.builtin.shell:           set -o pipefail && pcs status | grep '^  \* Online:'
       register:                        cluster_stable_check
       retries:                         12
       delay:                           10
-      until:                           "primary_instance_name in cluster_stable_check.stdout and secondary_instance_name in cluster_stable_check.stdout"
+      until:                           "'{{ primary_instance_name }} {{ secondary_instance_name }}' in cluster_stable_check.stdout or '{{ secondary_instance_name }} {{ primary_instance_name }}' in cluster_stable_check.stdout"
       when:                            ansible_distribution_major_version in ["8", "9"]
 
-    - name:                            "DB2 Cluster: Ensure Cluster resources are started"
+    - name:                            "5.7.3.0 DB2 Cluster configuration - Ensure Cluster resources are started - RHEL7"
       ansible.builtin.shell:           set -o pipefail && pcs resource show | grep '    Started:'
       register:                        db2_cluster_resource_check
       retries:                         12
       delay:                           10
       until:                           "'{{ primary_instance_name }} {{ secondary_instance_name }}' in db2_cluster_resource_check.stdout or '{{ secondary_instance_name }} {{ primary_instance_name }}' in db2_cluster_resource_check.stdout"
-      when:                            ansible_distribution_major_version not in ["8", "9"]
+      when:                            ansible_distribution_major_version == "7"
 
-    - name:                            "DB2 Cluster: Ensure Cluster resources are started - RHEL 8.x"
+    - name:                            "5.7.3.0 DB2 Cluster configuration - Ensure Cluster resources are started - RHEL8 / RHEL9"
       ansible.builtin.shell:           set -o pipefail && pcs resource status | grep 'Started'
       register:                        db2_cluster_resource_check
       retries:                         12
       delay:                           10
       until:                           "'{{ primary_instance_name }}' in db2_cluster_resource_check.stdout or '{{ secondary_instance_name }}' in db2_cluster_resource_check.stdout"
       when:                            ansible_distribution_major_version in ["8", "9"]
-  when: ansible_hostname == primary_instance_name
 
 # End of DB2 clustering resources


### PR DESCRIPTION
## Problem
Both nodes can be fenced when issues occur or you might end-up in a split-brain situation.

## Solution
Like with HANA and SCS/ERS we implement resource priority and set a fence delay of 15s.

## Notes
https://learn.microsoft.com/en-us/azure/sap/workloads/high-availability-guide-rhel-ibm-db2-luw?tabs=lb-portal isn't mentioning this (yet) but https://learn.microsoft.com/en-us/azure/sap/workloads/sap-hana-high-availability-rhel?tabs=lb-portal does.