### PR TITLE
Fix ARM_SUBSCRIPTION_ID after LogonToAzure with MSI

### DIFF
--- a/deploy/pipelines/helper.sh
+++ b/deploy/pipelines/helper.sh
@@ -68,6 +68,8 @@ function configureNonDeployer() {
 
 function LogonToAzure() {
 	local useMSI=$1
+	local subscriptionId=$ARM_SUBSCRIPTION_ID
+
 	if [ "$useMSI" != "true" ]; then
 		echo "Deployment credentials:              Service Principal"
 		echo "Deployment credential ID (SPN):      $ARM_CLIENT_ID"
@@ -76,6 +78,13 @@ function LogonToAzure() {
 	else
 		echo "Deployment credentials:              Managed Service Identity"
 		source "/etc/profile.d/deploy_server.sh"
+
+		# sourcing deploy_server.sh overwrites ARM_SUBSCRIPTION_ID with control plane subscription id
+		# ensure we are exporting the right ARM_SUBSCRIPTION_ID when authenticating against workload zones.
+		if [[ "$ARM_SUBSCRIPTION_ID" != "$subscriptionId" ]]; then
+			ARM_SUBSCRIPTION_ID=$subscriptionId
+			export ARM_SUBSCRIPTION_ID
+		fi
 	fi
 
 }

--- a/deploy/scripts/pipeline_scripts/helper.sh
+++ b/deploy/scripts/pipeline_scripts/helper.sh
@@ -84,6 +84,8 @@ function configureNonDeployer() {
 
 function LogonToAzure() {
 	local useMSI=$1
+	local subscriptionId=$ARM_SUBSCRIPTION_ID
+
 	if [ "$useMSI" != "true" ]; then
 		echo "Deployment credentials:              Service Principal"
 		echo "Deployment credential ID (SPN):      $ARM_CLIENT_ID"
@@ -100,6 +102,12 @@ function LogonToAzure() {
 		TF_VAR_use_spn=false
 		export TF_VAR_use_spn
 
+		# sourcing deploy_server.sh overwrites ARM_SUBSCRIPTION_ID with control plane subscription id
+		# ensure we are exporting the right ARM_SUBSCRIPTION_ID when authenticating against workload zones.
+		if [[ "$ARM_SUBSCRIPTION_ID" != "$subscriptionId" ]]; then
+			ARM_SUBSCRIPTION_ID=$subscriptionId
+			export ARM_SUBSCRIPTION_ID
+		fi
 	fi
 
 }


### PR DESCRIPTION
## Problem

This PR ensures the right `ARM_SUBSCRIPTION_ID` is exported after authenticating with the `LogonToAzure()` function wth MSI.
When using MSI, the `/etc/profile.d/deploy_server.sh` is sourced, which contains the `ARM_SUBSCRIPTION_ID` set to the control plane subscription. This ensures, that if the expected `ARM_SUBSCRIPTION_ID` set before the call to this function is also set after the sourcing.