### PR TITLE
Add SAP Functional Tests support and related configurations

### DIFF
--- a/deploy/ansible/ansible.cfg
+++ b/deploy/ansible/ansible.cfg
@@ -16,6 +16,8 @@ bin_ansible_callbacks = True
 host_key_checking = False
 error_on_undefined_vars = True
 # log_path = /var/tmp/ansible.log
+library = /opt/microsoft/sap_functional_tests/src/modules
+module_utils = /opt/microsoft/sap_functional_tests/src/module_utils
 
 allow_world_readable_tmpfiles = True
 

--- a/deploy/ansible/playbook_06_03_00_sap_functional_tests.yaml
+++ b/deploy/ansible/playbook_06_03_00_sap_functional_tests.yaml
@@ -1,0 +1,20 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+---
+
+# /*---------------------------------------------------------------------------8
+# |                                                                            |
+# |        Playbook for SAP Functional Tests (sap-automation-qa)               |
+# |                                                                            |
+# +------------------------------------4--------------------------------------*/
+
+- hosts:                               localhost
+  name:                                "SAP Functional Tests: - setup deployer"
+  gather_facts:                        true
+  vars_files:                          vars/ansible-input-api.yaml
+  tasks:
+    - name:                            "SAP Functional Tests: - setup prerequisites"
+      ansible.builtin.include_role:
+        name:                          "roles-misc/0.10-sap-functional-tests"
+        tasks_from:                    setup.yaml

--- a/deploy/ansible/playbook_06_03_01_sap_functional_tests.yaml
+++ b/deploy/ansible/playbook_06_03_01_sap_functional_tests.yaml
@@ -1,0 +1,48 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+---
+
+# /*---------------------------------------------------------------------------8
+# |                                                                            |
+# |        Playbook for SAP Functional Tests (sap-automation-qa)               |
+# |                                                                            |
+# +------------------------------------4--------------------------------------*/
+
+- hosts:                               localhost
+  name:                                "SAP Functional Tests: - setup deployer"
+  gather_facts:                        true
+  vars_files:                          vars/ansible-input-api.yaml
+  tasks:
+    - name:                            "SAP Functional Tests: - Create Progress folder"
+      ansible.builtin.file:
+        path:                          "{{ _workspace_directory }}/.progress"
+        state:                         directory
+        mode:                          0755
+
+    - name:                            "SAP Functional Tests: - Remove sap-funtional-test flag"
+      ansible.builtin.file:
+        path:                          "{{ _workspace_directory }}/.progress/sap-functional-tests-done"
+        state:                          absent
+
+# noqa syntax-check[missing-file]
+- name:                                "SAP Functional DB: Tests run checks"
+  ansible.builtin.import_playbook:     "/opt/microsoft/sap_functional_tests/src/playbook_00_ha_db_functional_tests.yml"
+  when:                                sap_functional_test_type == "DatabaseHighAvailability"
+
+# noqa syntax-check[missing-file]
+- name:                                "SAP Functional Central Services: Tests run checks"
+  ansible.builtin.import_playbook:     "/opt/microsoft/sap_functional_tests/src/playbook_00_ha_scs_functional_tests.yml"
+  when:                                sap_functional_test_type == "CentralServicesHighAvailability"
+
+- hosts:                               localhost
+  name:                                "SAP Functional Tests: - Done"
+  gather_facts:                        true
+  vars_files:                          vars/ansible-input-api.yaml
+  tasks:
+    - name:                            "SAP Functional Tests: - Create sap-functional-tests-done flag"
+      ansible.builtin.file:
+        path:                          "{{ _workspace_directory }}/.progress/sap-functional-tests-done"
+        state:                         touch
+        mode:                          0755
+...

--- a/deploy/ansible/roles-misc/0.10-sap-functional-tests/tasks/setup.yaml
+++ b/deploy/ansible/roles-misc/0.10-sap-functional-tests/tasks/setup.yaml
@@ -1,0 +1,29 @@
+# /*---------------------------------------------------------------------------8
+# |                                                                            |
+# |                Setup environment to run SAP Functional Tests               |
+# |                        from the sap-automation-qa                          |
+# +------------------------------------4--------------------------------------*/
+---
+
+- name:                            SAP Functional Tests - setup directories
+  become:                          true
+  ansible.builtin.file:
+    path:                          "{{ item.path }}"
+    state:                         directory
+    mode:                          0755
+    owner:                         "{{ item.owner }}"
+  loop:
+    - { path: "/opt/microsoft/sap_functional_tests", owner: "{{ orchestration_ansible_user }}" }
+    - { path: "{{ _workspace_directory }}/quality_assurance", owner: "{{ orchestration_ansible_user }}" }
+
+- name:                            "SAP Functional Tests - fetch sap-automation-qa"
+  become:                          true
+  ansible.builtin.git:
+    repo:                          "https://{{ github_pat }}@github.com/Azure/sap-automation-qa.git"
+    dest:                          "/opt/microsoft/sap_functional_tests"
+    version:                       main
+    clone:                         true
+    single_branch:                 true
+    force:                         true
+
+...

--- a/deploy/ansible/vars/ansible-input-api.yaml
+++ b/deploy/ansible/vars/ansible-input-api.yaml
@@ -305,3 +305,7 @@ UIDs:
     uid:                               "{{ sidadm_uid }}"
   SQLSERVER:
     uid:                               "{{ sidadm_uid }}"
+
+# ------------------- Begin - SAP Functional Tests variables --------------------8
+sap_functional_test_type:              ""
+# ------------------- End - SAP Functional Tests variables --------------------8

--- a/deploy/pipelines/05-DB-and-SAP-installation.yaml
+++ b/deploy/pipelines/05-DB-and-SAP-installation.yaml
@@ -85,11 +85,6 @@ parameters:
     type:                              boolean
     default:                           false
 
-  - name:                              sap_on_azure_quality_checks
-    displayName:                       SAP on Azure Quality Checks
-    type:                              boolean
-    default:                           false
-
   - name:                              ams_provider
     displayName:                       Configure AMS Provider
     type:                              boolean
@@ -410,26 +405,6 @@ stages:
                   azureSubscriptionId:       $(ARM_SUBSCRIPTION_ID)
                   USE_MSI:                   $(USE_MSI)
                   CONTROL_PLANE_SUBSCRIPTION_ID: $(Terraform_Remote_Storage_Subscription)
-          - ${{ if eq(parameters.sap_on_azure_quality_checks, true) }}:
-              - template:                    templates\run-ansible.yaml
-                parameters:
-                  displayName:               SAP on Azure quality checks
-                  ansibleFilePath:           ${{ parameters.sap_automation_repo_path }}/deploy/ansible/playbook_06_02_sap_on_azure_quality_checks.yaml
-                  ansibleConfigPath:         ${{ parameters.sap_automation_repo_path }}/deploy/ansible/ansible.cfg
-                  secretName:                "$(Preparation.SSH_KEY_NAME)"
-                  passwordSecretName:        "$(Preparation.PASSWORD_KEY_NAME)"
-                  userNameSecretName:        "$(Preparation.USERNAME_KEY_NAME)"
-                  vaultName:                 $(Preparation.VAULT_NAME)
-                  parametersFolder:          $(Preparation.FOLDER)
-                  sapParams:                 "${{ parameters.config_repo_path }}/$(Deployment_Configuration_Path)/SYSTEM/${{ parameters.sap_system_configuration_name }}/artifacts/$(Preparation.SAP_PARAMETERS)"
-                  sidHosts:                  $(Preparation.HOSTS)
-                  extraParams:               "$(Preparation.NEW_PARAMETERS)"
-                  azureClientId:             $(ARM_CLIENT_ID)
-                  azureClientSecret:         $(ARM_CLIENT_SECRET)
-                  azureTenantId:             $(ARM_TENANT_ID)
-                  azureSubscriptionId:       $(ARM_SUBSCRIPTION_ID)
-                  USE_MSI:                   $(USE_MSI)
-                  CONTROL_PLANE_SUBSCRIPTION_ID: $(Terraform_Remote_Storage_Subscription)
           - ${{ if eq(parameters.acss_registration, true) }}:
               - template:                    templates\acss-registration.yaml
                 parameters:
@@ -474,5 +449,3 @@ stages:
           - template:                        templates\collect-log-files.yaml
             parameters:
               logPath:                       ${{ parameters.config_repo_path }}/$(Deployment_Configuration_Path)/SYSTEM/${{ parameters.sap_system_configuration_name }}/logs
-              qualityAssuranceResultsPath:   ${{ parameters.config_repo_path }}/$(Deployment_Configuration_Path)/SYSTEM/${{ parameters.sap_system_configuration_name }}/quality_assurance
-              collectQualityChecks:          ${{ parameters.sap_on_azure_quality_checks }}

--- a/deploy/pipelines/13-sap-quality-assurance.yaml
+++ b/deploy/pipelines/13-sap-quality-assurance.yaml
@@ -1,0 +1,323 @@
+---
+# /*---------------------------------------------------------------------------8
+# |                                                                            |
+# |               This pipeline performs the SAP quality assurance             |
+# |              tests and must run on a self hosted deployment agent          |
+# |                      due to long run time.                                 |
+# |                                                                            |
+# +------------------------------------4--------------------------------------*/
+
+parameters:
+  - name:                              sap_system_configuration_name
+    displayName:                       "SAP System configuration name, use the following syntax: ENV-LOCA-VNET-SID"
+    type:                              string
+    default:                           DEV-WEEU-SAP01-X00
+
+  - name:                              environment
+    displayName:                       Workload Environment (DEV, QUA, PRD, ...)
+    type:                              string
+    default:                           DEV
+
+  - name:                              sap_on_azure_quality_checks
+    displayName:                       SAP on Azure Quality Checks
+    type:                              boolean
+    default:                           true
+
+  - name:                              sap_functional_tests
+    displayName:                       SAP Functional Tests
+    type:                              boolean
+    default:                           true
+
+  - name:                              sap_functional_test_type
+    displayName:                       SAP Functional Tests Type
+    type:                              string
+    default:                           "DatabaseHighAvailability"
+    values:
+      - "DatabaseHighAvailability"
+      - "CentralServicesHighAvailability"
+
+  - name:                              telemetry_data_destination
+    displayName:                       Telemetry Data Destination (Provide connection settings in Extra Parameters)
+    type:                              string
+    default:                           ""
+    values:
+      - "AzureLogAnalytics"
+      - "AzureDataExplorer"
+
+  - name:                              extra_params
+    displayName:                       Extra Parameters
+    type:                              string
+    default:                           ""
+
+  - name:                              sap_automation_repo_path
+    displayName:                       The local path on the agent where the sap_automation repo can be found
+    type:                              string
+
+  - name:                              config_repo_path
+    displayName:                       The local path on the agent where the config repo can be found
+    type:                              string
+
+stages:
+  - stage:                             Preparation_for_Ansible
+    condition:                         and(not(failed()), not(canceled()))
+    variables:
+      - template:                      variables/13-sap-quality-assurance.yaml
+        parameters:
+          environment:                 ${{ parameters.environment }}
+    displayName:                       SAP Quality Assurance Tests
+    jobs:
+      - job:                           Installation_step
+        displayName:                   SAP Quality Assurance Tests
+        timeoutInMinutes:              0
+        workspace:
+          clean:                       all
+        steps:
+          - template:                  templates\download.yaml
+            parameters:
+              getLatestFromBranch:     true
+          - task:                      PostBuildCleanup@3
+          - bash: |
+              #!/bin/bash
+              # Exit immediately if a command exits with a non-zero status.
+              set -e
+
+              green="\e[1;32m" ; reset="\e[0m" ; boldred="\e[1;31m"
+              if [[ ! -f /etc/profile.d/deploy_server.sh ]]; then
+                echo -e "$green --- Install dos2unix ---$reset"
+                  sudo apt-get -qq install dos2unix
+              fi
+              echo -e "$green--- Convert config file to UX format ---$reset"
+              echo -e "$green--- Update .sap_deployment_automation/config as DEPLOYMENT_REPO_PATH can change on devops agent ---$reset"
+                export HOME=${CONFIG_REPO_PATH}/$(Deployment_Configuration_Path)
+                cd $HOME
+
+              echo -e "$green--- Configure devops CLI extension ---$reset"
+                az config set extension.use_dynamic_install=yes_without_prompt  --output none
+
+                az extension add --name azure-devops --output none
+
+                az devops configure --defaults organization=$(System.CollectionUri) project='$(System.TeamProject)' --output none
+
+              echo -e "$green--- Validations ---$reset"
+                ENVIRONMENT=$(echo ${SAP_SYSTEM_CONFIGURATION_NAME} | awk -F'-' '{print $1}' | xargs) ; echo Environment $ENVIRONMENT
+                   LOCATION=$(echo ${SAP_SYSTEM_CONFIGURATION_NAME} | awk -F'-' '{print $2}' | xargs) ; echo Location    $LOCATION
+                    NETWORK=$(echo ${SAP_SYSTEM_CONFIGURATION_NAME} | awk -F'-' '{print $3}' | xargs) ; echo Virtual network logical name $NETWORK
+                        SID=$(echo ${SAP_SYSTEM_CONFIGURATION_NAME} | awk -F'-' '{print $4}' | xargs) ; echo SID $SID
+
+                environment_file_name=$HOME/.sap_deployment_automation/$ENVIRONMENT$LOCATION$NETWORK ; echo configuration_file $environment_file_name
+                          params_file=$HOME/SYSTEM/${SAP_SYSTEM_CONFIGURATION_NAME}/sap-parameters.yaml              ;  echo sap_parameters_file $params_file
+
+              if [ "azure pipelines" = "$(this_agent)" ]; then
+                  echo "##vso[task.logissue type=error]Please use a self hosted agent for this playbook. Define it in the SDAF-${ENVIRONMENT} variable group using the 'POOL' variable."
+                  exit 2
+                fi
+
+                if [ ! -f $environment_file_name ]; then
+                  echo -e "$boldred--- $environment_file_name was not found ---$reset"
+                  echo "##vso[task.logissue type=error]Workload zone configuration file $environment_file_name was not found."
+                  exit 2
+                fi
+
+                if [ ! -f $params_file ]; then
+                  echo -e "$boldred--- $HOME/SYSTEM/${SAP_SYSTEM_CONFIGURATION_NAME}/sap-parameters.yaml was not found ---$reset"
+                  echo "##vso[task.logissue type=error]File $HOME/SYSTEM/${SAP_SYSTEM_CONFIGURATION_NAME}/sap-parameters.yaml was not found."
+                  exit 2
+                else
+                  dos2unix -q $HOME/SYSTEM/${SAP_SYSTEM_CONFIGURATION_NAME}/sap-parameters.yaml
+                fi
+
+                if [ ! -n ${SID} ]; then
+                  echo "##vso[task.logissue type=error]SID was not found in ${SAP_SYSTEM_CONFIGURATION_NAME}."
+                  exit 2
+                fi
+
+                if [ ! -f $HOME/SYSTEM/${SAP_SYSTEM_CONFIGURATION_NAME}/${SID}_hosts.yaml ]; then
+                  echo -e "$boldred--- $HOME/SYSTEM/${SAP_SYSTEM_CONFIGURATION_NAME}/${SID}_hosts.yaml was not found ---$reset"
+                  echo "##vso[task.logissue type=error]File $HOME/SYSTEM/${SAP_SYSTEM_CONFIGURATION_NAME}/${SID}_hosts.yaml was not found."
+                  exit 2
+                fi
+                dos2unix -q $HOME/SYSTEM/${SAP_SYSTEM_CONFIGURATION_NAME}/${SID}_hosts.yaml
+
+                export VARIABLE_GROUP_ID=$(az pipelines variable-group list --query "[?name=='$(variable_group)'].id | [0]")
+                echo '$(variable_group) id: ' $VARIABLE_GROUP_ID
+                if [ -z ${VARIABLE_GROUP_ID} ]; then
+                    echo "##vso[task.logissue type=error]Variable group $(variable_group) could not be found."
+                    exit 2
+                fi
+
+                echo "##vso[task.setvariable variable=SID;isOutput=true]${SID}"
+                echo "##vso[task.setvariable variable=SAP_PARAMETERS;isOutput=true]sap-parameters.yaml"
+                echo "##vso[task.setvariable variable=FOLDER;isOutput=true]$HOME/SYSTEM/${SAP_SYSTEM_CONFIGURATION_NAME}"
+                echo "##vso[task.setvariable variable=HOSTS;isOutput=true]${SID}_hosts.yaml"
+
+              echo -e "$green--- Get Files from the DevOps Repository ---$reset"
+                cd ${CONFIG_REPO_PATH}/$(Deployment_Configuration_Path)/SYSTEM/${SAP_SYSTEM_CONFIGURATION_NAME}
+                sap_params_updated=0
+
+              echo -e "$green--- Get connection details ---$reset"
+                mkdir -p artifacts
+
+                az_var=$(az pipelines variable-group variable list --group-id ${VARIABLE_GROUP_ID} --query "${NETWORK}"Workload_Key_Vault.value --output tsv)
+                if [ -z ${az_var} ]; then
+                  export workload_key_vault=$(cat "${environment_file_name}"  | grep workloadkeyvault      | awk -F'=' '{print $2}' | xargs) ; echo 'Workload Key Vault' ${workload_key_vault}
+                else
+                  export workload_key_vault=${az_var} ; echo 'Workload Key Vault' ${workload_key_vault} ;
+                fi
+
+                az_var=$(az pipelines variable-group variable list --group-id ${VARIABLE_GROUP_ID} --query "${NETWORK}"Workload_Secret_Prefix.value  --output tsv)
+                if [ -z ${az_var} ]; then
+                  export workload_prefix=$(cat "${environment_file_name}"  | grep workload_zone_prefix      | awk -F'=' '{print $2}' | xargs) ; echo 'Workload Prefix' ${workload_prefix}
+                else
+                  export workload_prefix=${az_var} ; echo 'Workload Prefix' ${workload_prefix};
+                fi
+
+                az_var=$(az pipelines variable-group variable list --group-id ${VARIABLE_GROUP_ID} --query Terraform_Remote_Storage_Subscription.value  --output tsv)
+                if [ -z ${az_var} ]; then
+                  export control_plane_subscription=$(cat "${environment_file_name}"  | grep STATE_SUBSCRIPTION      | awk -F'=' '{print $2}' | xargs) ; echo 'Control Plane Subscription' ${control_plane_subscription}
+                else
+                  export control_plane_subscription=${az_var} ; echo 'Control Plane Subscription' ${control_plane_subscription}
+                fi
+
+                if [[ $EXTRA_PARAMETERS = "'$(EXTRA_PARAMETERS)'" ]]; then
+                  new_parameters=$PIPELINE_EXTRA_PARAMETERS
+                else
+                  echo "##vso[task.logissue type=warning]Extra parameters were provided - '$EXTRA_PARAMETERS'"
+                  new_parameters="$EXTRA_PARAMETERS $PIPELINE_EXTRA_PARAMETERS"
+                fi
+
+                echo "##vso[task.setvariable variable=SSH_KEY_NAME;isOutput=true]${workload_prefix}-sid-sshkey"
+                echo "##vso[task.setvariable variable=VAULT_NAME;isOutput=true]$workload_key_vault"
+                echo "##vso[task.setvariable variable=PASSWORD_KEY_NAME;isOutput=true]${workload_prefix}-sid-password"
+                echo "##vso[task.setvariable variable=USERNAME_KEY_NAME;isOutput=true]${workload_prefix}-sid-username"
+                echo "##vso[task.setvariable variable=NEW_PARAMETERS;isOutput=true]${new_parameters}"
+                echo "##vso[task.setvariable variable=CP_SUBSCRIPTION;isOutput=true]${control_plane_subscription}"
+
+
+              echo -e "$green--- az login ---$reset"
+                # If the deployer_file exists we run on a deployer configured by the framework instead of a azdo hosted one
+                deployer_file=/etc/profile.d/deploy_server.sh
+                if [ "$USE_MSI" = "true" ]; then
+                  echo  "Using MSI"
+                  source /etc/profile.d/deploy_server.sh
+                  az account set --subscription $control_plane_subscription
+
+                else
+                  if [ ! -n $AZURE_CLIENT_ID ]; then
+                    echo "##vso[task.logissue type=error]Variable ARM_CLIENT_ID was not defined."
+                    exit 2
+                  fi
+
+                  if [ ! -n $AZURE_CLIENT_SECRET ]; then
+                    echo "##vso[task.logissue type=error]Variable ARM_CLIENT_SECRET was not defined."
+                    exit 2
+                  fi
+
+                  if [ ! -n $AZURE_TENANT_ID ]; then
+                    echo "##vso[task.logissue type=error]Variable ARM_TENANT_ID was not defined."
+                    exit 2
+                  fi
+                  az login --service-principal --username $AZURE_CLIENT_ID --password=${AZURE_CLIENT_SECRET} --tenant $AZURE_TENANT_ID --output none
+                  return_code=$?
+                  if [ 0 != $return_code ]; then
+                    echo -e "$boldred--- Login failed ---$reset"
+                    echo "##vso[task.logissue type=error]az login failed."
+                    exit $return_code
+                  fi
+                  az account set --subscription $control_plane_subscription
+                fi
+
+                return_code=$?
+                if [ 0 != $return_code ]; then
+                  echo -e "$boldred--- Login failed ---$reset"
+                  echo "##vso[task.logissue type=error]az login failed."
+                  exit $return_code
+                fi
+
+                az keyvault secret show --name ${workload_prefix}-sid-sshkey --vault-name $workload_key_vault --subscription $AZURE_SUBSCRIPTION_ID --query value -o tsv > artifacts/${SAP_SYSTEM_CONFIGURATION_NAME}_sshkey
+                cp sap-parameters.yaml artifacts/.
+                cp ${SID}_hosts.yaml artifacts/.
+
+                2> >(while read line; do (>&2 echo "STDERROR: $line"); done)
+            name:                            Preparation
+            displayName:                     Preparation for Ansible
+            env:
+              SCRIPT_PATH:                   $${{ parameters.sap_automation_repo_path }}/deploy/pipelines/templates/*.sh
+              SYSTEM_ACCESSTOKEN:            $(System.AccessToken)
+              AZURE_DEVOPS_EXT_PAT:          $(System.AccessToken)
+              ANSIBLE_HOST_KEY_CHECKING:     false
+              AZURE_CLIENT_ID:               $(ARM_CLIENT_ID)
+              AZURE_CLIENT_SECRET:           $(ARM_CLIENT_SECRET)
+              AZURE_TENANT_ID:               $(ARM_TENANT_ID)
+              AZURE_SUBSCRIPTION_ID:         $(Terraform_Remote_Storage_Subscription)
+              ANSIBLE_COLLECTIONS_PATHS:     /opt/ansible/collections
+              CONFIG_REPO_PATH:              ${{ parameters.config_repo_path }}
+              SAP_SYSTEM_CONFIGURATION_NAME: ${{ parameters.sap_system_configuration_name }}
+              EXTRA_PARAMETERS:              $(EXTRA_PARAMETERS)
+              PIPELINE_EXTRA_PARAMETERS:     ${{ parameters.extra_params }}
+              USE_MSI:                       $(USE_MSI)
+          - ${{ if eq(parameters.sap_on_azure_quality_checks, true) }}:
+              - template:                    templates\run-ansible.yaml
+                parameters:
+                  displayName:               SAP on Azure quality checks
+                  ansibleFilePath:           ${{ parameters.sap_automation_repo_path }}/deploy/ansible/playbook_06_02_sap_on_azure_quality_checks.yaml
+                  secretName:                "$(Preparation.SSH_KEY_NAME)"
+                  passwordSecretName:        "$(Preparation.PASSWORD_KEY_NAME)"
+                  userNameSecretName:        "$(Preparation.USERNAME_KEY_NAME)"
+                  vaultName:                 $(Preparation.VAULT_NAME)
+                  parametersFolder:          $(Preparation.FOLDER)
+                  sapParams:                 "${{ parameters.config_repo_path }}/$(Deployment_Configuration_Path)/SYSTEM/${{ parameters.sap_system_configuration_name }}/artifacts/$(Preparation.SAP_PARAMETERS)"
+                  sidHosts:                  $(Preparation.HOSTS)
+                  extraParams:               "$(Preparation.NEW_PARAMETERS)"
+                  azureClientId:             $(ARM_CLIENT_ID)
+                  azureClientSecret:         $(ARM_CLIENT_SECRET)
+                  azureTenantId:             $(ARM_TENANT_ID)
+                  azureSubscriptionId:       $(ARM_SUBSCRIPTION_ID)
+                  USE_MSI:                   $(USE_MSI)
+          - ${{ if eq(parameters.sap_functional_tests, true) }}:
+              - template:                    templates\run-ansible.yaml
+                parameters:
+                  displayName:               SAP Functional Tests Setup
+                  ansibleFilePath:           ${{ parameters.sap_automation_repo_path }}/deploy/ansible/playbook_06_03_00_sap_functional_tests.yaml
+                  secretName:                "$(Preparation.SSH_KEY_NAME)"
+                  passwordSecretName:        "$(Preparation.PASSWORD_KEY_NAME)"
+                  userNameSecretName:        "$(Preparation.USERNAME_KEY_NAME)"
+                  vaultName:                 $(Preparation.VAULT_NAME)
+                  parametersFolder:          $(Preparation.FOLDER)
+                  sapParams:                 "${{ parameters.config_repo_path }}/$(Deployment_Configuration_Path)/SYSTEM/${{ parameters.sap_system_configuration_name }}/artifacts/$(Preparation.SAP_PARAMETERS)"
+                  sidHosts:                  $(Preparation.HOSTS)
+                  extraParams:               "$(Preparation.NEW_PARAMETERS)"
+                  azureClientId:             $(ARM_CLIENT_ID)
+                  azureClientSecret:         $(ARM_CLIENT_SECRET)
+                  azureTenantId:             $(ARM_TENANT_ID)
+                  azureSubscriptionId:       $(ARM_SUBSCRIPTION_ID)
+                  USE_MSI:                   $(USE_MSI)
+                  sapFunctionalTestType:     ${{ parameters.sap_functional_test_type }}
+                  ansibleConfigPath:         ${{ parameters.sap_automation_repo_path }}/deploy/ansible/ansible.cfg
+                  telemetryDataDestination:  ${{ parameters.telemetry_data_destination }}
+          - ${{ if eq(parameters.sap_functional_tests, true) }}:
+              - template:                    templates\run-ansible.yaml
+                parameters:
+                  displayName:               SAP Functional Tests Test Execution
+                  ansibleFilePath:           ${{ parameters.sap_automation_repo_path }}/deploy/ansible/playbook_06_03_01_sap_functional_tests.yaml
+                  secretName:                "$(Preparation.SSH_KEY_NAME)"
+                  passwordSecretName:        "$(Preparation.PASSWORD_KEY_NAME)"
+                  userNameSecretName:        "$(Preparation.USERNAME_KEY_NAME)"
+                  vaultName:                 $(Preparation.VAULT_NAME)
+                  parametersFolder:          $(Preparation.FOLDER)
+                  sapParams:                 "${{ parameters.config_repo_path }}/$(Deployment_Configuration_Path)/SYSTEM/${{ parameters.sap_system_configuration_name }}/artifacts/$(Preparation.SAP_PARAMETERS)"
+                  sidHosts:                  $(Preparation.HOSTS)
+                  extraParams:               "$(Preparation.NEW_PARAMETERS)"
+                  azureClientId:             $(ARM_CLIENT_ID)
+                  azureClientSecret:         $(ARM_CLIENT_SECRET)
+                  azureTenantId:             $(ARM_TENANT_ID)
+                  azureSubscriptionId:       $(ARM_SUBSCRIPTION_ID)
+                  USE_MSI:                   $(USE_MSI)
+                  sapFunctionalTestType:     ${{ parameters.sap_functional_test_type }}
+                  ansibleConfigPath:         ${{ parameters.sap_automation_repo_path }}/deploy/ansible/ansible.cfg
+                  telemetryDataDestination:  ${{ parameters.telemetry_data_destination }}
+          - template:                        templates\collect-log-files.yaml
+            parameters:
+              logPath:                       ${{ parameters.config_repo_path }}/$(Deployment_Configuration_Path)/SYSTEM/${{ parameters.sap_system_configuration_name }}/logs
+              qualityAssuranceResultsPath:   ${{ parameters.config_repo_path }}/$(Deployment_Configuration_Path)/SYSTEM/${{ parameters.sap_system_configuration_name }}/quality_assurance
+              runSapFunctionalTests:         ${{ parameters.sap_functional_tests }}
+              collectQualityChecks:          ${{ parameters.sap_on_azure_quality_checks }}

--- a/deploy/pipelines/templates/collect-log-files.yaml
+++ b/deploy/pipelines/templates/collect-log-files.yaml
@@ -5,6 +5,7 @@ parameters:
   logPath: ""
   qualityAssuranceResultsPath: ""
   collectQualityChecks: false
+  runSapFunctionalTests: false
 steps:
   - script: |
       #!/bin/bash
@@ -14,7 +15,7 @@ steps:
 
       echo "Collecting log files from ${{ parameters.logPath }}"
 
-      if [ -d ${LOG_PATH} ] && [ $(ls ${LOG_PATH}/*.zip | wc -l ) -gt 0 ]; then
+      if [ -d ${LOG_PATH} ] && [ $(ls ${LOG_PATH}/*.log ${LOG_PATH}/*.zip ${LOG_PATH}/cluster_report/*.tar.bz2 ${LOG_PATH}/cluster_report/*.tar.gz | wc -l ) -gt 0 ] ; then
         echo "Found log files in ${LOG_PATH}"
 
         cd ${LOG_PATH}
@@ -29,7 +30,18 @@ steps:
         git pull
 
         echo "Adding new logs..."
-        git add --ignore-errors *.zip
+        if [ $(ls ${LOG_PATH}/*.zip | wc -l ) -gt 0 ]; then
+          git add --ignore-errors ${LOG_PATH}/*.zip
+        fi
+        if [ $(ls ${LOG_PATH}/*.log | wc -l ) -gt 0 ]; then
+          git add --ignore-errors ${LOG_PATH}/*.log
+        fi
+        if [ $(ls ${LOG_PATH}/cluster_report/*.tar.bz2 | wc -l ) -gt 0 ]; then
+          git add --ignore-errors ${LOG_PATH}/cluster_report/*.tar.bz2
+        fi
+        if [ $(ls ${LOG_PATH}/cluster_report/*.tar.gz | wc -l ) -gt 0 ]; then
+          git add --ignore-errors ${LOG_PATH}/cluster_report/*.tar.gz
+        fi
         if [ $(git diff --name-only --cached | wc -l) -gt 0 ]; then
             echo "Committing changes..."
             git commit -m "Adding new logs"
@@ -123,7 +135,7 @@ steps:
       fi
     displayName: Store quality assurance files in repository
     enabled: true
-    condition: ${{ eq(parameters.collectQualityChecks, true) }}
+    condition: ${{ or(eq(parameters.collectQualityChecks, true), eq(parameters.runSapFunctionalTests, true)) }}
     env:
       USER_EMAIL: $(Build.RequestedForEmail)
       USER_NAME: $(Build.RequestedFor)

--- a/deploy/pipelines/templates/run-ansible.yaml
+++ b/deploy/pipelines/templates/run-ansible.yaml
@@ -18,6 +18,8 @@ parameters:
     sapParams: ''
     passwordSecretName: ''
     userNameSecretName: ''
+    sapFunctionalTestType: ''
+    telemetryDataDestination: ''
 
 steps:
 - bash: |
@@ -124,6 +126,7 @@ steps:
 
     command="ansible-playbook -i $INVENTORY --private-key $PARAMETERS_FOLDER/sshkey   -e 'kv_name=$VAULT_NAME'   \
       -e @$SAP_PARAMS -e 'download_directory=$(Agent.TempDirectory)' -e '_workspace_directory=$PARAMETERS_FOLDER' \
+      -e 'sap_functional_test_type=$SAP_FUNCTIONAL_TEST_TYPE' -e 'telemetry_data_destination=$TELEMETRY_DATA_DESTINATION' \
       -e ansible_ssh_pass='${password_secret}' "$EXTRA_PARAMS" $EXTRA_PARAM_FILE                                  \
        $ANSIBLE_FILE_PATH"
 
@@ -188,3 +191,5 @@ steps:
     VAULT_NAME:                     ${{ parameters.vaultName }}
     PASSWORD_KEY_NAME:              ${{ parameters.passwordSecretName }}
     USERNAME_KEY_NAME:              ${{ parameters.userNameSecretName }}
+    SAP_FUNCTIONAL_TEST_TYPE:       ${{ parameters.sapFunctionalTestType }}
+    TELEMETRY_DATA_DESTINATION:     ${{ parameters.telemetryDataDestination }}

--- a/deploy/pipelines/variables/13-sap-quality-assurance.yaml
+++ b/deploy/pipelines/variables/13-sap-quality-assurance.yaml
@@ -1,0 +1,22 @@
+#--------------------------------------+---------------------------------------8
+#                                                                              |
+# Defines the parameters and variables for SAP Quality Assurance Tests Pipeline|
+#                                                                              |
+#--------------------------------------+---------------------------------------8
+
+parameters:
+  environment:                         ""
+
+variables:
+  - group:                             "SDAF-General"
+
+  - group:                             SDAF-${{ parameters.environment }}
+
+  - name:                              agent_name
+    value:                             $[coalesce(variables['POOL'], variables['Agent'])]
+
+  - name:                              this_agent
+    value:                             $[lower(coalesce(variables['POOL'], variables['Agent']))]
+
+  - name:                              variable_group
+    value:                             SDAF-${{ parameters.environment }}


### PR DESCRIPTION

This pull request introduces several changes to the SAP Functional Tests setup and deployment process using Ansible and Azure Pipelines. The most important changes include updating configuration files, adding new playbooks for SAP Functional Tests, and modifying pipeline stages to remove quality checks.

### Configuration Updates:
* [`deploy/ansible/ansible.cfg`](diffhunk://#diff-47e8c78dcc0c0c7f736ffe2ff7abf1b004d90f4ad081f2357038deb8d0eb5382R19-R20): Added `library` and `module_utils` paths for SAP Functional Tests modules.

### New Playbooks for SAP Functional Tests:
* [`deploy/ansible/playbook_06_03_00_sap_functional_tests.yaml`](diffhunk://#diff-7028b00c08e1104d418cca3b55a80082d7a2ec1848910987302d4f63b3e1dcd9R1-R20): Created a new playbook for setting up the deployer for SAP Functional Tests.
* [`deploy/ansible/playbook_06_03_01_sap_functional_tests.yaml`](diffhunk://#diff-dffba94f2147f9cde70002ae3ccb98933142460a081a4a9fca09a953d95f6ec2R1-R48): Created a new playbook for executing SAP Functional Tests, including creating and removing progress flags.

### Role and Task Enhancements:
* [`deploy/ansible/roles-misc/0.10-sap-functional-tests/tasks/setup.yaml`](diffhunk://#diff-741fd0003e20f32b0df539e07808a6be6648b48f18d646f5e519be0d065ef969R1-R29): Added tasks to set up directories and fetch the `sap-automation-qa` repository for SAP Functional Tests.

### Variable Additions:
* [`deploy/ansible/vars/ansible-input-api.yaml`](diffhunk://#diff-d9cca76007a90a0df0f87ef6d5e920c391d2df8098b98ff3bcd324088b4e3918R308-R311): Introduced a new variable `sap_functional_test_type` for specifying the type of SAP Functional Test.

### Pipeline Modifications:
* [`deploy/pipelines/05-DB-and-SAP-installation.yaml`](diffhunk://#diff-7764570e485df8c61fda31b3ce2a17ff2a5e66a7efe96b18ce399087691626cdL88-L92): Removed parameters and stages related to SAP on Azure quality checks to streamline the pipeline. [[1]](diffhunk://#diff-7764570e485df8c61fda31b3ce2a17ff2a5e66a7efe96b18ce399087691626cdL88-L92) [[2]](diffhunk://#diff-7764570e485df8c61fda31b3ce2a17ff2a5e66a7efe96b18ce399087691626cdL413-L432) [[3]](diffhunk://#diff-7764570e485df8c61fda31b3ce2a17ff2a5e66a7efe96b18ce399087691626cdL477-L478)
