### PR TITLE
Pipeline v1 fixes

### DIFF
--- a/deploy/ansible/playbook_00_validate_parameters.yaml
+++ b/deploy/ansible/playbook_00_validate_parameters.yaml
@@ -81,7 +81,7 @@
       ansible.builtin.assert:
         that:
                                        - item_to_check.parameter is defined                  # Has the variable been defined
-                                       - item_to_check.parameter | type_debug != 'NoneType'  # Is the variable not empty"
+                                       - item_to_check.parameter | type_debug != 'NoneType'  # Is the variable not empty
                                        - item_to_check.parameter | trim | length > 1
         fail_msg:                      "{{ item_to_check.error }}"
       loop:
@@ -175,7 +175,7 @@
       ansible.builtin.assert:
         that:
           - item_to_check.parameter is defined # Has the variable been defined
-          - item_to_check.parameter | type_debug != 'NoneType' # Is the variable not empty"
+          - item_to_check.parameter | type_debug != 'NoneType' # Is the variable not empty
           - item_to_check.parameter | trim | length > 1
         fail_msg: "{{ item_to_check.error }}"
       loop:

--- a/deploy/scripts/installer.sh
+++ b/deploy/scripts/installer.sh
@@ -256,9 +256,9 @@ fi
 automation_config_directory=$CONFIG_REPO_PATH/.sap_deployment_automation/
 generic_config_information="${automation_config_directory}"config
 
-if [ "v1" == "${SDAFWZ_CALLER_VERSION:-v2}" ]; then
+if [ "v1" == "${SDAFWZ_CALLER_VERSION:-v2}" ] && [ -f "${automation_config_directory}${environment}${region_code}" ]; then
 	system_config_information="${automation_config_directory}${environment}${region_code}"
-elif [ "v2" == "${SDAFWZ_CALLER_VERSION:-v2}" ]; then
+else
 	system_config_information="${automation_config_directory}${environment}${region_code}${network_logical_name}"
 fi
 

--- a/deploy/scripts/pipeline_scripts/v1/01-control-plane-prepare.sh
+++ b/deploy/scripts/pipeline_scripts/v1/01-control-plane-prepare.sh
@@ -130,9 +130,9 @@ NETWORK=$(echo "$DEPLOYER_FOLDERNAME" | awk -F'-' '{print $3}' | xargs)
 CONTROL_PLANE_NAME=$(basename "${DEPLOYER_FOLDERNAME}" | cut -d'-' -f1-3)
 
 automation_config_directory=$CONFIG_REPO_PATH/.sap_deployment_automation/
-if [ "v1" == "${SDAFWZ_CALLER_VERSION:-v2}" ]; then
+if [ "v1" == "${SDAFWZ_CALLER_VERSION:-v2}" ] && [ -f "${automation_config_directory}${ENVIRONMENT}${LOCATION}" ]; then
 	deployer_environment_file_name="${automation_config_directory}${ENVIRONMENT}${LOCATION}"
-elif [ "v2" == "${SDAFWZ_CALLER_VERSION:-v2}" ]; then
+else
 	deployer_environment_file_name="${automation_config_directory}${ENVIRONMENT}${LOCATION}${NETWORK}"
 fi
 

--- a/deploy/scripts/pipeline_scripts/v1/02-sap-workload-zone.sh
+++ b/deploy/scripts/pipeline_scripts/v1/02-sap-workload-zone.sh
@@ -121,7 +121,11 @@ NETWORK_IN_FILENAME=$(echo $WORKLOAD_ZONE_FOLDERNAME | awk -F'-' '{print $3}')
 automation_config_directory=$CONFIG_REPO_PATH/.sap_deployment_automation/
 if [ "v1" == "${SDAFWZ_CALLER_VERSION:-v2}" ]; then
 	echo "Running v1 script"
-	workload_environment_file_name="${automation_config_directory}${ENVIRONMENT}${LOCATION_CODE_IN_FILENAME}"
+	if [ -f "${automation_config_directory}${ENVIRONMENT}${LOCATION_CODE_IN_FILENAME}" ]; then
+		workload_environment_file_name="${automation_config_directory}${ENVIRONMENT}${LOCATION_CODE_IN_FILENAME}"
+	else
+		workload_environment_file_name="${automation_config_directory}${ENVIRONMENT}${LOCATION_CODE_IN_FILENAME}${NETWORK}"
+	fi
 	ENVIRONMENT_IN_NAME=$(echo $DEPLOYER_ENVIRONMENT | awk -F'-' '{print $1}')
 	deployer_environment_file_name="${automation_config_directory}$ENVIRONMENT_IN_NAME$DEPLOYER_REGION"
 elif [ "v2" == "${SDAFWZ_CALLER_VERSION:-v2}" ]; then

--- a/deploy/scripts/pipeline_scripts/v1/03-sap-system-deployment.sh
+++ b/deploy/scripts/pipeline_scripts/v1/03-sap-system-deployment.sh
@@ -132,9 +132,9 @@ landscape_tfstate_key="${ENVIRONMENT_IN_FILENAME}-${LOCATION_CODE_IN_FILENAME}-$
 export landscape_tfstate_key
 
 automation_config_directory=$CONFIG_REPO_PATH/.sap_deployment_automation/
-if [ "v1" == "${SDAFWZ_CALLER_VERSION:-v2}" ]; then
+if [ "v1" == "${SDAFWZ_CALLER_VERSION:-v2}" ] && [ -f "${automation_config_directory}${ENVIRONMENT}${LOCATION_CODE_IN_FILENAME}" ]; then
 	workload_environment_file_name="${automation_config_directory}${ENVIRONMENT}${LOCATION_CODE_IN_FILENAME}"
-elif [ "v2" == "${SDAFWZ_CALLER_VERSION:-v2}" ]; then
+else
 	workload_environment_file_name="${automation_config_directory}${ENVIRONMENT}${LOCATION_CODE_IN_FILENAME}${NETWORK}"
 fi
 

--- a/deploy/scripts/pipeline_scripts/v1/03-sap-system-deployment.sh
+++ b/deploy/scripts/pipeline_scripts/v1/03-sap-system-deployment.sh
@@ -141,14 +141,14 @@ fi
 deployer_tfstate_key=$(getVariableFromVariableGroup "${VARIABLE_GROUP_ID}" "DEPLOYER_STATE_FILENAME" "${workload_environment_file_name}" "deployer_tfstate_key")
 export deployer_tfstate_key
 
-Terraform_Remote_Storage_Account_Name=$(getVariableFromVariableGroup "${VARIABLE_GROUP}" "TERRAFORM_STATE_STORAGE_ACCOUNT" "${workload_environment_file_name}" "REMOTE_STATE_SA")
+Terraform_Remote_Storage_Account_Name=$(getVariableFromVariableGroup "${VARIABLE_GROUP_ID}" "TERRAFORM_STATE_STORAGE_ACCOUNT" "${workload_environment_file_name}" "REMOTE_STATE_SA")
 tfstate_resource_id=$(az graph query -q "Resources | join kind=leftouter (ResourceContainers | where type=='microsoft.resources/subscriptions' | project subscription=name, subscriptionId) on subscriptionId | where name == '$Terraform_Remote_Storage_Account_Name' | project id, name, subscription" --query data[0].id --output tsv)
 
 if [ -v DEPLOYER_KEYVAULT ] && [ -n "$DEPLOYER_KEYVAULT" ]; then
 	# If the variable is already set, use it
 	key_vault_id=$(az graph query -q "Resources | join kind=leftouter (ResourceContainers | where type=='microsoft.resources/subscriptions' | project subscription=name, subscriptionId) on subscriptionId | where name == '$DEPLOYER_KEYVAULT' | project id, name, subscription" --query data[0].id --output tsv)
 else
-	DEPLOYER_KEYVAULT=$(getVariableFromVariableGroup "${VARIABLE_GROUP}" "DEPLOYER_KEYVAULT" "${workload_environment_file_name}" "deployer_keyvault")
+	DEPLOYER_KEYVAULT=$(getVariableFromVariableGroup "${VARIABLE_GROUP_ID}" "DEPLOYER_KEYVAULT" "${workload_environment_file_name}" "deployer_keyvault")
 	export DEPLOYER_KEYVAULT
 fi
 

--- a/deploy/scripts/pipeline_scripts/v1/05-DB-and-SAP-installation-prepare.sh
+++ b/deploy/scripts/pipeline_scripts/v1/05-DB-and-SAP-installation-prepare.sh
@@ -84,9 +84,9 @@ SID=$(echo "${SAP_SYSTEM_CONFIGURATION_NAME}" | awk -F'-' '{print $4}' | xargs)
 cd "$CONFIG_REPO_PATH" || exit
 
 automation_config_directory=$CONFIG_REPO_PATH/.sap_deployment_automation/
-if [ "v1" == "${SDAFWZ_CALLER_VERSION:-v2}" ]; then
+if [ "v1" == "${SDAFWZ_CALLER_VERSION:-v2}" ] && [ -f "${automation_config_directory}${ENVIRONMENT}${LOCATION}" ]; then
 	workload_environment_file_name="${automation_config_directory}${ENVIRONMENT}${LOCATION}"
-elif [ "v2" == "${SDAFWZ_CALLER_VERSION:-v2}" ]; then
+else
 	workload_environment_file_name="${automation_config_directory}${ENVIRONMENT}${LOCATION}${NETWORK}"
 fi
 

--- a/deploy/scripts/pipeline_scripts/v1/05-run-ansible.sh
+++ b/deploy/scripts/pipeline_scripts/v1/05-run-ansible.sh
@@ -199,7 +199,6 @@ if [ -f "${filename}" ]; then
 						-e 'download_directory=$AGENT_TEMPDIRECTORY'                                \
 						-e orchestration_ansible_user=$USER                                         \
   					-e ansible_user=$user_name                                                  \
-
 						-e '_workspace_directory=$PARAMETERS_FOLDER'                                \
 						-e ansible_ssh_pass='${ANSIBLE_PASSWORD}' '${filename}' $EXTRA_PARAMS       \
 						$EXTRA_PARAM_FILE"

--- a/deploy/scripts/pipeline_scripts/v1/10-remover-terraform-system.sh
+++ b/deploy/scripts/pipeline_scripts/v1/10-remover-terraform-system.sh
@@ -127,9 +127,9 @@ landscape_tfstate_key="${WORKLOAD_ZONE_NAME}-INFRASTRUCTURE.terraform.tfstate"
 export landscape_tfstate_key
 
 automation_config_directory=$CONFIG_REPO_PATH/.sap_deployment_automation/
-if [ "v1" == "${SDAFWZ_CALLER_VERSION:-v2}" ]; then
+if [ "v1" == "${SDAFWZ_CALLER_VERSION:-v2}" ] && [ -f "${automation_config_directory}${ENVIRONMENT}${LOCATION_CODE_IN_FILENAME}" ]; then
 	workload_environment_file_name="${automation_config_directory}${ENVIRONMENT}${LOCATION_CODE_IN_FILENAME}"
-elif [ "v2" == "${SDAFWZ_CALLER_VERSION:-v2}" ]; then
+else
 	workload_environment_file_name="${automation_config_directory}${ENVIRONMENT}${LOCATION_CODE_IN_FILENAME}${NETWORK}"
 fi
 

--- a/deploy/scripts/pipeline_scripts/v1/10-remover-terraform-workload-zone.sh
+++ b/deploy/scripts/pipeline_scripts/v1/10-remover-terraform-workload-zone.sh
@@ -112,7 +112,11 @@ NETWORK_IN_FILENAME=$(echo $WORKLOAD_ZONE_FOLDERNAME | awk -F'-' '{print $3}')
 automation_config_directory=$CONFIG_REPO_PATH/.sap_deployment_automation/
 if [ "v1" == "${SDAFWZ_CALLER_VERSION:-v2}" ]; then
 	echo "Running v1 script"
-	workload_environment_file_name="${automation_config_directory}${ENVIRONMENT}${LOCATION_CODE_IN_FILENAME}"
+	if [ -f  "${automation_config_directory}${ENVIRONMENT}${LOCATION_CODE_IN_FILENAME}" ]; then
+		workload_environment_file_name="${automation_config_directory}${ENVIRONMENT}${LOCATION_CODE_IN_FILENAME}"
+	else
+		workload_environment_file_name="${automation_config_directory}${ENVIRONMENT}${LOCATION_CODE_IN_FILENAME}${NETWORK}"
+	fi
 	ENVIRONMENT_IN_NAME=$(echo $DEPLOYER_ENVIRONMENT | awk -F'-' '{print $1}')
 	DEPLOYER_REGION=$(echo $DEPLOYER_ENVIRONMENT | awk -F'-' '{print $2}')
 	deployer_environment_file_name="${automation_config_directory}$ENVIRONMENT_IN_NAME$DEPLOYER_REGION"

--- a/deploy/scripts/pipeline_scripts/v1/12-remove-control-plane-finalize.sh
+++ b/deploy/scripts/pipeline_scripts/v1/12-remove-control-plane-finalize.sh
@@ -130,9 +130,9 @@ CONTROL_PLANE_NAME=$(echo "$DEPLOYER_FOLDERNAME" | cut -d'-' -f1-3)
 export "CONTROL_PLANE_NAME"
 
 automation_config_directory=$CONFIG_REPO_PATH/.sap_deployment_automation/
-if [ "v1" == "${SDAFWZ_CALLER_VERSION:-v2}" ]; then
+if [ "v1" == "${SDAFWZ_CALLER_VERSION:-v2}" ] && [ -f "${automation_config_directory}${ENVIRONMENT}${LOCATION}" ]; then
 	deployer_environment_file_name="${automation_config_directory}${ENVIRONMENT}${LOCATION}"
-elif [ "v2" == "${SDAFWZ_CALLER_VERSION:-v2}" ]; then
+else
 	deployer_environment_file_name="${automation_config_directory}${ENVIRONMENT}${LOCATION}${NETWORK}"
 fi
 

--- a/deploy/scripts/pipeline_scripts/v2/05-run-ansible.sh
+++ b/deploy/scripts/pipeline_scripts/v2/05-run-ansible.sh
@@ -197,7 +197,6 @@ if [ -f "${filename}" ]; then
 						-e 'download_directory=$AGENT_TEMPDIRECTORY'                                \
 						-e orchestration_ansible_user=$USER                                         \
   					-e ansible_user=$user_name                                                  \
-
 						-e '_workspace_directory=$PARAMETERS_FOLDER'                                \
 						-e ansible_ssh_pass='${ANSIBLE_PASSWORD}' '${filename}' $EXTRA_PARAMS       \
 						$EXTRA_PARAM_FILE"


### PR DESCRIPTION
Various small fixes to v1 pipelines:

1. In previous pipelines and version of SDAF it was possible to have multiple networks in the same workload zone, this fixes it across v1 pipelines to ensure that the framework is backwards compatible.
2. Extra line in post hook playbook call broke the post hook, removed the extra line to fix.
3. Ensure that system deployment correctly uses `VARIABLE_GROUP_ID`  instead of `VARIABLE_GROUP` in getVariableFromVariableGroup calls, to avoid int conversion error.