### PR TITLE
Add use_custom_dns_a_registration condition to key vault DNS A rec cr…

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_library/key_vault.tf
+++ b/deploy/terraform/terraform-units/modules/sap_library/key_vault.tf
@@ -83,7 +83,9 @@ resource "azurerm_key_vault_secret" "tfstate" {
 
 resource "azurerm_private_dns_a_record" "kv_user" {
   provider                             = azurerm.privatelinkdnsmanagement
-  count                                = var.dns_settings.register_storage_accounts_keyvaults_with_dns ? 1 : 0
+  # ASML customization
+  # count                                = var.dns_settings.register_storage_accounts_keyvaults_with_dns ? 1 : 0
+  count                                = var.dns_settings.register_storage_accounts_keyvaults_with_dns && var.use_custom_dns_a_registration ? 1 : 0
   name                                 = lower(split("/", var.key_vault.kv_spn_id)[8])
   zone_name                            = var.dns_settings.dns_zone_names.vault_dns_zone_name
   resource_group_name                  = coalesce(


### PR DESCRIPTION
…eation

## Problem
Deployer key vault with private endpoint has issues with DNS A record creation. The private endpoint DNS zone group and the custom DNS A rec creation conflicts.

## Solution
Add condition use_custom_dns_a_registration true for the DNS A record creation

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>