### PR TITLE
Release fixes

### DIFF
--- a/deploy/scripts/pipeline_scripts/01-control-plane-deploy.sh
+++ b/deploy/scripts/pipeline_scripts/01-control-plane-deploy.sh
@@ -112,8 +112,8 @@ fi
 
 cd "$CONFIG_REPO_PATH" || exit
 
-echo -e "$green--- Checkout $BRANCH ---$reset"
-git checkout -q "$BRANCH"
+echo -e "$green--- Checkout $BUILD_SOURCEBRANCHNAME ---$reset"
+git checkout -q "$BUILD_SOURCEBRANCHNAME"
 
 echo -e "$green--- Configure devops CLI extension ---$reset"
 az config set extension.use_dynamic_install=yes_without_prompt --only-show-errors
@@ -314,7 +314,7 @@ added=0
 cd "${CONFIG_REPO_PATH}" || exit
 
 # Pull changes
-git pull -q origin "$BRANCH"
+git pull -q origin "$BUILD_SOURCEBRANCHNAME"
 
 echo -e "$green--- Update repo ---$reset"
 if [ -f .sap_deployment_automation/"${ENVIRONMENT}${LOCATION}" ]; then
@@ -415,14 +415,14 @@ if [ 1 = $added ]; then
 	if [ $DEBUG = True ]; then
 		git status --verbose
 		if git commit --message --verbose "Added updates from Control Plane Deployment for $DEPLOYER_FOLDERNAME $LIBRARY_FOLDERNAME $BUILD_BUILDNUMBER [skip ci]"; then
-			if git -c http.extraheader="AUTHORIZATION: bearer $SYSTEM_ACCESSTOKEN" push --set-upstream origin "$BRANCH" --force-with-lease; then
+			if git -c http.extraheader="AUTHORIZATION: bearer $SYSTEM_ACCESSTOKEN" push --set-upstream origin "$BUILD_SOURCEBRANCHNAME" --force-with-lease; then
 				echo "Failed to push changes to the repository."
 			fi
 		fi
 
 	else
 		if git commit -m "Added updates from Control Plane Deployment for $DEPLOYER_FOLDERNAME $LIBRARY_FOLDERNAME $BUILD_BUILDNUMBER [skip ci]"; then
-			if git -c http.extraheader="AUTHORIZATION: bearer $SYSTEM_ACCESSTOKEN" push --set-upstream origin "$BRANCH" --force-with-lease; then
+			if git -c http.extraheader="AUTHORIZATION: bearer $SYSTEM_ACCESSTOKEN" push --set-upstream origin "$BUILD_SOURCEBRANCHNAME" --force-with-lease; then
 				echo "Failed to push changes to the repository."
 			fi
 		fi

--- a/deploy/scripts/pipeline_scripts/01-control-plane-prepare.sh
+++ b/deploy/scripts/pipeline_scripts/01-control-plane-prepare.sh
@@ -61,8 +61,8 @@ if [ 0 != "${step}" ]; then
 	exit 0
 fi
 
-echo -e "$green--- Checkout $BRANCH ---$reset"
-git checkout -q "$BRANCH"
+echo -e "$green--- Checkout $BUILD_SOURCEBRANCHNAME ---$reset"
+git checkout -q "$BUILD_SOURCEBRANCHNAME"
 
 echo -e "$green--- Configure devops CLI extension ---$reset"
 az config set extension.use_dynamic_install=yes_without_prompt --only-show-errors
@@ -302,7 +302,7 @@ added=0
 cd "$CONFIG_REPO_PATH" || exit
 
 # Pull changes
-git pull -q origin "$BRANCH"
+git pull -q origin "$BUILD_SOURCEBRANCHNAME"
 
 echo -e "$green--- Update repo ---$reset"
 
@@ -333,7 +333,7 @@ if [ 1 = $added ]; then
 	git config --global user.email "$BUILD_REQUESTEDFOREMAIL"
 	git config --global user.name "$BUILD_REQUESTEDFOR"
 	git commit -m "Added updates from Control Plane Deployment for $DEPLOYER_FOLDERNAME $LIBRARY_FOLDERNAME $BUILD_BUILDNUMBER [skip ci]"
-	if ! git -c http.extraheader="AUTHORIZATION: bearer $SYSTEM_ACCESSTOKEN" push --set-upstream origin "$BRANCH" --force-with-lease; then
+	if ! git -c http.extraheader="AUTHORIZATION: bearer $SYSTEM_ACCESSTOKEN" push --set-upstream origin "$BUILD_SOURCEBRANCHNAME" --force-with-lease; then
 		echo "##vso[task.logissue type=error]Failed to push changes to the repository."
 	fi
 fi

--- a/deploy/scripts/pipeline_scripts/02-sap-workload-zone.sh
+++ b/deploy/scripts/pipeline_scripts/02-sap-workload-zone.sh
@@ -35,11 +35,11 @@ if [ ! -f "$CONFIG_REPO_PATH/LANDSCAPE/$WORKLOAD_ZONE_FOLDERNAME/$WORKLOAD_ZONE_
 	exit 2
 fi
 
-echo -e "$green--- Checkout $BRANCH ---$reset"
+echo -e "$green--- Checkout $BUILD_SOURCEBRANCHNAME ---$reset"
 
 cd "${CONFIG_REPO_PATH}" || exit
 mkdir -p .sap_deployment_automation
-git checkout -q "$BRANCH"
+git checkout -q "$BUILD_SOURCEBRANCHNAME"
 
 echo -e "$green--- Validations ---$reset"
 if [ "$USE_MSI" != "true" ]; then
@@ -473,7 +473,7 @@ echo -e "$green--- Add & update files in the DevOps Repository ---$reset"
 
 cd "$CONFIG_REPO_PATH" || exit
 # Pull changes
-git pull -q origin "$BRANCH"
+git pull -q origin "$BUILD_SOURCEBRANCHNAME"
 
 added=0
 if [ -f ".sap_deployment_automation/${prefix}" ]; then
@@ -506,10 +506,10 @@ if [ 1 == $added ]; then
 	git config --global user.email "$BUILD_REQUESTEDFOREMAIL"
 	git config --global user.name "$BUILD_REQUESTEDFOR"
 	git commit -m "Added updates from devops deployment $BUILD_BUILDNUMBER of $WORKLOAD_ZONE_FOLDERNAME [skip ci]"
-	if git -c http.extraheader="AUTHORIZATION: bearer $SYSTEM_ACCESSTOKEN" push --set-upstream origin "$BRANCH" --force-with-lease; then
-		echo "##vso[task.logissue type=warning]Workload deployment $WORKLOAD_ZONE_FOLDERNAME pushed to $BRANCH"
+	if git -c http.extraheader="AUTHORIZATION: bearer $SYSTEM_ACCESSTOKEN" push --set-upstream origin "$BUILD_SOURCEBRANCHNAME" --force-with-lease; then
+		echo "##vso[task.logissue type=warning]Workload deployment $WORKLOAD_ZONE_FOLDERNAME pushed to $BUILD_SOURCEBRANCHNAME"
 	else
-		echo "##vso[task.logissue type=error]Failed to push changes to $BRANCH"
+		echo "##vso[task.logissue type=error]Failed to push changes to $BUILD_SOURCEBRANCHNAME"
 	fi
 
 fi

--- a/deploy/scripts/pipeline_scripts/03-sap-system-deployment.sh
+++ b/deploy/scripts/pipeline_scripts/03-sap-system-deployment.sh
@@ -32,11 +32,11 @@ echo "##vso[build.updatebuildnumber]Deploying the SAP System defined in $SAP_SYS
 
 tfvarsFile="SYSTEM/$SAP_SYSTEM_FOLDERNAME/$SAP_SYSTEM_TFVARS_FILENAME"
 
-echo -e "$green--- Checkout $BRANCH ---$reset"
+echo -e "$green--- Checkout $BUILD_SOURCEBRANCHNAME ---$reset"
 
 cd "${CONFIG_REPO_PATH}" || exit
 mkdir -p .sap_deployment_automation
-git checkout -q "$BRANCH"
+git checkout -q "$BUILD_SOURCEBRANCHNAME"
 
 if [ ! -f "$CONFIG_REPO_PATH/SYSTEM/$SAP_SYSTEM_FOLDERNAME/$SAP_SYSTEM_TFVARS_FILENAME" ]; then
 	echo -e "$bold_red--- $SAP_SYSTEM_TFVARS_FILENAME was not found ---$reset"
@@ -253,7 +253,7 @@ echo -e "$green--- Add & update files in the DevOps Repository ---$reset"
 cd "$CONFIG_REPO_PATH" || exit
 echo -e "$green--- Pull the latest content from DevOps ---$reset"
 # Pull changes
-git pull -q origin "$BRANCH"
+git pull -q origin "$BUILD_SOURCEBRANCHNAME"
 
 # Pull changes if there are other deployment jobs
 
@@ -315,10 +315,10 @@ if [ 1 == $added ]; then
 	git config --global user.name "$BUILD_REQUESTEDFOR"
 	git commit -m "Added updates from SAP deployment of $SAP_SYSTEM_FOLDERNAME for $BUILD_BUILDNUMBER [skip ci]"
 
-	if git -c http.extraheader="AUTHORIZATION: bearer SYSTEM_ACCESSTOKEN" push --set-upstream origin "$BRANCH" --force-with-lease; then
-		echo "##vso[task.logissue type=warning]Changes from SAP deployment of $SAP_SYSTEM_FOLDERNAME pushed to $BRANCH"
+	if git -c http.extraheader="AUTHORIZATION: bearer SYSTEM_ACCESSTOKEN" push --set-upstream origin "$BUILD_SOURCEBRANCHNAME" --force-with-lease; then
+		echo "##vso[task.logissue type=warning]Changes from SAP deployment of $SAP_SYSTEM_FOLDERNAME pushed to $BUILD_SOURCEBRANCHNAME"
 	else
-		echo "##vso[task.logissue type=error]Failed to push changes to $BRANCH"
+		echo "##vso[task.logissue type=error]Failed to push changes to $BUILD_SOURCEBRANCHNAME"
 	fi
 fi
 

--- a/deploy/scripts/pipeline_scripts/10-remover-terraform-system.sh
+++ b/deploy/scripts/pipeline_scripts/10-remover-terraform-system.sh
@@ -27,10 +27,10 @@ set -eu
 
 tfvarsFile="SYSTEM/$SAP_SYSTEM_FOLDERNAME/$SAP_SYSTEM_TFVARS_FILENAME"
 
-echo -e "$green--- Checkout $BRANCH ---$reset"
+echo -e "$green--- Checkout $BUILD_SOURCEBRANCHNAME ---$reset"
 
 cd "${CONFIG_REPO_PATH}" || exit
-git checkout -q "$BRANCH"
+git checkout -q "$BUILD_SOURCEBRANCHNAME"
 
 if [ ! -f "$CONFIG_REPO_PATH/SYSTEM/$SAP_SYSTEM_FOLDERNAME/$SAP_SYSTEM_TFVARS_FILENAME" ]; then
   echo -e "$bold_red--- $SAP_SYSTEM_TFVARS_FILENAME was not found ---$reset"
@@ -245,7 +245,7 @@ ${SAP_AUTOMATION_REPO_PATH}/deploy/scripts/remover.sh \
 
 return_code=$?
 echo -e "$green--- Pull latest from DevOps Repository ---$reset"
-git checkout -q "$BRANCH"
+git checkout -q "$BUILD_SOURCEBRANCHNAME"
 git pull
 
 #stop the pipeline after you have reset the whitelisting on your resources
@@ -267,8 +267,8 @@ if [ 0 == $return_code ]; then
     rm -r .terraform
   fi
   # Pull changes
-  git checkout -q "$BRANCH"
-  git pull origin "$BRANCH"
+  git checkout -q "$BUILD_SOURCEBRANCHNAME"
+  git pull origin "$BUILD_SOURCEBRANCHNAME"
 
   git clean -d -f -X
 
@@ -322,10 +322,10 @@ if [ 0 == $return_code ]; then
     git config --global user.name "$BUILD_REQUESTEDFOR"
 
     if git commit -m "Infrastructure for $SAP_SYSTEM_TFVARS_FILENAME removed. [skip ci]"; then
-      if git -c http.extraheader="AUTHORIZATION: bearer $SYSTEM_ACCESSTOKEN" push --set-upstream origin "$BRANCH" --force-with-lease; then
+      if git -c http.extraheader="AUTHORIZATION: bearer $SYSTEM_ACCESSTOKEN" push --set-upstream origin "$BUILD_SOURCEBRANCHNAME" --force-with-lease; then
         echo "##vso[task.logissue type=warning]Removal of $SAP_SYSTEM_TFVARS_FILENAME updated in $BUILD_BUILDNUMBER"
       else
-        echo "##vso[task.logissue type=error]Failed to push changes to $BRANCH"
+        echo "##vso[task.logissue type=error]Failed to push changes to $BUILD_SOURCEBRANCHNAME"
       fi
     fi
   fi

--- a/deploy/scripts/pipeline_scripts/10-remover-terraform-workload-zone.sh
+++ b/deploy/scripts/pipeline_scripts/10-remover-terraform-workload-zone.sh
@@ -28,11 +28,11 @@ set -eu
 
 tfvarsFile="LANDSCAPE/$WORKLOAD_ZONE_FOLDERNAME/$WORKLOAD_ZONE_TFVARS_FILENAME"
 
-echo -e "$green--- Checkout $BRANCH ---$reset"
+echo -e "$green--- Checkout $BUILD_SOURCEBRANCHNAME ---$reset"
 
 cd "${CONFIG_REPO_PATH}" || exit
 mkdir -p .sap_deployment_automation
-git checkout -q "$BRANCH"
+git checkout -q "$BUILD_SOURCEBRANCHNAME"
 
 if [ ! -f "$CONFIG_REPO_PATH/LANDSCAPE/$WORKLOAD_ZONE_FOLDERNAME/$WORKLOAD_ZONE_TFVARS_FILENAME" ]; then
   echo -e "$bold_red--- $WORKLOAD_ZONE_TFVARS_FILENAME was not found ---$reset"
@@ -237,7 +237,7 @@ ${SAP_AUTOMATION_REPO_PATH}/deploy/scripts/remover.sh \
 
 return_code=$?
 echo -e "$green--- Pull latest from DevOps Repository ---$reset"
-git checkout -q "$BRANCH"
+git checkout -q "$BUILD_SOURCEBRANCHNAME"
 git pull
 
 #stop the pipeline after you have reset the whitelisting on your resources
@@ -253,8 +253,8 @@ cd "$CONFIG_REPO_PATH" || exit
 
 changed=0
 # Pull changes
-git checkout -q "$BRANCH"
-git pull origin "$BRANCH"
+git checkout -q "$BUILD_SOURCEBRANCHNAME"
+git pull origin "$BUILD_SOURCEBRANCHNAME"
 
 cd "${CONFIG_REPO_PATH}" || exit
 
@@ -293,10 +293,10 @@ if [ 0 == $return_code ]; then
     git config --global user.name "$BUILD_REQUESTEDFOR"
 
     if git commit -m "Infrastructure for $WORKLOAD_ZONE_TFVARS_FILENAME removed. [skip ci]"; then
-      if git -c http.extraheader="AUTHORIZATION: bearer $SYSTEM_ACCESSTOKEN" push --set-upstream origin "$BRANCH" --force-with-lease; then
-        echo "##vso[task.logissue type=warning]Removal of $WORKLOAD_ZONE_TFVARS_FILENAME updated in $BRANCH"
+      if git -c http.extraheader="AUTHORIZATION: bearer $SYSTEM_ACCESSTOKEN" push --set-upstream origin "$BUILD_SOURCEBRANCHNAME" --force-with-lease; then
+        echo "##vso[task.logissue type=warning]Removal of $WORKLOAD_ZONE_TFVARS_FILENAME updated in $BUILD_SOURCEBRANCHNAME"
       else
-        echo "##vso[task.logissue type=error]Failed to push changes to $BRANCH"
+        echo "##vso[task.logissue type=error]Failed to push changes to $BUILD_SOURCEBRANCHNAME"
       fi
     fi
   fi

--- a/deploy/scripts/pipeline_scripts/11-remover-arm-fallback-control-plane.sh
+++ b/deploy/scripts/pipeline_scripts/11-remover-arm-fallback-control-plane.sh
@@ -82,7 +82,7 @@ echo "##vso[task.setprogress value=90;]Progress Indicator"
 
 if [ 0 == $return_code ]; then
   cd "$CONFIG_REPO_PATH" || exit
-  git checkout -q $BRANCH
+  git checkout -q $BUILD_SOURCEBRANCHNAME
   git pull
   changed=0
 
@@ -137,10 +137,10 @@ if [ 0 == $return_code ]; then
     git config --global user.email "$BUILD_REQUESTEDFOREMAIL"
     git config --global user.name "$BUILD_REQUESTEDFOR"
     git commit -m "Added updates from devops deployment $BUILD_BUILDNUMBER [skip ci]"
-    if git -c http.extraheader="AUTHORIZATION: bearer $SYSTEM_ACCESSTOKEN" push --set-upstream origin "$BRANCH" --force-with-lease; then
-      echo "##vso[task.logissue type=warning]Changes pushed to $BRANCH"
+    if git -c http.extraheader="AUTHORIZATION: bearer $SYSTEM_ACCESSTOKEN" push --set-upstream origin "$BUILD_SOURCEBRANCHNAME" --force-with-lease; then
+      echo "##vso[task.logissue type=warning]Changes pushed to $BUILD_SOURCEBRANCHNAME"
     else
-      echo "##vso[task.logissue type=error]Failed to push changes to $BRANCH"
+      echo "##vso[task.logissue type=error]Failed to push changes to $BUILD_SOURCEBRANCHNAME"
     fi
     echo -e "$green--- Deleting variables ---$reset"
     if [ ${#VARIABLE_GROUP_ID} != 0 ]; then

--- a/deploy/scripts/pipeline_scripts/11-remover-arm-fallback-system.sh
+++ b/deploy/scripts/pipeline_scripts/11-remover-arm-fallback-system.sh
@@ -32,7 +32,7 @@ cd "$CONFIG_REPO_PATH/SYSTEM/$SAP_SYSTEM_FOLDERNAME" || exit
 echo "##vso[build.updatebuildnumber]Removing SAP System zone $SAP_SYSTEM_FOLDERNAME"
 changed=0
 
-git checkout -q "$BRANCH"
+git checkout -q "$BUILD_SOURCEBRANCHNAME"
 git clean -d -f -X
 
 if [ -f ".terraform/terraform.tfstate" ]; then
@@ -85,10 +85,10 @@ if [ 1 == $changed ]; then
   git config --global user.name "$BUILD_REQUESTEDFOR"
 
   if git commit -m "Infrastructure for $SAP_SYSTEM_TFVARS_FILENAME removed. [skip ci]"; then
-    if git -c http.extraheader="AUTHORIZATION: bearer $SYSTEM_ACCESSTOKEN" push --set-upstream origin "$BRANCH" --force-with-lease; then
+    if git -c http.extraheader="AUTHORIZATION: bearer $SYSTEM_ACCESSTOKEN" push --set-upstream origin "$BUILD_SOURCEBRANCHNAME" --force-with-lease; then
       echo "##vso[task.logissue type=warning]Removal of $SAP_SYSTEM_TFVARS_FILENAME updated in $BUILD_BUILDNUMBER"
     else
-      echo "##vso[task.logissue type=error]Failed to push changes to $BRANCH"
+      echo "##vso[task.logissue type=error]Failed to push changes to $BUILD_SOURCEBRANCHNAME"
     fi
   fi
 fi

--- a/deploy/scripts/pipeline_scripts/11-remover-arm-fallback-workload-zone.sh
+++ b/deploy/scripts/pipeline_scripts/11-remover-arm-fallback-workload-zone.sh
@@ -43,7 +43,7 @@ git config --global user.email "$BUILD_REQUESTEDFOREMAIL"
 git config --global user.name "$BUILD_REQUESTEDFOR"
 git commit -m "Added updates from devops deployment $BUILD_BUILDNUMBER [skip ci]"
 
-git checkout -q "$BRANCH"
+git checkout -q "$BUILD_SOURCEBRANCHNAME"
 git clean -d -f -X
 
 

--- a/deploy/scripts/pipeline_scripts/12-remove-control-plane-finalize.sh
+++ b/deploy/scripts/pipeline_scripts/12-remove-control-plane-finalize.sh
@@ -220,7 +220,7 @@ return_code=$?
 echo "Return code from remove_deployer: $return_code."
 
 echo -e "$green--- Remove Control Plane Part 2 ---$reset"
-git checkout -q "$BRANCH"
+git checkout -q "$BUILD_SOURCEBRANCHNAME"
 git pull -q
 
 if [ 0 == $return_code ]; then
@@ -263,12 +263,12 @@ if [ 0 == $return_code ]; then
 		git config --global user.email "$BUILD_REQUESTEDFOREMAIL"
 		git config --global user.name "$BUILD_REQUESTEDFOR"
 		if git commit -m "Control Plane $DEPLOYER_FOLDERNAME removal step 2[skip ci]"; then
-			if git -c http.extraheader="AUTHORIZATION: bearer $SYSTEM_ACCESSTOKEN" push --set-upstream origin "$BRANCH" --force-with-lease; then
+			if git -c http.extraheader="AUTHORIZATION: bearer $SYSTEM_ACCESSTOKEN" push --set-upstream origin "$BUILD_SOURCEBRANCHNAME" --force-with-lease; then
 				return_code=$?
-				echo "##vso[task.logissue type=warning]Control Plane $DEPLOYER_FOLDERNAME removal step 2 updated in $BRANCH"
+				echo "##vso[task.logissue type=warning]Control Plane $DEPLOYER_FOLDERNAME removal step 2 updated in $BUILD_SOURCEBRANCHNAME"
 			else
 				return_code=$?
-				echo "##vso[task.logissue type=error]Failed to push changes to $BRANCH"
+				echo "##vso[task.logissue type=error]Failed to push changes to $BUILD_SOURCEBRANCHNAME"
 			fi
 		fi
 	fi

--- a/deploy/scripts/pipeline_scripts/12-remove-control-plane.sh
+++ b/deploy/scripts/pipeline_scripts/12-remove-control-plane.sh
@@ -233,7 +233,7 @@ echo "Return code from remove_controlplane: $return_code."
 
 echo -e "$green--- Remove Control Plane Part 1 ---$reset"
 cd "$CONFIG_REPO_PATH" || exit
-git checkout -q "$BRANCH"
+git checkout -q "$BUILD_SOURCEBRANCHNAME"
 
 changed=0
 if [ -f "$deployer_environment_file_name" ]; then
@@ -289,12 +289,12 @@ if [ 1 == $changed ]; then
 
 	if git commit -m "Control Plane $DEPLOYER_FOLDERNAME removal step 1[skip ci]"; then
 
-		if git -c http.extraheader="AUTHORIZATION: bearer $SYSTEM_ACCESSTOKEN" push --set-upstream origin "$BRANCH" --force-with-lease; then
+		if git -c http.extraheader="AUTHORIZATION: bearer $SYSTEM_ACCESSTOKEN" push --set-upstream origin "$BUILD_SOURCEBRANCHNAME" --force-with-lease; then
 			return_code=$?
-			echo "##vso[task.logissue type=warning]Control Plane $DEPLOYER_FOLDERNAME removal step 2 updated in $BRANCH"
+			echo "##vso[task.logissue type=warning]Control Plane $DEPLOYER_FOLDERNAME removal step 2 updated in $BUILD_SOURCEBRANCHNAME"
 		else
 			return_code=$?
-			echo "##vso[task.logissue type=error]Failed to push changes to $BRANCH"
+			echo "##vso[task.logissue type=error]Failed to push changes to $BUILD_SOURCEBRANCHNAME"
 		fi
 	fi
 

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/infrastructure.tf
@@ -152,10 +152,10 @@ resource "azurerm_lb_probe" "hdb_active_active" {
   provider                             = azurerm.main
   count                                = local.enable_db_lb_deployment && var.database_active_active ? 1 : 0
   name                                 = format("%s%s%s%s",
-                                           var.naming.resource_prefixes.db_rlb_hp,
+                                           try(var.naming.resource_prefixes.db_rlb_hp, ""),
                                            local.prefix,
                                            var.naming.separator,
-                                           local.resource_suffixes.db_rlb_hp
+                                           try(local.resource_suffixes.db_rlb_hp, "dbRlb-hp")
                                          )
   loadbalancer_id                      = azurerm_lb.hdb[count.index].id
   port                                 = "626${var.database.instance.number}"
@@ -169,10 +169,10 @@ resource "azurerm_lb_rule" "hdb_active_active" {
   provider                             = azurerm.main
   count                                = local.enable_db_lb_deployment && var.database_active_active ? 1 : 0
   name                                 = format("%s%s%s%s",
-                                           var.naming.resource_prefixes.db_rlb_rule,
+                                           try(var.naming.resource_prefixes.db_rlb_rule, ""),
                                            local.prefix,
                                            var.naming.separator,
-                                           local.resource_suffixes.db_rlb_rule
+                                           try(local.resource_suffixes.db_rlb_rule, "dbRlb-rule")
                                          )
   loadbalancer_id                      = azurerm_lb.hdb[count.index].id
   protocol                             = "All"

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
@@ -192,10 +192,10 @@ locals {
                                           },
                                           {
                                             name = format("%s%s%s%s",
-                                              var.naming.resource_prefixes.db_rlb_feip,
+                                              try(var.naming.resource_prefixes.db_rlb_feip, ""),
                                               local.prefix,
                                               var.naming.separator,
-                                              local.resource_suffixes.db_rlb_feip
+                                              try(local.resource_suffixes.db_rlb_feip, "dbRlb-feip")
                                             )
                                             subnet_id = var.database.scale_out ? var.admin_subnet.id : var.db_subnet.id
                                             private_ip_address = length(try(var.database.loadbalancer.frontend_ips[1], "")) > 0 ? (


### PR DESCRIPTION
## Problem

This PR fixes two separate issues introduced by the latest SDAF release.

1. The introduction of new properties derived from the sap_namegenerator is not backwards compatible with the system removal pipeline when using the `{SID}_resource_names.json` to handle custom naming. This is due to the naming map being saved in the tfstate file and missing the new properties. Instead of having to modify the tfstate or doing a redeployment before removal, this PR ensures that the suffixes/prefixes that are missing from the object, are set to the defaults if they are missing.  

2. When running a pipeline on a branch, the current version correctly checks out the source code from the $(Build.SourceBranch), but utilizes the wrong environment variable for the branch inside the sh scripts. Meaning removal and adding of files to the config repo are always triggered on the main branch. This PR ensures that `$BUILD_SOURCEBRANCHNAME` is used instead of `$BRANCH`.