### PR TITLE
Resolve key_vault name providing non inherited deployment in 02-sap-w…

### DIFF
--- a/deploy/pipelines/02-sap-workload-zone.yaml
+++ b/deploy/pipelines/02-sap-workload-zone.yaml
@@ -413,7 +413,7 @@ stages:
               else
                   deployer_tfstate_key=$(grep "^deployer_tfstate_key=" ${workload_environment_file_name}  | awk -F'=' '{print $2}' | xargs)
 
-                  key_vault=$(grep -m1 "^workload_key_vault=" ${workload_environment_file_name} | awk -F'=' '{print $2}' | xargs) ;
+                  key_vault=$(grep -m1 "^workloadkeyvault=" ${workload_environment_file_name} | awk -F'=' '{print $2}' | xargs) ;
 
                   REMOTE_STATE_SA=$(grep "^REMOTE_STATE_SA=" ${workload_environment_file_name} | awk -F'=' '{print $2}' | xargs)
 


### PR DESCRIPTION
…orkload-zone.yaml

## Problem
WL zone redeploy goes wrong due to a typo in the key vault name resolve.

## Solution
Fix key vault property key name in the code.

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>