### PR TITLE
Fix sybase standalone deployment

### DIFF
--- a/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.6-sybase-mounts.yaml
+++ b/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.6-sybase-mounts.yaml
@@ -121,12 +121,25 @@
 
 - name:                                "SYBASE: Set NFS Server variable"
   ansible.builtin.set_fact:
-    sapmnt_nfs_mount: >-
-                                        {% if (NFS_provider == 'AFS' or NFS_provider == 'ANF') and (sap_mnt is defined) %}{{ sap_mnt }}{% else %}{{ query('inventory_hostnames', '{{ sap_sid | upper }}_SCS') | first }}:/sapmnt/{{ sap_sid | upper }}{% endif %}
+    nfs_server:                        "{{ query('inventory_hostnames', '{{ sap_sid | upper }}_SCS') | first }}"
+  when:
+    - NFS_provider == "NONE"
+    - sap_mnt is not defined
+    - node_tier != 'scs'
+    - node_tier in ['pas', 'app', 'ers', 'oracle', 'db2', 'sybase']
 
-- name:                                "SYBASE: Set NFS Server variable"
+- name:                                "SYBASE: Set NFS Mount variable"
+  ansible.builtin.set_fact:
+    sapmnt_nfs_mount: >-
+                                        {% if (NFS_provider == 'AFS' or NFS_provider == 'ANF') and (sap_mnt is defined) %}{{ sap_mnt }}{% else %}{{ nfs_server }}:/sapmnt/{{ sap_sid | upper }}{% endif %}
+  when:
+    - (nfs_server is defined and nfs_server != ansible_hostname) or nfs_server is not defined
+
+- name:                                "SYBASE: Debug NFS Mount variable"
   ansible.builtin.debug:
     var:  sapmnt_nfs_mount
+  when:
+    - sapmnt_nfs_mount is defined
 
 - name:                                "SYBASE: Set NFS Server options"
   ansible.builtin.set_fact:
@@ -155,6 +168,7 @@
   when:
     - item.tier == "sybase"
     - sap_mnt is undefined
+    - sapmnt_nfs_mount is defined
 
 # Debug for testing
 - name:                                "SYBASE: Print filesystems"

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
@@ -133,10 +133,12 @@ locals {
                                            )
                                          ) : ""
 
-  web_subnet_deployed                  = local.web_subnet_exists ? (
+  web_subnet_deployed                  = local.enable_deployment ? ( local.web_subnet_exists ? (
                                              data.azurerm_subnet.subnet_sap_web[0]) : (
                                              azurerm_subnet.subnet_sap_web[0]
-                                           )
+                                         )) : (
+                                            ""
+                                         )
 
   ##############################################################################################
   #


### PR DESCRIPTION
This PR fixes two problem encountered during a SYBASE standalone deployment.

1. When having `enable_app_tier_deployment` set to false, the infrastructure deployment fails when trying to resolve `web_subnet_deployed` in `app_tier\variables_local.tf`. This is fixed by ensuring the variable defaults to an empty string when `local.enable_deployment` is false, which is the case.
2. Fixes a circular mount of /sapmnt in a standalone deployment using `NFS_provider` = `NONE`, as the standalone host has supported_tiers `scs` and `sybase`.