### PR TITLE
Modify terraform dirs to be accessible without root user

### DIFF
--- a/deploy/scripts/advanced_state_management.sh
+++ b/deploy/scripts/advanced_state_management.sh
@@ -203,7 +203,8 @@ if checkIfCloudShell; then
   export TF_PLUGIN_CACHE_DIR="${HOME}/.terraform.d/plugin-cache"
 else
   if [ ! -d /opt/terraform/.terraform.d/plugin-cache ]; then
-    mkdir -p /opt/terraform/.terraform.d/plugin-cache
+
+    sudo mkdir -p /opt/terraform/.terraform.d/plugin-cache
     sudo chown -R $USER /opt/terraform
   fi
   export TF_PLUGIN_CACHE_DIR=/opt/terraform/.terraform.d/plugin-cache

--- a/deploy/scripts/helpers/script_helpers.sh
+++ b/deploy/scripts/helpers/script_helpers.sh
@@ -430,7 +430,9 @@ function validate_dependencies {
         export TF_PLUGIN_CACHE_DIR="${HOME}/.terraform.d/plugin-cache"
     else
         if [ ! -d /opt/terraform/.terraform.d/plugin-cache ]; then
-            mkdir -p /opt/terraform/.terraform.d/plugin-cache
+       
+            sudo mkdir -p /opt/terraform/.terraform.d/plugin-cache
+            sudo chown -R $USER /opt/terraform
         fi
         export TF_PLUGIN_CACHE_DIR=/opt/terraform/.terraform.d/plugin-cache
     fi

--- a/deploy/scripts/install_library.sh
+++ b/deploy/scripts/install_library.sh
@@ -179,7 +179,8 @@ if checkIfCloudShell; then
   export TF_PLUGIN_CACHE_DIR="${HOME}/.terraform.d/plugin-cache"
 else
   if [ ! -d /opt/terraform/.terraform.d/plugin-cache ]; then
-    mkdir -p /opt/terraform/.terraform.d/plugin-cache
+
+    sudo mkdir -p /opt/terraform/.terraform.d/plugin-cache
     sudo chown -R "$USER" /opt/terraform
   fi
   export TF_PLUGIN_CACHE_DIR=/opt/terraform/.terraform.d/plugin-cache

--- a/deploy/scripts/install_workloadzone.sh
+++ b/deploy/scripts/install_workloadzone.sh
@@ -597,7 +597,8 @@ if checkIfCloudShell; then
   export TF_PLUGIN_CACHE_DIR="${HOME}/.terraform.d/plugin-cache"
 else
   if [ ! -d /opt/terraform/.terraform.d/plugin-cache ]; then
-    mkdir -p /opt/terraform/.terraform.d/plugin-cache
+
+    sudo mkdir -p /opt/terraform/.terraform.d/plugin-cache
     sudo chown -R "$USER" /opt/terraform
   fi
   export TF_PLUGIN_CACHE_DIR=/opt/terraform/.terraform.d/plugin-cache

--- a/deploy/scripts/installer.sh
+++ b/deploy/scripts/installer.sh
@@ -204,7 +204,8 @@ if checkIfCloudShell; then
   export TF_PLUGIN_CACHE_DIR="${HOME}/.terraform.d/plugin-cache"
 else
   if [ ! -d /opt/terraform/.terraform.d/plugin-cache ]; then
-    mkdir -p /opt/terraform/.terraform.d/plugin-cache
+
+    sudo mkdir -p /opt/terraform/.terraform.d/plugin-cache
     sudo chown -R "$USER" /opt/terraform
   fi
   export TF_PLUGIN_CACHE_DIR=/opt/terraform/.terraform.d/plugin-cache

--- a/deploy/scripts/remover.sh
+++ b/deploy/scripts/remover.sh
@@ -240,7 +240,8 @@ if checkIfCloudShell; then
     export TF_PLUGIN_CACHE_DIR="${HOME}/.terraform.d/plugin-cache"
 else
     if [ ! -d /opt/terraform/.terraform.d/plugin-cache ]; then
-        mkdir -p /opt/terraform/.terraform.d/plugin-cache
+
+        sudo mkdir -p /opt/terraform/.terraform.d/plugin-cache
         sudo chown -R "$USER" /opt/terraform
     fi
     export TF_PLUGIN_CACHE_DIR=/opt/terraform/.terraform.d/plugin-cache


### PR DESCRIPTION
## Problem
The terraform init fails using self hosted agent with other than the root user.

## Solution
Change 
mkdir -p /opt/terraform/.terraform.d/plugin-cache
to
sudo mkdir -p /opt/terraform/.terraform.d/plugin-cache
in front 
of 
sudo chown -R $USER /opt/terraform

lines in the helper scripts.

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>