### PR TITLE
Add support for Red Hat 9.6 in package versions, repositories

### DIFF
--- a/deploy/ansible/roles-os/1.17-generic-pacemaker/vars/main.yml
+++ b/deploy/ansible/roles-os/1.17-generic-pacemaker/vars/main.yml
@@ -98,6 +98,9 @@ package_versions:
   redhat9.4:
     - {name: "pacemaker",               version: "2.0.5",   compare_operator: ">=", version_type: "loose"}
     - {name: "resource-agents-cloud",   version: "4.10.0",  compare_operator: ">=", version_type: "loose"}
+  redhat9.6:
+    - {name: "pacemaker",               version: "2.0.5",   compare_operator: ">=", version_type: "loose"}
+    - {name: "resource-agents-cloud",   version: "4.10.0",  compare_operator: ">=", version_type: "loose"}
   sles_sap12.5:
     - {name: "pacemaker",               version: "1.1.23",  compare_operator: ">=", version_type: "loose"}
     - {name: "resource-agents",         version: "4.3.018", compare_operator: ">=", version_type: "loose"}

--- a/deploy/ansible/roles-os/1.18-scaleout-pacemaker/vars/main.yml
+++ b/deploy/ansible/roles-os/1.18-scaleout-pacemaker/vars/main.yml
@@ -99,6 +99,9 @@ package_versions:
   redhat9.4:
     - {name: "pacemaker",               version: "2.0.5",   compare_operator: ">=", version_type: "loose"}
     - {name: "resource-agents-cloud",   version: "4.10.0",  compare_operator: ">=", version_type: "loose"}
+  redhat9.6:
+    - {name: "pacemaker",               version: "2.0.5",   compare_operator: ">=", version_type: "loose"}
+    - {name: "resource-agents-cloud",   version: "4.10.0",  compare_operator: ">=", version_type: "loose"}
   sles_sap12.5:
     - {name: "pacemaker",               version: "1.1.23",  compare_operator: ">=", version_type: "loose"}
     - {name: "resource-agents",         version: "4.3.018", compare_operator: ">=", version_type: "loose"}

--- a/deploy/ansible/roles-os/1.3-repository/vars/repos.yaml
+++ b/deploy/ansible/roles-os/1.3-repository/vars/repos.yaml
@@ -32,6 +32,7 @@ repos:
   redhat9.0:
   redhat9.2:
   redhat9.4:
+  redhat9.6:
 
   # SLES
   sles12.3:

--- a/deploy/ansible/roles-os/1.4-packages/vars/os-packages.yaml
+++ b/deploy/ansible/roles-os/1.4-packages/vars/os-packages.yaml
@@ -317,6 +317,9 @@ packages:
   redhat9.4:
     - { tier: 'os',     package: 'NetworkManager-cloud-setup',                   node_tier: 'all',            state: 'present' }
     - { tier: 'ha',     package: 'NetworkManager-cloud-setup',                   node_tier: 'all',            state: 'absent'  }
+  redhat9.6:
+    - { tier: 'os',     package: 'NetworkManager-cloud-setup',                   node_tier: 'all',            state: 'present' }
+    - { tier: 'ha',     package: 'NetworkManager-cloud-setup',                   node_tier: 'all',            state: 'absent'  }
 
   sles_sap12:
     - { tier: 'os',     package: 'chrony',                                       node_tier: 'all',            state: 'present' }

--- a/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.1-anf-mounts.yaml
+++ b/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.1-anf-mounts.yaml
@@ -15,12 +15,12 @@
 - name:                                "ANF Mount: Set the NFSmount options"
   ansible.builtin.set_fact:
     mnt_options:                       'rw,nfsvers=4.1,hard,timeo=600,rsize=262144,wsize=262144,noatime,lock,_netdev,sec=sys'
-  when: distribution_full_id not in ['redhat8.4', 'redhat8.6', 'redhat8.8', 'redhat9.0', 'redhat9.2', 'redhat9.4', 'sles_sap15.2', 'sles_sap15.3', 'sles_sap15.4', 'sles_sap15.5', 'sles_sap15.6', 'sles_sap15.7']
+  when: distribution_full_id not in ['redhat8.4', 'redhat8.6', 'redhat8.8', 'redhat9.0', 'redhat9.2', 'redhat9.4', redhat9.6', 'sles_sap15.2', 'sles_sap15.3', 'sles_sap15.4', 'sles_sap15.5', 'sles_sap15.6', 'sles_sap15.7']
 
 - name:                                "ANF Mount: Set the NFSmount options"
   ansible.builtin.set_fact:
     mnt_options:                       'rw,nfsvers=4.1,hard,timeo=600,rsize=262144,wsize=262144,noatime,lock,_netdev,sec=sys,nconnect=8'
-  when: distribution_full_id in ['redhat8.4', 'redhat8.6', 'redhat8.8', 'redhat9.0', 'redhat9.2', 'redhat9.4', 'sles_sap15.2', 'sles_sap15.3', 'sles_sap15.4', 'sles_sap15.5', 'sles_sap15.6', 'sles_sap15.7']
+  when: distribution_full_id in ['redhat8.4', 'redhat8.6', 'redhat8.8', 'redhat9.0', 'redhat9.2', 'redhat9.4', redhat9.6', 'sles_sap15.2', 'sles_sap15.3', 'sles_sap15.4', 'sles_sap15.5', 'sles_sap15.6', 'sles_sap15.7']
 
 - name:                                "ANF Mount: Define this SID"
   ansible.builtin.set_fact:

--- a/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.8-anf-mounts-simplemount.yaml
+++ b/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.8-anf-mounts-simplemount.yaml
@@ -15,12 +15,12 @@
 - name:                                "ANF Mount: Set the NFSmount options"
   ansible.builtin.set_fact:
     mnt_options:                       'rw,nfsvers=4.1,hard,timeo=600,rsize=262144,wsize=262144,noatime,lock,_netdev,sec=sys'
-  when: distribution_full_id not in ['redhat8.4', 'redhat8.6', 'redhat8.8', 'redhat9.0', 'redhat9.2', 'redhat9.4', 'sles_sap15.2', 'sles_sap15.3', 'sles_sap15.4', 'sles_sap15.5', 'sles_sap15.6', 'sles_sap15.7']
+  when: distribution_full_id not in ['redhat8.4', 'redhat8.6', 'redhat8.8', 'redhat9.0', 'redhat9.2', 'redhat9.4', redhat9.6', 'sles_sap15.2', 'sles_sap15.3', 'sles_sap15.4', 'sles_sap15.5', 'sles_sap15.6', 'sles_sap15.7']
 
 - name:                                "ANF Mount: Set the NFSmount options"
   ansible.builtin.set_fact:
     mnt_options:                       'rw,nfsvers=4.1,hard,timeo=600,rsize=262144,wsize=262144,noatime,lock,_netdev,sec=sys,nconnect=8'
-  when: distribution_full_id in ['redhat8.4', 'redhat8.6', 'redhat8.8', 'redhat9.0', 'redhat9.2', 'redhat9.4', 'sles_sap15.2', 'sles_sap15.3', 'sles_sap15.4', 'sles_sap15.5', 'sles_sap15.6', 'sles_sap15.7']
+  when: distribution_full_id in ['redhat8.4', 'redhat8.6', 'redhat8.8', 'redhat9.0', 'redhat9.2', 'redhat9.4', redhat9.6', 'sles_sap15.2', 'sles_sap15.3', 'sles_sap15.4', 'sles_sap15.5', 'sles_sap15.6', 'sles_sap15.7']
 
 - name:                                "ANF Mount: Define this SID"
   ansible.builtin.set_fact:


### PR DESCRIPTION
This pull request adds support for the `redhat9.6` distribution across several Ansible roles, ensuring that package, repository, and mount configuration tasks are correctly applied for this new OS version. The changes are primarily focused on updating variable files and task conditions to include `redhat9.6` wherever other Red Hat 9.x versions are handled.

**Support for redhat9.6 distribution:**

* Added `redhat9.6` to the `repos:` list in `repos.yaml` to ensure repository management tasks include this version.
* Included `redhat9.6` in the `packages:` section of `os-packages.yaml` to manage required packages for this OS version.
* Added package version requirements for `pacemaker` and `resource-agents-cloud` under `redhat9.6` in both `1.17-generic-pacemaker` and `1.18-scaleout-pacemaker` roles. [[1]](diffhunk://#diff-6cae64b94f444d52838e409131da07cee6f9b0e23b3f34166afd031cf78e35bcR101-R103) [[2]](diffhunk://#diff-0ec5d984868a42b7d10d1a6a8be203dee1872e9693bfcf7ef5c247783f032538R102-R104)

**Mount options and conditional logic updates:**

* Updated conditional logic in `2.6.1-anf-mounts.yaml` and `2.6.8-anf-mounts-simplemount.yaml` to include `redhat9.6` in the lists that determine which NFS mount options to apply, ensuring correct mount behavior for this version. [[1]](diffhunk://#diff-71796226843a970d9fbdca171983f6020266419a45dba0e5429c09fb894d8c0eL18-R23) [[2]](diffhunk://#diff-a75722ba25834fa4407c2d9cbb1e0ee5e9f2c1572aaedd7a29ff9e140da51a8dL18-R23)[Copilot is generating a summary...]