### PR TITLE
Update virtual machine names in outputs.tf

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/outputs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/outputs.tf
@@ -164,7 +164,7 @@ output "database_shared_disks"         {
                                          description = "List of Azure shared disks"
                                          value       = distinct(
                                                          flatten(
-                                                           [for vm in var.naming.virtualmachine_names.ANYDB_VMNAME :
+                                                           [for vm in var.naming.virtualmachine_names.ANYDB_COMPUTERNAME :
                                                              [for idx, disk in azurerm_virtual_machine_data_disk_attachment.cluster :
                                                                format("{ host: '%s', LUN: %d, type: 'ASD' }", vm, disk.lun)
                                                              ]
@@ -176,7 +176,7 @@ output "database_kdump_disks"          {
                                          description = "List of Azure kdump disks"
                                          value       = distinct(
                                                          flatten(
-                                                           [for vm in var.naming.virtualmachine_names.ANYDB_VMNAME :
+                                                           [for vm in var.naming.virtualmachine_names.ANYDB_COMPUTERNAME :
                                                              [for idx, disk in azurerm_virtual_machine_data_disk_attachment.kdump :
                                                                format("{ host: '%s', LUN: %d, type: 'kdump' }", vm, disk.lun)
                                                              ]


### PR DESCRIPTION
This pull request updates the output variables in the `anydb_node` Terraform module to use the correct variable for virtual machine names. The change ensures that the outputs reference `ANYDB_COMPUTERNAME` instead of the previously used `ANYDB_VMNAME`, which should improve accuracy and consistency in resource naming.

**Output variable updates:**

* Updated both `database_shared_disks` and `database_kdump_disks` outputs in `outputs.tf` to use `var.naming.virtualmachine_names.ANYDB_COMPUTERNAME` instead of `ANYDB_VMNAME` when iterating over VM names. [[1]](diffhunk://#diff-1e6f1a9edfd1427f9668cb8c1f9fa031545177bbf7965d1f6187e2a8ef30a381L167-R167) [[2]](diffhunk://#diff-1e6f1a9edfd1427f9668cb8c1f9fa031545177bbf7965d1f6187e2a8ef30a381L179-R179)## Problem
<Please describe what problem this PR is trying to resolve>

## Solution
<Please elaborate the solution for the problem>

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>