### PR TITLE
Development Pacemaker fixes

### DIFF
--- a/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.2.0-cluster-Suse.yml
+++ b/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.2.0-cluster-Suse.yml
@@ -402,6 +402,12 @@
     #   WARNING: cib-bootstrap-options: unknown attribute 'azure-events_globalPullState'
     #   WARNING: cib-bootstrap-options: unknown attribute 'hostName_ hostname'
     # These warning messages can be ignored.
+
+    - name:                            "1.17 Generic Pacemaker - Check pacemaker version is 2.1.3 or higher"
+      when:                            ansible_facts.packages['pacemaker'] is defined
+      ansible.builtin.set_fact:
+        is_pcmk_213_or_later:          "{{ ansible_facts.packages['pacemaker'][0].version is version('2.1.3', '>=') }}"
+
     - name:                            "1.17 Generic Pacemaker - Ensure maintenance mode is set"
       ansible.builtin.shell:           crm configure property maintenance-mode=true
 
@@ -419,18 +425,45 @@
     - name:                            "1.17 Generic Pacemaker - Set initial value for cluster attributes for {{ secondary_instance_name }}"
       ansible.builtin.shell:           crm_attribute --node {{ secondary_instance_name }} --name '#health-azure' --update 0
 
-    - name:                            "1.17 Generic Pacemaker - Ensure Pacemaker resources for the Azure agent is created"
-      ansible.builtin.shell: |
+    - name:                            "1.17 Generic Pacemaker - Set the pacemaker cluster node health agent (pcmk < 2.13)"
+      when:                            not is_pcmk_213_or_later | bool
+      block:
+        - name:                        "1.17 Generic Pacemaker - Ensure Pacemaker resources for the Azure agent is created (pcmk < 2.13)"
+          ansible.builtin.shell: |
                                        crm configure primitive health-azure-events ocf:heartbeat:azure-events-az \
                                        meta allow-unhealthy-nodes=true failure-timeout=120s \
                                        op start start-delay=90s \
                                        op monitor interval=10s
-      register:                        crm_configure_result
-      failed_when:
+          register:                    crm_configure_result
+          failed_when:
                                        - "crm_configure_result.stderr | lower | regex_search('error|fail')" # Check if the resource is created successfully
 
-    - name:                            "1.17 Generic Pacemaker - Ensure clone resource azure-events is configured"
-      ansible.builtin.shell:           crm configure clone health-azure-events-cln health-azure-events
+        - name:                        "1.17 Generic Pacemaker - Ensure clone resource azure-events is configured (pcmk < 2.13)"
+          ansible.builtin.shell:       crm configure clone health-azure-events-cln health-azure-events
+          register:                    crm_configure_clone_result
+          failed_when:
+                                       - "crm_configure_clone_result.stderr | lower | regex_search('error|fail')" # Check if the resource is created successfully
+
+    - name:                            "1.17 Generic Pacemaker - Set the pacemaker cluster node health agent (pcmk >= 2.13)"
+      when:                            is_pcmk_213_or_later | bool
+      block:
+        - name:                        "1.17 Generic Pacemaker - Ensure Pacemaker resources for the Azure agent is created (pcmk >= 2.13)"
+          ansible.builtin.shell: |
+                                       crm configure primitive health-azure-events ocf:heartbeat:azure-events-az \
+                                       meta failure-timeout=120s \
+                                       op start start-delay=90s \
+                                       op monitor interval=10s
+          register:                    crm_configure_result
+          failed_when:
+                                       - "crm_configure_result.stderr | lower | regex_search('error|fail')"
+
+        - name:                        "1.17 Generic Pacemaker - Ensure clone resource azure-events is configured (pcmk >= 2.13)"
+          ansible.builtin.shell: |
+                                       crm configure clone health-azure-events-cln health-azure-events \
+                                       meta allow-unhealthy-nodes=true
+          register:                    crm_configure_clone_result
+          failed_when:
+                                       - "crm_configure_clone_result.stderr | lower | regex_search('error|fail')"
 
     - name:                            "1.17 Generic Pacemaker - Remove false positives"
       ansible.builtin.shell:           crm_resource -C

--- a/deploy/scripts/pipeline_scripts/01-control-plane-deploy.sh
+++ b/deploy/scripts/pipeline_scripts/01-control-plane-deploy.sh
@@ -133,14 +133,16 @@ printf -v val '%-20s' "${tempval}"
 echo "$val                 $VARIABLE_GROUP_ID"
 
 # Set logon variables
-ARM_CLIENT_ID="$CP_ARM_CLIENT_ID"
-export ARM_CLIENT_ID
-ARM_CLIENT_SECRET="$CP_ARM_CLIENT_SECRET"
-export ARM_CLIENT_SECRET
-ARM_TENANT_ID=$CP_ARM_TENANT_ID
-export ARM_TENANT_ID
-ARM_SUBSCRIPTION_ID=$CP_ARM_SUBSCRIPTION_ID
-export ARM_SUBSCRIPTION_ID
+if [ $USE_MSI != "true" ]; then
+	ARM_CLIENT_ID=$CP_ARM_CLIENT_ID
+	export ARM_CLIENT_ID
+	ARM_CLIENT_SECRET=$CP_ARM_CLIENT_SECRET
+	export ARM_CLIENT_SECRET
+	ARM_TENANT_ID=$CP_ARM_TENANT_ID
+	export ARM_TENANT_ID
+	ARM_SUBSCRIPTION_ID=$CP_ARM_SUBSCRIPTION_ID
+	export ARM_SUBSCRIPTION_ID
+fi
 
 # Check if running on deployer
 if [[ ! -f /etc/profile.d/deploy_server.sh ]]; then


### PR DESCRIPTION
This pull request includes several changes to the Ansible playbooks and shell scripts to improve compatibility and functionality. The most important changes include adding conditional checks for Pacemaker version 2.1.3 or higher and modifying the deployment script to handle Managed Service Identity (MSI).

Changes to Ansible playbooks:

* [`deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.2.0-cluster-Suse.yml`](diffhunk://#diff-1d2dc3c3ce551ce79d2a2cdd86321485f63b008c7f1e7a2446447718e22fb22dR405-R410): Added a task to check if Pacemaker version is 2.1.3 or higher and set a fact accordingly.
* [`deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.2.0-cluster-Suse.yml`](diffhunk://#diff-1d2dc3c3ce551ce79d2a2cdd86321485f63b008c7f1e7a2446447718e22fb22dL422-R431): Added conditional blocks to handle Pacemaker resources creation differently for versions below and above 2.1.3. [[1]](diffhunk://#diff-1d2dc3c3ce551ce79d2a2cdd86321485f63b008c7f1e7a2446447718e22fb22dL422-R431) [[2]](diffhunk://#diff-1d2dc3c3ce551ce79d2a2cdd86321485f63b008c7f1e7a2446447718e22fb22dL432-R466)

Changes to deployment scripts:

* [`deploy/scripts/pipeline_scripts/01-control-plane-deploy.sh`](diffhunk://#diff-228240f2a6f381b1c08c20b095a9f363a2fb46e81dc75c45a889f26f5146ed0bL136-R145): Modified the script to set ARM client ID and secret only if Managed Service Identity (MSI) is not used.## Problem
<Please describe what problem this PR is trying to resolve>

## Solution
<Please elaborate the solution for the problem>

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>