### PR TITLE
Oracle install fixes

### DIFF
--- a/deploy/ansible/roles-sap/5.1-dbload/tasks/oracle-postprocessing.yaml
+++ b/deploy/ansible/roles-sap/5.1-dbload/tasks/oracle-postprocessing.yaml
@@ -17,7 +17,7 @@
 
   when:
     - ansible_memory_mb.real.total < 4194304
-    - "pas not in supported_tiers"
+    - "'pas' not in supported_tiers"
 - name:                                "ORACLE Post Processing: Set the SGA and PGA Sizes for RAM < 4TB Single Node Deployments"
   ansible.builtin.set_fact:
     main_mem1:                         "{{ ansible_memory_mb.real.total }}"
@@ -25,7 +25,7 @@
     ora_pga:                           "{{ [(pga_temp_l4tb_std | int), 4194304] | min }}"
   when:
     - ansible_memory_mb.real.total < 4194304
-    - "pas in supported_tiers"
+    - "'pas' in supported_tiers"
 
 - name:                                "ORACLE Post Processing: Show Main Memory"
   ansible.builtin.debug:

--- a/deploy/ansible/roles-sap/5.1-dbload/templates/dbload-inifile-param.j2
+++ b/deploy/ansible/roles-sap/5.1-dbload/templates/dbload-inifile-param.j2
@@ -6,13 +6,6 @@
 
 archives.downloadBasket                                               = {{ target_media_location }}/download_basket
 
-SAPINST.CD.PACKAGE.HDBCLIENT                                          = {{ target_media_location }}/CD_HDBCLIENT/SAP_HANA_CLIENT
-SAPINST.CD.PACKAGE.CD1                                                = {{ target_media_location }}/CD_EXPORT/DATA_UNITS/EXP1
-SAPINST.CD.PACKAGE.CD2                                                = {{ target_media_location }}/CD_EXPORT/DATA_UNITS/EXP2
-SAPINST.CD.PACKAGE.CD3                                                = {{ target_media_location }}/CD_EXPORT/DATA_UNITS/EXP3
-SAPINST.CD.PACKAGE.CD4                                                = {{ target_media_location }}/CD_EXPORT/DATA_UNITS/EXP4
-
-
 nwUsers.sapadmUID                                                     = {{ sapadm_uid }}
 nwUsers.sapsysGID                                                     = {{ sapsys_gid }}
 nwUsers.sidAdmUID                                                     = {{ sidadm_uid }}
@@ -35,6 +28,11 @@ hanadb.landscape.reorg.useParameterFile                               = DONOTUSE
 
 {% if platform | upper == 'HANA' %}
 
+SAPINST.CD.PACKAGE.HDBCLIENT                                          = {{ target_media_location }}/CD_HDBCLIENT/SAP_HANA_CLIENT
+SAPINST.CD.PACKAGE.CD1                                                = {{ target_media_location }}/CD_EXPORT/DATA_UNITS/EXP1
+SAPINST.CD.PACKAGE.CD2                                                = {{ target_media_location }}/CD_EXPORT/DATA_UNITS/EXP2
+SAPINST.CD.PACKAGE.CD3                                                = {{ target_media_location }}/CD_EXPORT/DATA_UNITS/EXP3
+SAPINST.CD.PACKAGE.CD4                                                = {{ target_media_location }}/CD_EXPORT/DATA_UNITS/EXP4
 
 HDB_Schema_Check_Dialogs.schemaName                                   = {{ hana_schema }}
 HDB_Schema_Check_Dialogs.schemaPassword                               = {{ main_password }}

--- a/deploy/ansible/roles-sap/5.2-pas-install/templates/pas-inifile-param.j2
+++ b/deploy/ansible/roles-sap/5.2-pas-install/templates/pas-inifile-param.j2
@@ -6,16 +6,10 @@
 
 
 # Location of Export CD
-SAPINST.CD.PACKAGE.HDBCLIENT                                          = {{ target_media_location }}/CD_HDBCLIENT/SAP_HANA_CLIENT
 SAPINST.CD.PACKAGE.CLIENT                                             = {{ target_media_location }}/sapdb2_software/db2client
 SAPINST.CD.PACKAGE.RDBMS                                              = {{ target_media_location }}/sapdb2_software/db2server/LINUXX86_64
 SAPINST.CD.PACKAGE.LOAD                                               = {{ target_media_location }}/CD_EXPORT
 SAPINST.CD.PACKAGE.ORACLI                                             = {{ target_media_location }}/oraclient
-
-SAPINST.CD.PACKAGE.CD1                                                = {{ target_media_location }}/CD_EXPORT/DATA_UNITS/EXP1
-SAPINST.CD.PACKAGE.CD2                                                = {{ target_media_location }}/CD_EXPORT/DATA_UNITS/EXP2
-SAPINST.CD.PACKAGE.CD3                                                = {{ target_media_location }}/CD_EXPORT/DATA_UNITS/EXP3
-SAPINST.CD.PACKAGE.CD4                                                = {{ target_media_location }}/CD_EXPORT/DATA_UNITS/EXP4
 
 NW_Unpack.sapExeDbSar                                                 = {{ target_media_location }}/download_basket
 NW_Unpack.sapExeSar                                                   = {{ target_media_location }}/download_basket
@@ -26,6 +20,13 @@ archives.downloadBasket                                               = {{ targe
 UmeConfiguration.adminPassword                                        = {{ main_password }}
 
 {% if platform | upper == 'HANA' %}
+
+SAPINST.CD.PACKAGE.HDBCLIENT                                          = {{ target_media_location }}/CD_HDBCLIENT/SAP_HANA_CLIENT
+SAPINST.CD.PACKAGE.CD1                                                = {{ target_media_location }}/CD_EXPORT/DATA_UNITS/EXP1
+SAPINST.CD.PACKAGE.CD2                                                = {{ target_media_location }}/CD_EXPORT/DATA_UNITS/EXP2
+SAPINST.CD.PACKAGE.CD3                                                = {{ target_media_location }}/CD_EXPORT/DATA_UNITS/EXP3
+SAPINST.CD.PACKAGE.CD4                                                = {{ target_media_location }}/CD_EXPORT/DATA_UNITS/EXP4
+
 HDB_Schema_Check_Dialogs.schemaName                                   = {{ db_schema }}
 HDB_Schema_Check_Dialogs.schemaPassword                               = {{ main_password }}
 HDB_Userstore.doNotResolveHostnames                                   = {{ virt_do_not_resolve_hostname }}
@@ -121,9 +122,9 @@ storageBasedCopy.ora.listenerName                                    = LISTENER
 storageBasedCopy.ora.listenerPort                                    = 1521
 storageBasedCopy.ora.serverVersion                                   = {{ ora_release }}
 storageBasedCopy.ora.swowner                                         = oracle
-SAPINST.CD.PACKAGE.CD1                                                = {{ target_media_location }}/CD_EXPORT/DATA_UNITS/EXP1
-SAPINST.CD.PACKAGE.CD2                                                = {{ target_media_location }}/CD_EXPORT/DATA_UNITS/EXP2
-SAPINST.CD.PACKAGE.CD3                                                = {{ target_media_location }}/CD_EXPORT/DATA_UNITS/EXP3
+SAPINST.CD.PACKAGE.CD1                                                = {{ target_media_location }}/EXPORT/DATA_UNITS/EXP1
+SAPINST.CD.PACKAGE.CD2                                                = {{ target_media_location }}/EXPORT/DATA_UNITS/EXP2
+SAPINST.CD.PACKAGE.CD3                                                = {{ target_media_location }}/EXPORT/DATA_UNITS/EXP3
 {% endif %}
 
 {% if platform | upper == 'ORACLE' %}


### PR DESCRIPTION
Some fixes for oracle installations:

1. Ensure oracle-postprocessing pas in supported_tiers check is valid
2. ensure that the sap-automation provided installation param inifile works for oracle installations. The current solution ends up with multiple declarations of SAPINST.CD.PACKAGE.CD?, one for HANA and one for ORACLE, HANA is listed first and takes precedence. This is problematic when the default oracle installation extract the db export into {{ target_media_location }}/EXPORT and not {{ target_media_location }}/DB_EXPORT which is the case for HANA.