### PR TITLE
Refactor iSCSI configuration tasks for improved clarity and debugging

### DIFF
--- a/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.1.1-iSCSI.yml
+++ b/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.1.1-iSCSI.yml
@@ -113,10 +113,12 @@
     - iscsid
     - iscsi
 
-- name:                                "1.17.1 iSCSI configuration block - iterate through the available iSCSI servers"
+- name:                                "1.17.1 iSCSI configuration block - iterate through the available iSCSI servers for {{ iscsi_node_type }}"
+  become:                              true
+  become_user:                         root
   when:
-    - iscsi_node_type is defined
-    - iscsi_initiator_name is defined
+                                       - iscsi_node_type is defined
+                                       - iscsi_initiator_name is defined
   block:
     # error codes:
     # https://github.com/open-iscsi/open-iscsi/blob/master/include/iscsi_err.h
@@ -126,46 +128,81 @@
     # iscsiadm -m node -T {{ item.iqn }} --login --portal={{ item.host }}:3260
     # iscsiadm -m node -p {{ item.host }}:3260 -T {{ item.iqn }} --op=update --name=node.startup --value=automatic
 
-    - name:                            "1.17.1 iSCSI configuration on cluster servers for {{ iscsi_node_type }} - discovery, login and update node.startup"
+    - name:                            "1.17.1.1 - Discover iSCSI targets for {{ iscsi_node_type }}"
       community.general.open_iscsi:
-        login:                         true
         portal:                        "{{ item.host }}"
-        # auto_portal_startup:           true
-        auto_node_startup:             true
+        port:                          "3260"
         discover:                      true
-        target:                        "{{ item.iqn }}"
-        rescan:                        true
       loop:                            "{{ iscsi_servers }}"
-      register:                        iscsi_configuration_result
-      failed_when:                     false
       when:
-        # - iscsi_node_type == 'scs'
-        - iscsi_node_type in ['scs', 'db']
-        - iscsi_initiator_name == item.iqn
+                                       - iscsi_node_type in ['scs', 'db']
+                                       - iscsi_initiator_name == item.iqn
+      register:                        discovery_result
 
-    - name:                                "1.17.1 iSCSI packages - print iSCSI configuration result"
-      when:
-        - iscsi_node_type is defined
-        - iscsi_node_type in ['scs', 'db']
+    - name:                            "1.17.1.1 - [DEBUG]: Show Discovery Results for {{ iscsi_node_type }}"
       ansible.builtin.debug:
-        msg:                               "{{ iscsi_configuration_result }}"
-        verbosity:                         2
+        var:                           discovery_result
+        verbosity:                     2
 
-    # - name:                            "1.17.1 iSCSI configuration on cluster servers for {{ iscsi_node_type }} - discovery, login and update node.startup"
-    #   community.general.open_iscsi:
-    #     login:                         true
-    #     portal:                        "{{ item.host }}"
-    #     # auto_portal_startup:           true
-    #     auto_node_startup:             true
-    #     discover:                      true
-    #     target:                        "{{ item.iqn }}"
-    #     rescan:                        true
-    #   loop:                            "{{ iscsi_servers }}"
-    #   register:                        iscsi_configuration_result
-    #   failed_when:                     false
-    #   when:
-    #     - iscsi_node_type == 'db'
-    #     - iscsi_initiator_name == item.iqn
+    - name:                            "1.17.1.2 - Login to iSCSI targets for {{ iscsi_node_type }}"
+      community.general.open_iscsi:
+        portal:                        "{{ item.host }}"
+        port:                          "3260"
+        target:                        "{{ item.iqn }}"
+        login:                         true
+      loop:                            "{{ iscsi_servers }}"
+      when:
+                                       - iscsi_node_type in ['scs', 'db']
+                                       - iscsi_initiator_name == item.iqn
+      register:                        login_result
+      failed_when:
+                                       - login_result.rc is defined
+                                       - login_result.rc != 0
+                                       - login_result.rc != 15  # Ignore "session exists"
+
+    - name:                            "1.17.1.2 - [DEBUG]: Show login Results for {{ iscsi_node_type }}"
+      ansible.builtin.debug:
+        var:                           login_result
+        verbosity:                     2
+
+    - name:                            "1.17.1.3 - Set automatic startup for targets for {{ iscsi_node_type }}"
+      community.general.open_iscsi:
+        portal:                        "{{ item.host }}"
+        port:                          "3260"
+        target:                        "{{ item.iqn }}"
+        auto_node_startup:             true
+      loop:                            "{{ iscsi_servers }}"
+      when:
+                                       - iscsi_node_type in ['scs', 'db']
+                                       - iscsi_initiator_name == item.iqn
+      register:                        startup_result
+
+    - name:                            "1.17.1.3 - [DEBUG]: Show startup Results for {{ iscsi_node_type }}"
+      ansible.builtin.debug:
+        var:                           startup_result
+        verbosity:                     2
+
+    - name:                            "1.17.1.4 - Final session rescan for {{ iscsi_node_type }}"
+      ansible.builtin.command:
+        cmd:                           "iscsiadm -m session -R"
+      when:                            login_result is changed
+      register:                        final_rescan
+      changed_when:                    true
+
+    - name:                            "1.17.1.4 - [DEBUG]: Show final rescan Results"
+      ansible.builtin.debug:
+        var:                           final_rescan
+        verbosity:                     2
+
+    # Capture the login results into iscsi_configuration_result
+    - name:                            "1.17.1.5 - Set iscsi_configuration_result"
+      ansible.builtin.set_fact:
+        iscsi_configuration_result:    "{{ login_result }}"
+  rescue:
+    - name:                            "1.17.1 iSCSI configuration on cluster servers for {{ iscsi_node_type }}:
+                                         Report iSCSI configuration failure"
+      ansible.builtin.fail:
+        msg:                           "Failed to configure iSCSI targets. Please check the logs for details."
 
 - name:                                "1.17.1 reload iSCSI on cluster servers"
   ansible.builtin.systemd:
@@ -173,38 +210,41 @@
     enabled:                           true
     daemon_reload:                     true
   loop:
-    - iscsid
-    - iscsi
+                                       - iscsid
+                                       - iscsi
 
-- name:                                "1.17.1 iSCSI packages - Select iscsi_configuration_result device nodes list"
+- name:                                "1.17.1 iSCSI packages - Extract unique device nodes from iSCSI configuration"
+  when:
+                                       - iscsi_configuration_result is defined
   ansible.builtin.set_fact:
     iscsi_devices_on_client:           "{{ iscsi_configuration_result.results | selectattr('devicenodes', 'defined') |
                                            map(attribute='devicenodes') | select() | flatten(levels=1) |
                                            default([]) | unique | list }}"
-  when:
-    - iscsi_configuration_result is defined
 
-- name:                                "1.17.1 iSCSI packages - Set product of ansible_play_hosts_all in group and iscsi_configuration_result devices on client"
+
+- name:                                "1.17.1 iSCSI packages - Create host-to-device mapping"
+  when:
+                                       - iscsi_configuration_result is defined
   ansible.builtin.set_fact:
     iscsi_device_map:                  "{{ [ansible_hostname] | product(iscsi_devices_on_client) |
                                            default([]) | unique | list }}"
-  when:
-    - iscsi_configuration_result is defined
 
-- name:                                "1.17.1 iSCSI packages - Show product of servers in group and iscsi_configuration_result devicenodes attribute"
+- name:                                "1.17.1 iSCSI packages - Verify device mapping status"
+  when:
+                                       - iscsi_configuration_result is defined
   ansible.builtin.debug:
     msg:
       - "iscsi_devices_on_client:      {{ iscsi_devices_on_client }}"
       - "iscsi_device_map:             {{ iscsi_device_map }}"
     verbosity:                         2
-  when:
-    - iscsi_configuration_result is defined
 
-- name:                                "1.17.1 iSCSI Check if iSCSI configuration was successful"
+
+- name:                                "1.17.1 iSCSI packages - Validate iSCSI device configuration"
+  when:
+                                       - iscsi_devices_on_client == []
+                                       - iscsi_device_map == []
   ansible.builtin.fail:
     msg:                               "iSCSI configuration failed"
-  when:
-    - iscsi_devices_on_client == []
-    - iscsi_device_map == []
+
 
 ...


### PR DESCRIPTION
This pull request makes updates to the iSCSI configuration tasks in the Ansible role for generic pacemaker. The changes focus on improving the clarity, and debugging capabilities of the iSCSI configuration process.

Key changes include:

### Enhancements to iSCSI Configuration Process:

* Added `become` and `become_user` directives to ensure the tasks run with root privileges for better control over the iSCSI configuration.

* Split the iSCSI configuration into multiple distinct steps: discovery, login, setting automatic startup, and final rescan. This modular approach helps in isolating and debugging each step more effectively.

### Improved Debugging and Error Handling:

* Introduced debug tasks to show the results of discovery, login, and startup operations, which aids in troubleshooting issues during the iSCSI configuration process.

* Added a final session rescan task to ensure the iSCSI sessions are correctly updated after the configuration changes.

### Fact Setting and Validation:

* Enhanced the fact-setting tasks to create and verify device mappings, ensuring the correct association of iSCSI devices with hosts.

* Implemented validation checks to confirm the success of the iSCSI configuration and fail the playbook gracefully if the configuration is not successful.