### PR TITLE
2 HANA Scale out fixes for RHEL

### DIFF
--- a/deploy/ansible/roles-sap/5.8-hanadb-scaleout-pacemaker/templates/20-saphana-rhel.j2
+++ b/deploy/ansible/roles-sap/5.8-hanadb-scaleout-pacemaker/templates/20-saphana-rhel.j2
@@ -4,7 +4,7 @@
 
 Cmnd_Alias SOK = /usr/sbin/crm_attribute -n hana_{{ db_sid | lower }}_glob_srHook -v SOK -t crm_config -s SAPHanaSR
 Cmnd_Alias SFAIL = /usr/sbin/crm_attribute -n hana_{{ db_sid | lower }}_glob_srHook -v SFAIL -t crm_config -s SAPHanaSR
-Cmnd_Alias SRREBOOT = /usr/sbin/crm_attribute -n hana_{{ db_sid | lower }}_gsh -v * -l reboot -t crm_config -s SAPHanaSR
+Cmnd_Alias SRREBOOT = /usr/sbin/crm_attribute -n hana_{{ db_sid | lower }}_gsh -v * -l reboot
 
 {{ db_sid | lower }}adm ALL=(ALL) NOPASSWD: SOK, SFAIL, SRREBOOT
 Defaults!SOK, SFAIL, SRREBOOT !requiretty

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/infrastructure.tf
@@ -105,8 +105,8 @@ resource "azurerm_lb_probe" "hdb" {
 resource "azurerm_network_interface_backend_address_pool_association" "hdb" {
   provider                             = azurerm.main
   count                                = local.enable_db_lb_deployment ? var.database_server_count : 0
-  network_interface_id                 = var.database.scale_out && var.database_dual_nics ? azurerm_network_interface.nics_dbnodes_admin[count.index].id : azurerm_network_interface.nics_dbnodes_db[count.index].id
-  ip_configuration_name                = var.database.scale_out && var.database_dual_nics? azurerm_network_interface.nics_dbnodes_admin[count.index].ip_configuration[0].name : azurerm_network_interface.nics_dbnodes_db[count.index].ip_configuration[0].name
+  network_interface_id                 = var.database.scale_out && var.database_dual_nics && var.NFS_provider == "ANF" ? azurerm_network_interface.nics_dbnodes_admin[count.index].id : azurerm_network_interface.nics_dbnodes_db[count.index].id
+  ip_configuration_name                = var.database.scale_out && var.database_dual_nics && var.NFS_provider == "ANF" ? azurerm_network_interface.nics_dbnodes_admin[count.index].ip_configuration[0].name : azurerm_network_interface.nics_dbnodes_db[count.index].ip_configuration[0].name
   backend_address_pool_id              = azurerm_lb_backend_address_pool.hdb[0].id
 }
 

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
@@ -178,7 +178,7 @@ locals {
                                               var.naming.separator,
                                               local.resource_suffixes.db_alb_feip
                                             )
-                                            subnet_id = var.database.scale_out ? (
+                                            subnet_id = var.database.scale_out && var.database_dual_nics && var.NFS_provider == "ANF" ? (
                                               try(
                                                 var.admin_subnet.id,
                                                 var.landscape_tfstate.admin_subnet_id
@@ -190,7 +190,7 @@ locals {
                                               var.database.use_DHCP ? (
                                                 null) : (
                                                 cidrhost(
-                                                  var.database.scale_out ? var.admin_subnet.address_prefixes[0] : var.db_subnet.address_prefixes[0],
+                                                  var.database.scale_out && var.database_dual_nics && var.NFS_provider == "ANF" ? var.admin_subnet.address_prefixes[0] : var.db_subnet.address_prefixes[0],
                                                   local.hdb_ip_offsets.hdb_lb
                                               ))
                                             )
@@ -203,7 +203,7 @@ locals {
                                               var.naming.separator,
                                               try(local.resource_suffixes.db_rlb_feip, "dbRlb-feip")
                                             )
-                                            subnet_id = var.database.scale_out ? (
+                                            subnet_id = var.database.scale_out && var.database_dual_nics && var.NFS_provider == "ANF" ? (
                                               try(
                                                 var.admin_subnet.id,
                                                 var.landscape_tfstate.admin_subnet_id
@@ -215,7 +215,7 @@ locals {
                                               var.database.use_DHCP ? (
                                                 null) : (
                                                 cidrhost(
-                                                  var.database.scale_out ? var.admin_subnet.address_prefixes[0] :  var.db_subnet.address_prefixes[0],
+                                                  var.database.scale_out && var.database_dual_nics && var.NFS_provider == "ANF" ? var.admin_subnet.address_prefixes[0] :  var.db_subnet.address_prefixes[0],
                                                   local.hdb_ip_offsets.hdb_lb + 1
                                               ))
                                             )


### PR DESCRIPTION
## Problem
1. The sudo rule was a bit too strict for RHEL. The docs showed to include the `-t` and `-s` options, but a lot of 256 return codes showed up in the trace files.
2. For scale out the database loadbalancer would be connected to the admin subnet rather than the application subnet. This is only needed for ANF.

## Solution
1. Removed the `-t` and `-s` options from the sudo rules
2. Whenever a check on scaleout was done to use admin nic, a check for ANF usage was added
