### PR TITLE
Revert application avset count to use ppg length

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/infrastructure.tf
@@ -327,7 +327,10 @@ resource "azurerm_availability_set" "scs" {
 #######################################4#######################################8
 resource "azurerm_availability_set" "app" {
   provider                             = azurerm.main
-  count                                = local.use_app_avset && var.application_tier.avset_arm_ids_count == 0 ? max(var.application_tier.app_zone_count, 1) : 0
+  count                                = local.use_app_avset && var.application_tier.avset_arm_ids_count == 0 ? (
+                                           max(length(var.ppg), 1)) : (
+                                           0
+                                         )
 
   depends_on                           = [azurerm_virtual_machine_data_disk_attachment.scs]
   name                                 = format("%s%s%s",


### PR DESCRIPTION
When deploying an application availability set the application server zones can be ignored. This means that the zones will be an empty list and thus the max won't work. For SCS the count is still based on ppg (like app was previously as well), so reverting to that state.
