### PR TITLE
Fix WL zone deployment by pipeline

### DIFF
--- a/deploy/pipelines/02-sap-workload-zone.yaml
+++ b/deploy/pipelines/02-sap-workload-zone.yaml
@@ -394,8 +394,10 @@ stages:
                       STATE_SUBSCRIPTION=${az_var}
 
                   fi
-
-                  az_var=$(az pipelines variable-group variable list --group-id ${VARIABLE_GROUP_ID} --query "WL_ARM_SUBSCRIPTION_ID.value" --out tsv)
+                  
+                  # ASML customization
+                  az_var=$(az pipelines variable-group variable list --group-id ${VARIABLE_GROUP_ID} --query "ARM_SUBSCRIPTION_ID.value" --out tsv)
+                  #az_var=$(az pipelines variable-group variable list --group-id ${VARIABLE_GROUP_ID} --query "WL_ARM_SUBSCRIPTION_ID.value" --out tsv)
                   if [ -z ${az_var} ]; then
                       echo "##vso[task.logissue type=error]Variable WL_ARM_SUBSCRIPTION_ID was not defined."
                       exit 2
@@ -545,20 +547,24 @@ stages:
                           echo "##vso[task.logissue type=error]az login failed."
                           exit $return_code
                       fi
-                      $SAP_AUTOMATION_REPO_PATH/deploy/scripts/install_workloadzone.sh --parameterfile $(workload_zone_configuration_file)   \
-                      --deployer_environment $(deployer_environment) --subscription $ARM_SUBSCRIPTION_ID                                     \
-                      --spn_id $WL_ARM_CLIENT_ID --spn_secret $WL_ARM_CLIENT_SECRET --tenant_id $WL_ARM_TENANT_ID                            \
-                      --deployer_tfstate_key "${deployer_tfstate_key}" --keyvault "${key_vault}" --storageaccountname "${REMOTE_STATE_SA}"   \
-                      --state_subscription "${STATE_SUBSCRIPTION}" --auto-approve --ado
-                  else
-                      $SAP_AUTOMATION_REPO_PATH/deploy/scripts/install_workloadzone.sh --parameterfile $(workload_zone_configuration_file)   \
-                      --deployer_environment $(deployer_environment) --subscription $ARM_SUBSCRIPTION_ID                                     \
-                      --deployer_tfstate_key "${deployer_tfstate_key}" --keyvault "${key_vault}" --storageaccountname "${REMOTE_STATE_SA}"   \
-                      --state_subscription "${STATE_SUBSCRIPTION}" --auto-approve --ado --msi
 
                   fi
 
               fi
+
+              if [ $USE_MSI != "true" ]; then
+                  $SAP_AUTOMATION_REPO_PATH/deploy/scripts/install_workloadzone.sh --parameterfile $(workload_zone_configuration_file)   \
+                  --deployer_environment $(deployer_environment) --subscription $ARM_SUBSCRIPTION_ID                                     \
+                  --spn_id $WL_ARM_CLIENT_ID --spn_secret $WL_ARM_CLIENT_SECRET --tenant_id $WL_ARM_TENANT_ID                            \
+                  --deployer_tfstate_key "${deployer_tfstate_key}" --keyvault "${key_vault}" --storageaccountname "${REMOTE_STATE_SA}"   \
+                  --state_subscription "${STATE_SUBSCRIPTION}" --auto-approve --ado
+              else
+                  $SAP_AUTOMATION_REPO_PATH/deploy/scripts/install_workloadzone.sh --parameterfile $(workload_zone_configuration_file)   \
+                  --deployer_environment $(deployer_environment) --subscription $ARM_SUBSCRIPTION_ID                                     \
+                  --deployer_tfstate_key "${deployer_tfstate_key}" --keyvault "${key_vault}" --storageaccountname "${REMOTE_STATE_SA}"   \
+                  --state_subscription "${STATE_SUBSCRIPTION}" --auto-approve --ado --msi
+              fi
+
               return_code=$?
 
               echo "Return code from deployment:         ${return_code}"


### PR DESCRIPTION
## Problem
The install_workloadzone.sh is not called by the 02 wlzone pipeline leveraging self hosted agent rather then deployer VM.

## Solution
Move the install_workloadzone.sh call out of the  if [ -f /etc/profile.d/deploy_server.sh ]; then

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>