### PR TITLE
Fix workload zone remediation logic

### DIFF
--- a/deploy/scripts/install_workloadzone.sh
+++ b/deploy/scripts/install_workloadzone.sh
@@ -837,31 +837,34 @@ if [ 1 == $check_output ]; then
 			moduleID='module.sap_landscape.azurerm_storage_account.storage_bootdiag[0]'
 			storage_account_name=$(terraform -chdir="${terraform_module_directory}" output -no-color -raw storageaccount_name)
 			storage_account_rg_name=$(terraform -chdir="${terraform_module_directory}" output -no-color -raw storageaccount_rg_name)
-			STORAGE_ACCOUNT_ID=$(az storage account show --name "${storage_account_name}" --resource-group "${storage_account_rg_name}" --query "id" --output tsv)
+			STORAGE_ACCOUNT_ID=$(az storage account show --subscription "${subscription}" --name "${storage_account_name}" --resource-group "${storage_account_rg_name}" --query "id" --output tsv)
 			export STORAGE_ACCOUNT_ID
 
 			ReplaceResourceInStateFile "${moduleID}" "${terraform_module_directory}" "providers/Microsoft.Storage/storageAccounts"
 
 			moduleID='module.sap_landscape.azurerm_storage_account.witness_storage[0]'
 			storage_account_name=$(terraform -chdir="${terraform_module_directory}" output -no-color -raw witness_storage_account)
-			STORAGE_ACCOUNT_ID=$(az storage account show --name "${storage_account_name}" --resource-group "${storage_account_rg_name}" --query "id" --output tsv)
+			STORAGE_ACCOUNT_ID=$(az storage account show --subscription "${subscription}" --name "${storage_account_name}" --resource-group "${storage_account_rg_name}" --query "id" --output tsv)
 			export STORAGE_ACCOUNT_ID
 			ReplaceResourceInStateFile "${moduleID}" "${terraform_module_directory}" "providers/Microsoft.Storage/storageAccounts"
-			unset STORAGE_ACCOUNT_ID
-
-			moduleID='module.sap_landscape.azurerm_storage_account.install[0]'
-			azureResourceID=$(terraform -chdir="${terraform_module_directory}" state show "${moduleID}" | grep -m1 providers/Microsoft.Storage/storageAccounts | xargs | cut -d "=" -f2 | xargs)
-
-			resourceGroupName=$(az resource show --ids "${azureResourceID}" --query "resourceGroup" --output tsv)
-			resourceType=$(az resource show --ids "${azureResourceID}" --query "type" --output tsv)
-			resourceName=$(az resource show --ids "${azureResourceID}" --query "name" --output tsv)
-			az resource lock create --lock-type CanNotDelete -n "SAP Installation Media account delete lock" --subscription "${subscription}" \
-				--resource-group "${resourceGroupName}" --resource "${resourceName}" --resource-type "${resourceType}"
-
-			ReplaceResourceInStateFile "${moduleID}" "${terraform_module_directory}" "id"
 
 			moduleID='module.sap_landscape.azurerm_storage_account.transport[0]'
+			STORAGE_ACCOUNT_ID=$(terraform -chdir="${terraform_module_directory}" output -raw transport_storage_account_id | xargs | cut -d "=" -f2 | xargs)
+			export STORAGE_ACCOUNT_ID
 			ReplaceResourceInStateFile "${moduleID}" "${terraform_module_directory}" "providers/Microsoft.Storage/storageAccounts"
+
+			moduleID='module.sap_landscape.azurerm_storage_account.install[0]'
+			storage_account_name=$(terraform -chdir="${terraform_module_directory}" output -raw install_path | xargs | cut -d "/" -f2 | xargs)
+			STORAGE_ACCOUNT_ID=$(az storage account show --subscription "${subscription}" --name "${storage_account_name}" --query "id" --output tsv)
+			export STORAGE_ACCOUNT_ID
+
+			resourceGroupName=$(az resource show --subscription "${subscription}" --ids "${STORAGE_ACCOUNT_ID}" --query "resourceGroup" --output tsv)
+			resourceType=$(az resource show --subscription "${subscription}" --ids "${STORAGE_ACCOUNT_ID}" --query "type" --output tsv)
+			az resource lock create --lock-type CanNotDelete -n "SAP Installation Media account delete lock" --subscription "${subscription}" \
+				--resource-group "${resourceGroupName}" --resource "${storage_account_name}" --resource-type "${resourceType}"
+
+			ReplaceResourceInStateFile "${moduleID}" "${terraform_module_directory}" "id"
+			unset STORAGE_ACCOUNT_ID
 
 			moduleID='module.sap_landscape.azurerm_storage_share.transport[0]'
 			ReplaceResourceInStateFile "${moduleID}" "${terraform_module_directory}" "resource_manager_id"


### PR DESCRIPTION
This PR fixes the remediation logic for storage account, which is needed to upgrade the provider with the `data_plane_available` setting.

- This ensures that the `az cli` commands run against the right subscription, as it's authenticated against the state storage subscription, it fails to resolve the resource group from the target workload zone.
- This increases the robustness of the backwards compatibility, in cases where it's been a while since the last re-deployment of a workload zone, there might be introduced changes to resource properties, which then fails the `terraform state show` without a failure message, as the subsequent grep and cut results in a empty string as the resourceId. The fix is to use other means, like the `az cli` to query the resource id or where possible use the `terraform state output`.
- This also streamlines the way storage accounts are handled.
- Further it's changed to use `export STORAGE_ACCOUNT_ID` as setting the `azureResourceID` only worked by chance, as it was overwritten by the function `ReplaceResourceInStateFile`

To increase readability and robustness, the function `ReplaceResourceInStateFile` should be updated to not rely on being aware of context outside it's scope and instead take the `STORAGE_ACCOUNT_ID` as direct input.