### PR TITLE
Update sudoers template for SAPHanaSR and fix path for helper commands

### DIFF
--- a/deploy/ansible/roles-sap/5.5-hanadb-pacemaker/tasks/5.5.3-SAPHanaSR.yml
+++ b/deploy/ansible/roles-sap/5.5-hanadb-pacemaker/tasks/5.5.3-SAPHanaSR.yml
@@ -432,7 +432,7 @@
 
     - name:                            "5.5 HANA Pacemaker - Create sudoers file for SLES"
       ansible.builtin.template:
-        src:                           "20-saphana-suse.j2"
+        src:                           "20-saphana-angi-suse.j2"
         dest:                          "/etc/sudoers.d/20-saphana"
         mode:                          "0440"
         owner:                         root

--- a/deploy/ansible/roles-sap/5.5-hanadb-pacemaker/templates/20-saphana-angi-suse.j2
+++ b/deploy/ansible/roles-sap/5.5-hanadb-pacemaker/templates/20-saphana-angi-suse.j2
@@ -6,7 +6,7 @@ Cmnd_Alias SOK_SITEA    = /usr/sbin/crm_attribute -n hana_{{ db_sid | lower }}_s
 Cmnd_Alias SFAIL_SITEA  = /usr/sbin/crm_attribute -n hana_{{ db_sid | lower }}_site_srHook_SITEA -v SFAIL -t crm_config -s SAPHanaSR
 Cmnd_Alias SOK_SITEB    = /usr/sbin/crm_attribute -n hana_{{ db_sid | lower }}_site_srHook_SITEB -v SOK   -t crm_config -s SAPHanaSR
 Cmnd_Alias SFAIL_SITEB  = /usr/sbin/crm_attribute -n hana_{{ db_sid | lower }}_site_srHook_SITEB -v SFAIL -t crm_config -s SAPHanaSR
-Cmnd_Alias HELPER_TAKEOVER  = /usr/sbin/SAPHanaSR-hookHelper --sid={{ db_sid | upper }} --case=checkTakeover
-Cmnd_Alias HELPER_FENCE     = /usr/sbin/SAPHanaSR-hookHelper --sid={{ db_sid | upper }} --case=fenceMe
+Cmnd_Alias HELPER_TAKEOVER  = /usr/bin/SAPHanaSR-hookHelper --sid={{ db_sid | upper }} --case=checkTakeover
+Cmnd_Alias HELPER_FENCE     = /usr/bin/SAPHanaSR-hookHelper --sid={{ db_sid | upper }} --case=fenceMe
 
 {{ db_sid | lower }}adm ALL=(ALL) NOPASSWD: SOK_SITEA, SFAIL_SITEA, SOK_SITEB, SFAIL_SITEB, HELPER_TAKEOVER, HELPER_FENCE


### PR DESCRIPTION
This pull request updates the configuration for SAP HANA Pacemaker in the Ansible deployment scripts. The changes primarily involve switching to a new sudoers template file and modifying command aliases for SAPHanaSR hooks to align with updated requirements.

### Updates to SAP HANA Pacemaker Configuration:

#### Template File Changes:
* Changed the source template file for the sudoers configuration from `20-saphana-suse.j2` to `20-saphana-angi-suse.j2`, which introduces a new structure for managing SAPHanaSR hooks. (`deploy/ansible/roles-sap/5.5-hanadb-pacemaker/tasks/5.5.3-SAPHanaSR.yml`, [deploy/ansible/roles-sap/5.5-hanadb-pacemaker/tasks/5.5.3-SAPHanaSR.ymlL435-R435](diffhunk://#diff-4953f828dcde1ff1798eb95fd3cb61f0862a3a00ebc930da7705e690b45f3500L435-R435))

* Added a new template file `20-saphana-angi-suse.j2` with updated command aliases (`Cmnd_Alias`) for managing SAPHanaSR hooks, including `SOK_SITEA`, `SFAIL_SITEA`, `SOK_SITEB`, `SFAIL_SITEB`, `HELPER_TAKEOVER`, and `HELPER_FENCE`. These aliases are used for specific operations like checking takeover and fencing. (`deploy/ansible/roles-sap/5.5-hanadb-pacemaker/templates/20-saphana-angi-suse.j2`, [deploy/ansible/roles-sap/5.5-hanadb-pacemaker/templates/20-saphana-angi-suse.j2R1-R12](diffhunk://#diff-d6526a67d182146d37a3f9d9ef2db616d19063433f675fdadce0eb2b10fc18c8R1-R12))

#### Command Alias Adjustments:
* Updated the paths for `HELPER_TAKEOVER` and `HELPER_FENCE` commands in the original template file (`20-saphana-suse.j2`) from `/usr/bin/` to `/usr/sbin/`, ensuring consistency with the new template. (`deploy/ansible/roles-sap/5.5-hanadb-pacemaker/templates/20-saphana-suse.j2`, [deploy/ansible/roles-sap/5.5-hanadb-pacemaker/templates/20-saphana-suse.j2L9-R10](diffhunk://#diff-4d3fec206d224e9ca58afa261390e00388b7eeb2a1ce3ae6f923f1600d91fa6eL9-R10))