### PR TITLE
feat: add support for SLES 15.7 and update timeout settings in pacemaker

### DIFF
--- a/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.1.2-sbd.yaml
+++ b/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.1.2-sbd.yaml
@@ -221,7 +221,7 @@
       loop:
         - { regexp: "^SBD_PACEMAKER=.*",    line: 'SBD_PACEMAKER=yes'     }
         - { regexp: "^SBD_STARTMODE=.*",    line: 'SBD_STARTMODE=always'  }
-        - { regexp: "^SBD_DELAY_START=.*",  line: 'SBD_DELAY_START=yes'   }
+        - { regexp: "^SBD_DELAY_START=.*",  line: 'SBD_DELAY_START=216'   }
         # Format line as so:
         #   SBD_DEVICE="/dev/disk/by-id/scsi-3600224804208a67da8073b2a9728af19"
         #   SBD_DEVICE="/dev/disk/by-id/scsi-360022480ef971a6c5759f2dc3adf4c96;/dev/disk/by-id/scsi-360022480ea4064ac4952ea8452d66317"
@@ -276,20 +276,24 @@
             group:                            root
             mode:                             '0644'
 
-        - name:                               "SBD - Add Before=corosync.service in Unit section"
-          ansible.builtin.lineinfile:
-            path:                             /etc/systemd/system/sbd.service
-            insertafter:                      '^\[Unit\].*'
-            line:                             'Before=corosync.service'
-            state:                            present
+        - name:                               "SBD - Create service override directory (if not exists)"
+          ansible.builtin.file:
+            path:                             /etc/systemd/system/sbd.service.d
+            state:                            directory
+            owner:                            root
+            group:                            root
+            mode:                             '0755'
 
-        - name:                               "SBD - Set TimeoutSec in Service section"
-          ansible.builtin.lineinfile:
-            path:                             /etc/systemd/system/sbd.service
-            regexp:                           '^TimeoutSec='
-            line:                             'TimeoutSec=600'
-            insertafter:                      '^\[Service\].*'
-            state:                            present
+        - name:                               "SBD - Set increased timeout for delayed start and before corosync"
+          ansible.builtin.copy:
+            content: |
+                                              [Service]
+                                              TimeoutSec=259
+                                              Before=corosync.service
+            dest:                             /etc/systemd/system/sbd.service.d/sbd_delay_start.conf
+            owner:                            root
+            group:                            root
+            mode:                             '0644'
 
     - name:                                   "SBD - Configure service file for RedHat"
       when:                                   ansible_os_family | upper == "REDHAT"

--- a/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.2.0-cluster-RedHat.yml
+++ b/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.2.0-cluster-RedHat.yml
@@ -131,7 +131,7 @@
 
     - name:                            "1.17 Generic Pacemaker - Set stonith-timeout property"
       ansible.builtin.command:
-        cmd:                           "pcs property set stonith-timeout=144"
+        cmd:                           "pcs property set stonith-timeout=210"
       register:                        pcs_stonith_timeout_result
       changed_when:                    pcs_stonith_timeout_result.rc == 0
 

--- a/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.2.0-cluster-Suse.yml
+++ b/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.2.0-cluster-Suse.yml
@@ -228,7 +228,7 @@
       failed_when:                     crm_configure_result.rc > 1
       when:
         - use_msi_for_clusters
-        - distribution_full_id in ["sles_sap12.5", "sles_sap15.1","sles_sap15.2", "sles_sap15.3", "sles_sap15.4", "sles_sap15.5", "sles_sap15.6"]
+        - distribution_full_id in ["sles_sap12.5", "sles_sap15.1","sles_sap15.2", "sles_sap15.3", "sles_sap15.4", "sles_sap15.5", "sles_sap15.6", "sles_sap15.7"]
 
 
     - name:                            "1.17 Generic Pacemaker - Stonith Timeout Property"

--- a/deploy/ansible/roles-os/1.17-generic-pacemaker/vars/main.yml
+++ b/deploy/ansible/roles-os/1.17-generic-pacemaker/vars/main.yml
@@ -119,3 +119,6 @@ package_versions:
   sles_sap15.6:
     - {name: "pacemaker",               version: "1.1.23",  compare_operator: ">=", version_type: "loose"}
     - {name: "resource-agents",         version: "4.10.0",  compare_operator: ">=", version_type: "semver"}
+  sles_sap15.7:
+    - {name: "pacemaker",               version: "1.1.23",  compare_operator: ">=", version_type: "loose"}
+    - {name: "resource-agents",         version: "4.10.0",  compare_operator: ">=", version_type: "semver"}

--- a/deploy/ansible/roles-os/1.18-scaleout-pacemaker/tasks/1.18.2.0-cluster-Suse.yml
+++ b/deploy/ansible/roles-os/1.18-scaleout-pacemaker/tasks/1.18.2.0-cluster-Suse.yml
@@ -113,7 +113,7 @@
                                        pcmk_host_map="{% for item in ansible_play_hosts_all %}{{ item }}:{{ hostvars[item]['vm_name'] }}{{ ';' if not loop.last }}{% endfor %}"
       when:
         - use_msi_for_clusters
-        - distribution_full_id in ["sles_sap12.5", "sles_sap15.1","sles_sap15.2", "sles_sap15.3", "sles_sap15.4", "sles_sap15.5", "sles_sap15.6"]
+        - distribution_full_id in ["sles_sap12.5", "sles_sap15.1","sles_sap15.2", "sles_sap15.3", "sles_sap15.4", "sles_sap15.5", "sles_sap15.6", "sles_sap15.7"]
 
 
     - name:                            "1.18.2.0 Generic Pacemaker - Stonith Timeout Property"

--- a/deploy/ansible/roles-os/1.18-scaleout-pacemaker/vars/main.yml
+++ b/deploy/ansible/roles-os/1.18-scaleout-pacemaker/vars/main.yml
@@ -120,3 +120,6 @@ package_versions:
   sles_sap15.6:
     - {name: "pacemaker",               version: "1.1.23",  compare_operator: ">=", version_type: "loose"}
     - {name: "resource-agents",         version: "4.10.0",  compare_operator: ">=", version_type: "semver"}
+  sles_sap15.7:
+    - {name: "pacemaker",               version: "1.1.23",  compare_operator: ">=", version_type: "loose"}
+    - {name: "resource-agents",         version: "4.10.0",  compare_operator: ">=", version_type: "semver"}

--- a/deploy/ansible/roles-os/1.3-repository/vars/repos.yaml
+++ b/deploy/ansible/roles-os/1.3-repository/vars/repos.yaml
@@ -44,6 +44,7 @@ repos:
   sles_sap15.4:
   sles_sap15.5:
   sles_sap15.6:
+  sles_sap15.7:
   sles15.3:
   sles15.4:
   sles15.5:

--- a/deploy/ansible/roles-os/1.4-packages/vars/os-packages.yaml
+++ b/deploy/ansible/roles-os/1.4-packages/vars/os-packages.yaml
@@ -507,6 +507,16 @@ packages:
     - { tier: 'ha',     package: 'fence-agents-azure-arm',                       node_tier: 'scs',            state: 'present' }
     - { tier: 'ha',     package: 'fence-agents-azure-arm',                       node_tier: 'ers',            state: 'present' }
     - { tier: 'ha',     package: 'fence-agents-azure-arm',                       node_tier: 'hana',           state: 'present' }
+  sles_sap15.7:
+    - { tier: 'os',     package: 'python3-xml',                                  node_tier: 'all',            state: 'present' }
+    - { tier: 'os',     package: 'python3-rpm',                                  node_tier: 'all',            state: 'present' }
+    - { tier: 'os',     package: 'azure-vm-utils',                               node_tier: 'all',            state: 'present' }
+    - { tier: 'db2',    package: 'system-user-bin',                              node_tier: 'db2',             state: 'present' }
+    - { tier: 'ha',     package: 'sapstartsrv-resource-agents',                  node_tier: 'scs',            state: 'present' }
+    - { tier: 'ha',     package: 'sapstartsrv-resource-agents',                  node_tier: 'ers',            state: 'present' }
+    - { tier: 'ha',     package: 'fence-agents-azure-arm',                       node_tier: 'scs',            state: 'present' }
+    - { tier: 'ha',     package: 'fence-agents-azure-arm',                       node_tier: 'ers',            state: 'present' }
+    - { tier: 'ha',     package: 'fence-agents-azure-arm',                       node_tier: 'hana',           state: 'present' }
   # Adding packages for Oracle linux 8.4 to start with, copied the list from RHEL.
   # Adding additional Oracle linux packages as per SAP Note 2069760 - Oracle Linux 7.x SAP Installation and
   # Upgrade. Need to add the groupinstall command.

--- a/deploy/ansible/roles-sap-os/2.10-sap-notes/tasks/2.10.3119751.yaml
+++ b/deploy/ansible/roles-sap-os/2.10-sap-notes/tasks/2.10.3119751.yaml
@@ -61,12 +61,12 @@
     group:                             sapsys
   when:                                compat_sap_c12_version.stat.exists
 
-- name:                                "SAP Note 3119751 check if version 13 of compat-sap-c++ is installed"
+- name:                                "SAP Note 3449186 check if version 13 of compat-sap-c++ is installed"
   ansible.builtin.stat:
     path:                              /opt/rh/SAP/lib64/compat-sap-c++-13.so
   register:                            compat_sap_c13_version
 
-- name:                                "SAP Note 3119751 create symlink"
+- name:                                "SAP Note 3449186 create symlink"
   become:                              true
   ansible.builtin.file:
     src:                               /opt/rh/SAP/lib64/compat-sap-c++-13.so

--- a/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.1-anf-mounts.yaml
+++ b/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.1-anf-mounts.yaml
@@ -15,12 +15,12 @@
 - name:                                "ANF Mount: Set the NFSmount options"
   ansible.builtin.set_fact:
     mnt_options:                       'rw,nfsvers=4.1,hard,timeo=600,rsize=262144,wsize=262144,noatime,lock,_netdev,sec=sys'
-  when: distribution_full_id not in ['redhat8.4', 'redhat8.6', 'redhat8.8', 'redhat9.0', 'redhat9.2', 'redhat9.4', 'sles_sap15.2', 'sles_sap15.3', 'sles_sap15.4', 'sles_sap15.5', 'sles_sap15.6']
+  when: distribution_full_id not in ['redhat8.4', 'redhat8.6', 'redhat8.8', 'redhat9.0', 'redhat9.2', 'redhat9.4', 'sles_sap15.2', 'sles_sap15.3', 'sles_sap15.4', 'sles_sap15.5', 'sles_sap15.6', 'sles_sap15.7']
 
 - name:                                "ANF Mount: Set the NFSmount options"
   ansible.builtin.set_fact:
     mnt_options:                       'rw,nfsvers=4.1,hard,timeo=600,rsize=262144,wsize=262144,noatime,lock,_netdev,sec=sys,nconnect=8'
-  when: distribution_full_id in ['redhat8.4', 'redhat8.6', 'redhat8.8', 'redhat9.0', 'redhat9.2', 'redhat9.4', 'sles_sap15.2', 'sles_sap15.3', 'sles_sap15.4', 'sles_sap15.5', 'sles_sap15.6']
+  when: distribution_full_id in ['redhat8.4', 'redhat8.6', 'redhat8.8', 'redhat9.0', 'redhat9.2', 'redhat9.4', 'sles_sap15.2', 'sles_sap15.3', 'sles_sap15.4', 'sles_sap15.5', 'sles_sap15.6', 'sles_sap15.7']
 
 - name:                                "ANF Mount: Define this SID"
   ansible.builtin.set_fact:

--- a/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.8-anf-mounts-simplemount.yaml
+++ b/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.8-anf-mounts-simplemount.yaml
@@ -15,12 +15,12 @@
 - name:                                "ANF Mount: Set the NFSmount options"
   ansible.builtin.set_fact:
     mnt_options:                       'rw,nfsvers=4.1,hard,timeo=600,rsize=262144,wsize=262144,noatime,lock,_netdev,sec=sys'
-  when: distribution_full_id not in ['redhat8.4', 'redhat8.6', 'redhat8.8', 'redhat9.0', 'redhat9.2', 'redhat9.4', 'sles_sap15.2', 'sles_sap15.3', 'sles_sap15.4', 'sles_sap15.5', 'sles_sap15.6']
+  when: distribution_full_id not in ['redhat8.4', 'redhat8.6', 'redhat8.8', 'redhat9.0', 'redhat9.2', 'redhat9.4', 'sles_sap15.2', 'sles_sap15.3', 'sles_sap15.4', 'sles_sap15.5', 'sles_sap15.6', 'sles_sap15.7']
 
 - name:                                "ANF Mount: Set the NFSmount options"
   ansible.builtin.set_fact:
     mnt_options:                       'rw,nfsvers=4.1,hard,timeo=600,rsize=262144,wsize=262144,noatime,lock,_netdev,sec=sys,nconnect=8'
-  when: distribution_full_id in ['redhat8.4', 'redhat8.6', 'redhat8.8', 'redhat9.0', 'redhat9.2', 'redhat9.4', 'sles_sap15.2', 'sles_sap15.3', 'sles_sap15.4', 'sles_sap15.5', 'sles_sap15.6']
+  when: distribution_full_id in ['redhat8.4', 'redhat8.6', 'redhat8.8', 'redhat9.0', 'redhat9.2', 'redhat9.4', 'sles_sap15.2', 'sles_sap15.3', 'sles_sap15.4', 'sles_sap15.5', 'sles_sap15.6', 'sles_sap15.7']
 
 - name:                                "ANF Mount: Define this SID"
   ansible.builtin.set_fact:

--- a/deploy/ansible/roles-sap/5.5-hanadb-pacemaker/tasks/5.5.1-set_runtime_facts.yml
+++ b/deploy/ansible/roles-sap/5.5-hanadb-pacemaker/tasks/5.5.1-set_runtime_facts.yml
@@ -128,7 +128,7 @@
       when:
         - saphanaSR_angi_version == '0.0.0'
         - use_hanasr_angi
-        - distribution_full_id in ['sles_sap15.4', 'sles_sap15.5', 'sles_sap15.6']
+        - distribution_full_id in ['sles_sap15.4', 'sles_sap15.5', 'sles_sap15.6', 'sles_sap15.7']
       block:
         - name:                        "5.5 HANA Pacemaker - Uninstall the old-style SAPHanaSR package"
           community.general.zypper:

--- a/deploy/ansible/roles-sap/5.5-hanadb-pacemaker/tasks/5.5.4.1-cluster-Suse.yml
+++ b/deploy/ansible/roles-sap/5.5-hanadb-pacemaker/tasks/5.5.4.1-cluster-Suse.yml
@@ -148,6 +148,17 @@
                                        msl_SAPHana_{{ db_sid | upper }}_HDB{{ db_instance_number }}:Master
       register:                        sap_hana_g_col_ip
       failed_when:                     sap_hana_g_col_ip.rc > 1
+      when:                            ansible_distribution_major_version < "15"
+
+    - name:                            "5.5.4.1 HANA Pacemaker configuration - Ensure Co-Location constraint is configured"
+      ansible.builtin.shell: >
+                                       crm configure colocation col_saphana_ip_{{ db_sid | upper }}_HDB{{ db_instance_number }}
+                                       4000:
+                                       g_ip_{{ db_sid | upper }}_HDB{{ db_instance_number }}:Started
+                                       msl_SAPHana_{{ db_sid | upper }}_HDB{{ db_instance_number }}:Promoted
+      register:                        sap_hana_g_col_ip
+      failed_when:                     sap_hana_g_col_ip.rc > 1
+      when:                            ansible_distribution_major_version >= "15"
 
     - name:                            "5.5.4.1 HANA Pacemaker configuration - Ensure Resource order is configured"
       ansible.builtin.shell: >
@@ -198,6 +209,15 @@
                                        msl_SAPHana_{{ db_sid | upper }}_HDB{{ db_instance_number }}:Slave
           register:                    sec_colocation
           failed_when:                 sec_colocation.rc > 1
+          when:                        ansible_distribution_major_version < "15"
+
+        - name:                        "5.5.4.1 HANA Cluster configuration - Ensure the Active/Active co-Location constraint is configured"
+          ansible.builtin.shell: >
+                                       crm configure colocation col_saphana_secip_{{ db_sid | upper }}_HDB{{ db_instance_number }} 4000: g_secip_{{ db_sid | upper }}_HDB{{ db_instance_number }}:Started
+                                       msl_SAPHana_{{ db_sid | upper }}_HDB{{ db_instance_number }}:Unpromoted
+          register:                    sec_colocation
+          failed_when:                 sec_colocation.rc > 1
+          when:                        ansible_distribution_major_version >= "15"
 
     - name:                            "5.5.4.1 HANA Pacemaker configuration - cleanup cluster resources"
       ansible.builtin.command:         "crm resource cleanup"


### PR DESCRIPTION
This pull request introduces several updates to the Ansible roles for managing Pacemaker clusters and SAP environments, with a focus on improving compatibility, configuration, and support for the new `sles_sap15.7` distribution. Key changes include updates to SBD service configurations, adjustments to stonith and timeout properties, and expanded support for `sles_sap15.7` across multiple roles.

### Updates to SBD Service Configuration:
* Changed the `SBD_DELAY_START` value from `yes` to `216` for improved delay management during startup (`deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.1.2-sbd.yaml`).
* Replaced inline modifications of the SBD service file with the creation of a service override directory and an override configuration file to set `TimeoutSec=259` and `Before=corosync.service` (`deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.1.2-sbd.yaml`).

### Adjustments to Cluster Properties:
* Increased the stonith timeout from `144` to `210` for enhanced reliability during fencing operations (`deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.2.0-cluster-RedHat.yml`).

### Expanded Support for `sles_sap15.7`:
* Added `sles_sap15.7` to supported distributions in multiple roles, including repository definitions, package versions, and mount configurations:
  - Repository support (`deploy/ansible/roles-os/1.3-repository/vars/repos.yaml`).
  - Package versions (`deploy/ansible/roles-os/1.17-generic-pacemaker/vars/main.yml`, `deploy/ansible/roles-os/1.18-scaleout-pacemaker/vars/main.yml`). [[1]](diffhunk://#diff-6cae64b94f444d52838e409131da07cee6f9b0e23b3f34166afd031cf78e35bcR122-R124) [[2]](diffhunk://#diff-0ec5d984868a42b7d10d1a6a8be203dee1872e9693bfcf7ef5c247783f032538R123-R125)
  - OS package definitions (`deploy/ansible/roles-os/1.4-packages/vars/os-packages.yaml`).
  - Mount configurations (`deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.1-anf-mounts.yaml`, `deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.8-anf-mounts-simplemount.yaml`). [[1]](diffhunk://#diff-71796226843a970d9fbdca171983f6020266419a45dba0e5429c09fb894d8c0eL18-R23) [[2]](diffhunk://#diff-a75722ba25834fa4407c2d9cbb1e0ee5e9f2c1572aaedd7a29ff9e140da51a8dL18-R23)

### Updates to SAP-Specific Roles:
* Updated SAP Note references from `3119751` to `3449186` for compatibility with the latest SAP requirements (`deploy/ansible/roles-sap-os/2.10-sap-notes/tasks/2.10.3119751.yaml`).
* Enhanced HANA Pacemaker configurations with conditional co-location constraints for distributions with major version `>= 15` (`deploy/ansible/roles-sap/5.5-hanadb-pacemaker/tasks/5.5.4.1-cluster-Suse.yml`). [[1]](diffhunk://#diff-9be48f33281344f314b6c7b09081dd7b0e2237fd55dcee13ef5df9e77aa0a8e6R151-R161) [[2]](diffhunk://#diff-9be48f33281344f314b6c7b09081dd7b0e2237fd55dcee13ef5df9e77aa0a8e6R212-R220)