### PR TITLE
Refactor output files to improve variable handling and ensure proper trimming of subnet CIDR values

### DIFF
--- a/deploy/terraform/run/sap_system/module.tf
+++ b/deploy/terraform/run/sap_system/module.tf
@@ -401,7 +401,7 @@ module "output_files" {
                                                   )
   observer_shared_disks                         = upper(try(local.database.platform, "HANA")) == "HANA" ? (
                                                     module.hdb_node.observer_shared_disks) : (
-                                                    module.anydb_node.observer_shared_disks
+                                                    try(module.anydb_node.observer_shared_disks, [])
                                                   )
   platform                                      = upper(try(local.database.platform, "HANA"))
   sap_sid                                       = local.sap_sid

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/outputs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/outputs.tf
@@ -164,7 +164,7 @@ output "database_shared_disks"         {
                                          description = "List of Azure shared disks"
                                          value       = distinct(
                                                          flatten(
-                                                           [for vm in var.naming.virtualmachine_names.ANYDB_VMNAME :
+                                                           [for vm in coalesce(azurerm_linux_virtual_machine.dbserver[*].computer_name, azurerm_windows_virtual_machine.dbserver[*].computer_name) :
                                                              [for idx, disk in azurerm_virtual_machine_data_disk_attachment.cluster :
                                                                format("{ host: '%s', LUN: %d, type: 'ASD' }", vm, disk.lun)
                                                              ]
@@ -176,7 +176,7 @@ output "database_kdump_disks"          {
                                          description = "List of Azure kdump disks"
                                          value       = distinct(
                                                          flatten(
-                                                           [for vm in var.naming.virtualmachine_names.ANYDB_VMNAME :
+                                                           [for vm in coalesce(azurerm_linux_virtual_machine.dbserver[*].computer_name, azurerm_windows_virtual_machine.dbserver[*].computer_name) :
                                                              [for idx, disk in azurerm_virtual_machine_data_disk_attachment.kdump :
                                                                format("{ host: '%s', LUN: %d, type: 'kdump' }", vm, disk.lun)
                                                              ]

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/outputs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/outputs.tf
@@ -164,7 +164,7 @@ output "database_shared_disks"         {
                                          description = "List of Azure shared disks"
                                          value       = distinct(
                                                          flatten(
-                                                           [for vm in var.naming.virtualmachine_names.ANYDB_VMNAME :
+                                                           [for vm in var.naming.virtualmachine_names.ANYDB_COMPUTERNAME :
                                                              [for idx, disk in azurerm_virtual_machine_data_disk_attachment.cluster :
                                                                format("{ host: '%s', LUN: %d, type: 'ASD' }", vm, disk.lun)
                                                              ]
@@ -176,7 +176,7 @@ output "database_kdump_disks"          {
                                          description = "List of Azure kdump disks"
                                          value       = distinct(
                                                          flatten(
-                                                           [for vm in var.naming.virtualmachine_names.ANYDB_VMNAME :
+                                                           [for vm in var.naming.virtualmachine_names.ANYDB_COMPUTERNAME :
                                                              [for idx, disk in azurerm_virtual_machine_data_disk_attachment.kdump :
                                                                format("{ host: '%s', LUN: %d, type: 'kdump' }", vm, disk.lun)
                                                              ]

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/outputs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/outputs.tf
@@ -164,7 +164,7 @@ output "database_shared_disks"         {
                                          description = "List of Azure shared disks"
                                          value       = distinct(
                                                          flatten(
-                                                           [for vm in var.naming.virtualmachine_names.ANYDB_COMPUTERNAME :
+                                                           [for vm in var.naming.virtualmachine_names.ANYDB_VMNAME :
                                                              [for idx, disk in azurerm_virtual_machine_data_disk_attachment.cluster :
                                                                format("{ host: '%s', LUN: %d, type: 'ASD' }", vm, disk.lun)
                                                              ]
@@ -176,7 +176,7 @@ output "database_kdump_disks"          {
                                          description = "List of Azure kdump disks"
                                          value       = distinct(
                                                          flatten(
-                                                           [for vm in var.naming.virtualmachine_names.ANYDB_COMPUTERNAME :
+                                                           [for vm in var.naming.virtualmachine_names.ANYDB_VMNAME :
                                                              [for idx, disk in azurerm_virtual_machine_data_disk_attachment.kdump :
                                                                format("{ host: '%s', LUN: %d, type: 'kdump' }", vm, disk.lun)
                                                              ]

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/disk_logic.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/disk_logic.tf
@@ -233,17 +233,17 @@ locals {
   //Disks for Ansible
   // host: xxx, LUN: #, type: sapusr, size: #
 
-  app_disks_ansible                    = distinct(flatten([for vm in var.naming.virtualmachine_names.APP_COMPUTERNAME : [
+  app_disks_ansible                    = distinct(flatten([for vm in coalesce(azurerm_linux_virtual_machine.app[*].computer_name, azurerm_windows_virtual_machine.app[*].computer_name) : [
                                            for idx, datadisk in local.app_data_disk_per_node :
                                            format("{ host: '%s', LUN: %d, type: '%s' }", vm, datadisk.lun, datadisk.type)
                                          ]]))
 
-  scs_disks_ansible                    = distinct(flatten([for vm in var.naming.virtualmachine_names.SCS_COMPUTERNAME : [
+  scs_disks_ansible                    = distinct(flatten([for vm in coalesce(azurerm_linux_virtual_machine.scs[*].computer_name, azurerm_windows_virtual_machine.scs[*].computer_name) : [
                                            for idx, datadisk in local.scs_data_disk_per_node :
                                            format("{ host: '%s', LUN: %d, type: '%s' }", vm, datadisk.lun, datadisk.type)
                                          ]]))
 
-  web_disks_ansible                    = distinct(flatten([for vm in var.naming.virtualmachine_names.WEB_COMPUTERNAME : [
+  web_disks_ansible                    = distinct(flatten([for vm in coalesce(azurerm_linux_virtual_machine.web[*].computer_name, azurerm_windows_virtual_machine.web[*].computer_name) : [
                                            for idx, datadisk in local.web_data_disk_per_node :
                                            format("{ host: '%s', LUN: %d, type: '%s' }", vm, datadisk.lun, datadisk.type)
                                          ]]))

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/outputs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/outputs.tf
@@ -247,7 +247,7 @@ output "database_shared_disks"         {
                                          description = "List of Azure shared disks"
                                          value       = distinct(
                                                          flatten(
-                                                           [for vm in var.naming.virtualmachine_names.HANA_COMPUTERNAME :
+                                                           [for vm in azurerm_linux_virtual_machine.vm_dbnode[*].computer_name :
                                                              [for idx, disk in azurerm_virtual_machine_data_disk_attachment.cluster :
                                                                format("{ host: '%s', LUN: %d, type: 'ASD' }", vm, disk.lun)
                                                              ]
@@ -260,7 +260,7 @@ output "database_kdump_disks"          {
                                          description = "List of Azure disks for kdump"
                                          value       = distinct(
                                                          flatten(
-                                                           [for vm in var.naming.virtualmachine_names.HANA_COMPUTERNAME :
+                                                           [for vm in azurerm_linux_virtual_machine.vm_dbnode[*].computer_name :
                                                              [for idx, disk in azurerm_virtual_machine_data_disk_attachment.kdump :
                                                                format("{ host: '%s', LUN: %d, type: 'kdump' }", vm, disk.lun)
                                                              ]

--- a/deploy/terraform/terraform-units/modules/sap_system/output_files/inventory.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/output_files/inventory.tf
@@ -250,9 +250,9 @@ resource "local_file" "sap-parameters_yml" {
               sid                         = var.sap_sid,
               subnet_cidr_anf             = var.subnet_cidr_anf,
               subnet_cidr_app             = var.subnet_cidr_app,
-              subnet_cidr_client          = var.subnet_cidr_client
-              subnet_cidr_db              = var.subnet_cidr_db
-              subnet_cidr_storage         = var.subnet_cidr_storage,
+              subnet_cidr_client          = trimspace(coalesce(var.subnet_cidr_client," ")),
+              subnet_cidr_db              = trimspace(coalesce(var.subnet_cidr_db," ")),
+              subnet_cidr_storage         = trimspace(coalesce(var.subnet_cidr_storage," ")),
               upgrade_packages            = var.upgrade_packages ? "true" : "false"
               use_msi_for_clusters        = var.use_msi_for_clusters
               usr_sap                     = length(var.usr_sap) > 1 ? (


### PR DESCRIPTION
This pull request improves the robustness and compatibility of how virtual machine names and subnet CIDRs are handled throughout the Terraform modules for SAP system deployment. The changes ensure that outputs and local variables work correctly regardless of whether Linux or Windows VMs are used, and that optional subnet CIDR variables are safely managed.

**Improvements to VM name handling and disk outputs:**

* Updated all relevant outputs and local variables to use the actual VM computer names from both Linux and Windows resources (using `coalesce`), instead of relying solely on naming variables. This affects disk outputs for AnyDB, HANA, and the app tier, ensuring correct disk-to-host mapping regardless of VM OS. [[1]](diffhunk://#diff-1e6f1a9edfd1427f9668cb8c1f9fa031545177bbf7965d1f6187e2a8ef30a381L167-R167) [[2]](diffhunk://#diff-1e6f1a9edfd1427f9668cb8c1f9fa031545177bbf7965d1f6187e2a8ef30a381L179-R179) [[3]](diffhunk://#diff-20cbfe17f3b45aa9e36b90fc3ec540555f57666a6b760c7532b629140094efbbL250-R250) [[4]](diffhunk://#diff-20cbfe17f3b45aa9e36b90fc3ec540555f57666a6b760c7532b629140094efbbL263-R263) [[5]](diffhunk://#diff-830a872f92cedcc9330c7ae53a53b8d0878ca951170e0f86ba98d9581a1af31fL236-R246)

**Enhancements to optional variable handling:**

* Changed the assignment of `subnet_cidr_client`, `subnet_cidr_db`, and `subnet_cidr_storage` to use `coalesce` and `trimspace`, preventing issues if these variables are unset or contain extra whitespace.

**Increased resilience for output modules:**

* Modified the `observer_shared_disks` output in the `output_files` module to use a safe fallback (`[]`) if the expected value is not present, making the output more robust to missing data.This pull request introduces improvements to how optional variables are handled in the SAP system Terraform modules, making the configuration more robust against missing or unset values. The main focus is on ensuring that unset subnet CIDRs and observer disk values do not cause errors during deployment.

**Robust handling of optional variables:**

* [`deploy/terraform/terraform-units/modules/sap_system/output_files/inventory.tf`](diffhunk://#diff-cc4cb007e96fe313cba3d8b0733cf8cbb3d5e9d1c3d1a72316b2786d1f3585daL253-R255): Updated the assignment of `subnet_cidr_client`, `subnet_cidr_db`, and `subnet_cidr_storage` to use `trimspace(coalesce(..., " "))`, ensuring these variables default to a blank string if unset and removing leading/trailing whitespace.
* [`deploy/terraform/run/sap_system/module.tf`](diffhunk://#diff-f308feab46874404e1d0e929889f9151c802de5e378849f89cc90a9f25605397L404-R404): Changed the assignment of `observer_shared_disks` to use `try(module.anydb_node.observer_shared_disks, [])`, providing an empty list as a safe fallback if the value is unset.…trimming of subnet CIDR values

## Problem
<Please describe what problem this PR is trying to resolve>

## Solution
<Please elaborate the solution for the problem>

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>