### PR TITLE
Fix Oracle ASM deployments

### DIFF
--- a/deploy/ansible/playbook_04_00_00_db_install.yaml
+++ b/deploy/ansible/playbook_04_00_00_db_install.yaml
@@ -60,25 +60,24 @@
         - db_high_availability is defined
         - database_high_availability is not defined
 
-    - name:                                 "Database Installation Playbook: - Read/Create key vault secrets"
+    - name:                            "Database Installation Playbook: - Read/Create key vault secrets"
       ansible.builtin.include_role:
-        name:                               roles-misc/0.2-kv-secrets
-        public:                             true
+        name:                          roles-misc/0.2-kv-secrets
+        public:                        true
       vars:
-        # tier:                               fencing
-        operation:                          fencing
-      when:                                 (database_high_availability and database_cluster_type == "AFA")
+        # tier:                        fencing
+        operation:                     fencing
+      when:                            (database_high_availability and database_cluster_type == "AFA")
       tags:
                                             - 0.2-kv-secrets
 
     - name:                            "Database Installation Playbook: - Read storage account details"
-      ansible.builtin.include_role:
+      ansible.builtin.import_role:
         name:                          roles-misc/0.3.sap-installation-media-storage-details
-        public:                        true
       vars:
         tier:                          bom_download
       tags:
-        - kv-sap-installation-media-storage-details
+        - always
 
     - name:                            "Database Installation Playbook: - Generate root password"
       ansible.builtin.set_fact:
@@ -288,12 +287,12 @@
 
     # This configures root account on HANA nodes for scale out configuration ( shared and shared nothing with HSR ) to use password based login.
     - name:                            "SAP HANA: Configure root credential for Scale-Out"
-      become:                          true
       when:
                                        - database_scale_out
                                        - hostvars.localhost.root_password is defined
       block:
         - name:                            Reset root password
+          become:                          true
           ansible.builtin.user:
             name:                          root
             update_password:               always
@@ -301,6 +300,7 @@
             password_lock:                 false
 
         - name:                            Enable {{ item.key }} in /etc/ssh/sshd_config
+          become:                          true
           ansible.builtin.lineinfile:
             path:                          "/etc/ssh/sshd_config"
             regex:                         "^(# *)?{{ item.key }}"
@@ -319,6 +319,7 @@
           ignore_errors:                   true
 
         - name:                            Append root user to AllowUsers if used
+          become:                          true
           ansible.builtin.lineinfile:
             path:                          "/etc/ssh/sshd_config"
             regexp:                        '^AllowUsers (?!.*root.*)(.*)'
@@ -327,6 +328,7 @@
             state:                         present
 
         - name:                            "Restart SSHD on {{ ansible_hostname }}"
+          become:                          true
           ansible.builtin.service:
             name:                          sshd
             state:                         restarted
@@ -669,7 +671,6 @@
             state:                     touch
             mode:                      0755
 
-
     - name:                            "Install Oracle for MSID"
       become:                          true
       become_user:                     root
@@ -714,53 +715,56 @@
         - node_tier == 'oracle-asm'
         - platform == 'ORACLE-ASM'
       block:
-        - name:                        Setting the DB facts for ASM
+        - name:                        "Oracle ASM: Setting the DB facts for ASM"
           ansible.builtin.set_fact:
             tier:                      ora                                    # Actions for Oracle DB Servers
             main_password:             "{{ hostvars.localhost.sap_password }}"
+            sapbits_location_base_path: "{{ hostvars.localhost.sapbits_location_base_path }}"
+            sapbits_sas_token:         "{{ hostvars.localhost.sapbits_sas_token }}"
           tags:
             - always
 
-        - name:                        Include 1.5.1.1-disk-setup-asm-sap
+        - name:                         "Oracle ASM: Register repositories"
+          ansible.builtin.import_tasks: roles-os/1.3-repository/tasks/1.3.3-repositories-Oracle-ASM.yaml
+
+        - name:                        "Oracle ASM: Install Oracle specific packages"
+          ansible.builtin.include_role:
+            name:                      roles-os/1.4-packages
+
+        - name:                        "Oracle ASM: ASM Disk setup"
           ansible.builtin.include_role:
             name:                      roles-os/1.5.1.1-disk-setup-asm-sap
 
-        - name:                        "OS configuration playbook: - Ensure the kernel parameters are set"
+        - name:                        "Oracle ASM: Ensure the kernel parameters are set"
           ansible.builtin.include_role:
             name:                      roles-os/1.9-kernelparameters
           tags:
             - 1.9-kernelparameters
 
-        # - name:                        "SAP OS configuration playbook: - Configure accounts"
-        #   ansible.builtin.include_role:
-        #     name:                      roles-os/1.11-accounts
-        #   tags:
-        #     - 1.11-accounts
-
-        - name:                        "SAP OS configuration playbook: - Create SAP users/groups"
+        - name:                        "Oracle ASM: Create SAP users/groups"
           ansible.builtin.include_role:
             name:                      roles-sap-os/2.5-sap-users
           tags:
             - 2.5-sap-users
 
-        - name:                        Mount the file systems for ASM installation
+        - name:                        "Oracle ASM: Mount the file systems for ASM installation"
           ansible.builtin.include_role:
             name:                      roles-sap-os/2.6-sap-mounts
 
-        - name:                        Include 1.5.1-disk-setup-asm role
+        - name:                        "Oracle ASM: Include 1.5.1-disk-setup-asm role"
           ansible.builtin.include_role:
             name:                      roles-os/1.5.1-disk-setup-asm
 
-        - name:                        Check for file system mounts
+        - name:                        "Oracle ASM: Check for file system mounts"
           ansible.builtin.include_role:
             name:                      roles-sap-os/2.6-sap-mounts
 
-        - name:                        Installing Oracle ASM Grid
+        - name:                        "Oracle ASM: Installing Oracle ASM Grid"
           ansible.builtin.include_role:
             name:                      roles-db/4.1.1-ora-asm-grid
           tags:                        4.1.1-ora-asm-grid
 
-        - name:                        Installing Oracle on ASM
+        - name:                        "Oracle ASM: Installing Oracle on ASM"
           ansible.builtin.include_role:
             name:                      roles-db/4.1.2-ora-asm-db-install
 

--- a/deploy/ansible/roles-db/4.1.0-ora-install/tasks/main.yaml
+++ b/deploy/ansible/roles-db/4.1.0-ora-install/tasks/main.yaml
@@ -36,6 +36,14 @@
     owner:                             oracle
     group:                             oinstall
 
+- name:                                "ORACLE: Create temp directory"
+  ansible.builtin.file:
+    path:                              "{{ tmp_directory }}/{{ sap_sid | upper }}"
+    mode:                              0755
+    state:                             directory
+    owner:                             oracle
+    group:                             oinstall
+
 - name:                                "ORACLE: check if permissions are set"
   ansible.builtin.stat:
     path:                              "/etc/sap_deployment_automation/{{ sap_sid | upper }}/oracleowner.txt"
@@ -340,8 +348,8 @@
 
     - name:                            "ORACLE: Post Processing - SBP Patching"
       become:                          true
-      become_user:                     "oracle"
-      ansible.builtin.shell:           $IHRDBMS/MOPatch/mopatch.sh -v -s {{ oracle_sbp_patch }}
+      become_user:                     oracle
+      ansible.builtin.shell:           "env ORACLE_HOME=$IHRDBMS $IHRDBMS/MOPatch/mopatch.sh -v -s {{ oracle_sbp_patch }}"
       environment:
         DB_SID:                        "{{ db_sid | upper }}"
         IHRDBMS:                       /oracle/{{ db_sid | upper }}/{{ ora_version }}

--- a/deploy/ansible/roles-db/4.1.1-ora-asm-grid/tasks/main.yaml
+++ b/deploy/ansible/roles-db/4.1.1-ora-asm-grid/tasks/main.yaml
@@ -19,7 +19,7 @@
 
 ---
 
-- name:                                "ORACLE: - Validate ORACLE parameters"
+- name:                                "ORACLE ASM: - Validate ORACLE parameters"
   ansible.builtin.assert:
     that:
       - item_to_check.parameter is defined                    # Has the variable been defined
@@ -33,7 +33,7 @@
   loop_control:
     loop_var: item_to_check
 
-- name:                                "SAP Oracle ASM: Load the disk configuration settings"
+- name:                                "ORACLE ASM: Load the disk configuration settings"
   ansible.builtin.include_vars:        disks_config_asm.yml
 
 - name:                                "Create hidden directory"
@@ -44,7 +44,7 @@
   loop:
     - { state: 'directory', mode: '0755', path: '/etc/sap_deployment_automation/' }
 
-- name:                                "SAP Oracle ASM: Permissions"
+- name:                                "ORACLE ASM: Permissions"
   ansible.builtin.file:
     path:                              /etc/sap_deployment_automation/oracle
     state:                             directory
@@ -52,7 +52,7 @@
     owner:                             oracle
     group:                             oinstall
 
-# - name:                                "SAP Oracle ASM: Create Grid extract software directory"
+# - name:                                "ORACLE ASM: Create Grid extract software directory"
 #   ansible.builtin.file:
 #     path:                              /oracle/GRID/{{ ora_version }}
 #     state:                             directory
@@ -60,7 +60,7 @@
 #     group:                             oinstall
 #     mode:                              0755
 
-- name:                                "SAP Oracle ASM: Create Grid software directory"
+- name:                                "ORACLE ASM: Create Grid software directory"
   ansible.builtin.file:
     path:                              /oracle/GRID/{{ ora_version }}
     state:                             directory
@@ -77,25 +77,25 @@
 # |                                                                            |
 # +------------------------------------4--------------------------------------*/
 
-- name:                                "Oracle: Setting the primary and Secondary DB names"
+- name:                                "ORACLE ASM: Setting the primary and Secondary DB names"
   ansible.builtin.set_fact:
     # ora_primary:                       "{{ ansible_play_hosts_all[0] }}"         # Oracle Primary Host
     # ora_secondary:                     "{{ ansible_play_hosts_all[1] }}"         # Oracle Secondary Host
     current_host:                      "{{ ansible_hostname }}"
 
-- name:                               "Get the List of Data disks"
+- name:                               "ORACLE ASM: Get the List of Data disks"
   become:                             true
   become_user:                        root
-  ansible.builtin.shell:              "set -o pipefail && oracleasm listdisks |grep DATA"
+  ansible.builtin.shell:              "set -o pipefail && oracleasm listdisks | grep DATA"
   register:                           asm_dlist
 
-- name:                               "Get the List of ARCH disks"
+- name:                               "ORACLE ASM: Get the List of ARCH disks"
   become:                             true
   become_user:                        root
-  ansible.builtin.shell:              "set -o pipefail && oracleasm listdisks |grep ARCH"
+  ansible.builtin.shell:              "set -o pipefail && oracleasm listdisks | grep ARCH"
   register:                           asm_alist
 
-- name:                               "Get the List of RECO disks"
+- name:                               "ORACLE ASM: Get the List of RECO disks"
   become:                             true
   become_user:                        root
   ansible.builtin.shell:              "set -o pipefail && oracleasm listdisks |grep RECO"
@@ -108,38 +108,41 @@
 #   register:                          asm_olist
 
 
-- name:                              "Prepare the Data disk list"
+- name:                                "ORACLE ASM: Prepare the Data disk list"
   ansible.builtin.set_fact:
     asm_dlist1:                    "{{ asm_dlist.stdout_lines | list }}"
     asm_alist1:                    "{{ asm_alist.stdout_lines | list }}"
     asm_rlist1:                    "{{ asm_rlist.stdout_lines | list }}"
 
 
-- name:                            "DISPLAY Oracle lists"
+- name:                                "ORACLE ASM: DISPLAY Oracle lists"
   ansible.builtin.debug:
-    var:                           asm_dlist1,asm_alist1,asm_rlist1
-    verbosity:                     2
+    msg:
+      - "Data:     {{ asm_dlist1 }}"
+      - "Archive:  {{ asm_alist1 }}"
+      - "Recovery: {{ asm_rlist1 }}"
 
 
-- name:                           "Append /dev/oracleasm/disk to each of of the disk"
+- name:                               "ORACLE ASM: Prepend /dev/oracleasm/disk to each of of the disk"
   ansible.builtin.set_fact:
     asm_datadisklist:     "{{ asm_dlist1 | map('regex_replace', '^(.*)$', '/dev/oracleasm/disks/\\1') | join(',') }}"
     asm_archdisklist:     "{{ asm_alist1 | map('regex_replace', '^(.*)$', '/dev/oracleasm/disks/\\1') | join(',') }}"
     asm_recodisklist:     "{{ asm_rlist1 | map('regex_replace', '^(.*)$', '/dev/oracleasm/disks/\\1') | join(',') }}"
 
+- name:                               "ORACLE ASM: Store the disk lists as arrays"
+  ansible.builtin.set_fact:
+    data_disk_list:   "{{ asm_datadisklist | split(',') | list }}"
+    arch_disk_list:   "{{ asm_archdisklist | split(',') | list }}"
+    reco_disk_list:   "{{ asm_recodisklist | split(',') | list }}"
 
-- name:                            "DISPLAY Oracle lists with prefix"
+- name:                                "ORACLE ASM: DISPLAY Oracle lists with prefix"
   ansible.builtin.debug:
-    var:                           asm_datadisklist,asm_archdisklist,asm_recodisklist
-    verbosity:                     2
+    msg:
+      - "Data:     {{ data_disk_list }}"
+      - "Archive:  {{ arch_disk_list }}"
+      - "Recovery: {{ reco_disk_list }}"
 
-# - name:                              "Prepare the Data disk list"
-#   vars:
-#     prefix:                          /dev/oracleasm/disks/
-#     datadisk_list:                   result
-#     result1:                          "{{ [prefix] | product(datadisk_list) | map('join') | list }}"
-
-- name:                               "SAP Oracle ASM: deploy Grid install response file"
+- name:                               "ORACLE ASM: deploy Grid install response file"
   become:                             true
   become_user:                        oracle
   ansible.builtin.template:
@@ -155,24 +158,23 @@
 # |                                                                            |
 # +------------------------------------4--------------------------------------*/
 
-- name:                                "SAP Oracle ASM: Unzip the Grid software"
+- name:                                "ORACLE ASM: Unzip the Grid software"
   become:                              true
   become_user:                         root
   ansible.builtin.unarchive:
     src:                               /usr/sap/install/oraserver/LINUX_X86_64/grid_home/LINUX.X64_193000_grid_home.zip
     dest:                              /oracle/GRID/{{ ora_version }}
-    creates:                           /etc/sap_deployment_automation/oracle/gridswunzip.txt
+    creates:                           /etc/sap_deployment_automation/oracle/grids_unzip.txt
     owner:                             oracle
     group:                             oinstall
     remote_src:                        true
 
 
-- name:                                "SAP Oracle ASM: create after a successful unzip"
+- name:                                "ORACLE ASM: create after a successful unzip"
   ansible.builtin.file:
-    path:                              "/etc/sap_deployment_automation/oracle/gridswunzip.txt"
+    path:                              "/etc/sap_deployment_automation/oracle/grids_unzip.txt"
     state:                             touch
     mode:                              '0755'
-
 
 - name:                                "ORACLE ASM: Install RPM Packages"
   ansible.builtin.dnf:
@@ -181,67 +183,49 @@
     state:                             present
     disable_gpg_check:                 true
 
-# # Can not use ansible yum module as we need to use -y option in yum.
-# - name:                                "SAP Oracle ASM: Install CVUQDISK RPM"
-#   become:                              true
-#   become_user:                         root
-#   ansible.builtin.shell: |
-#                                        set -o errexit
-#                                        set -o pipefail
-#                                        yum install -y /oracle/GRID/{{ ora_version }}/cv/rpm/cvuqdisk-1.0.10-1.rpm
-#   args:
-#     creates:                           /etc/sap_deployment_automation/oracle/CVUQDISK.txt
-
-# - name:                                "SAP Oracle ASM: create after a RPM install"
-#   ansible.builtin.file:
-#     path:                              "/etc/sap_deployment_automation/oracle/CVUQDISK.txt"
-#     state:                             touch
-#     mode:                              '0755'
-
 # +------------------------------------4--------------------------------------*/
 # |                                                                            |
 # |                       Oracle Grid: Perform installation                    |
 # |                                                                            |
 # +------------------------------------4--------------------------------------*/
 
-- name:                                "Make oracle:oinstall are the owners for ASM Data Disks "
+- name:                                "ORACLE ASM: Make oracle:oinstall are the owners for ASM Data Disks "
   become:                              true
   become_user:                         root
   ansible.builtin.file:
-    path:                              '{{ item }}1'
+    path:                              '{{ item }}'
     owner:                             oracle
     group:                             oinstall
     mode:                              '755'
-  loop:                                '{{ datadisklist }}'
+  loop:                                '{{ data_disk_list }}'
 
-
-- name:                                "Make oracle:oinstall are the owners for ASM Arch Disks "
+- name:                                "ORACLE ASM: Make oracle:oinstall are the owners for ASM Archive Disks "
   become:                              true
   become_user:                         root
   ansible.builtin.file:
-    path:                              '{{ item }}1'
+    path:                              '{{ item }}'
     owner:                             oracle
     group:                             oinstall
     mode:                              '755'
-  loop:                                '{{ archdisklist }}'
+  loop:                                '{{ arch_disk_list }}'
 
-- name:                                "Make oracle:oinstall are the owners for ASM Reco Disks "
+- name:                                "ORACLE ASM: Make oracle:oinstall are the owners for ASM Recovery Disks "
   become:                              true
   become_user:                         root
   ansible.builtin.file:
-    path:                              '{{ item }}1'
+    path:                              '{{ item }}'
     owner:                             oracle
     group:                             oinstall
     mode:                              '755'
-  loop:                                '{{ recodisklist }}'
+  loop:                                '{{ reco_disk_list }}'
 
-- name:                                "SAP Oracle ASM: Install Execute GRIDSETUP"
+- name:                                "ORACLE ASM: Install Execute GRIDSETUP"
   become:                              true
   become_user:                         oracle
   ansible.builtin.shell: |
                                        set -o errexit
                                        set -o pipefail
-                                       ./gridSetup.sh -silent -responseFile /etc/sap_deployment_automation/oracle/ORACLE_{{ ora_release }}c_00_ASM_{{ ansible_hostname }}_{{ db_sid }}_install.rsp |tee -a /etc/sap_deployment_automation/oracle/gridinstall.log
+                                       ./gridSetup.sh -silent -responseFile /etc/sap_deployment_automation/oracle/ORACLE_{{ ora_release }}c_00_ASM_{{ ansible_hostname }}_{{ db_sid }}_install.rsp | tee -a /etc/sap_deployment_automation/oracle/gridinstall.log
   register:                            gridinstaller_results
   failed_when:                         gridinstaller_results.rc >= 2              # installer returns rc=1 (exited with warning) by default when run is silent mode as the oratab file is created only after running the root.sh
   environment:
@@ -253,11 +237,11 @@
   args:
     executable:                        /bin/csh
     chdir:                             "/oracle/GRID/{{ ora_version }}"
-    creates:                           /etc/sap_deployment_automation/oracle/gridinstall.txt
+    creates:                           /etc/sap_deployment_automation/oracle/grid_install.txt
 
-- name:                                "SAP Oracle ASM: Create after a successful GRID install"
+- name:                                "ORACLE ASM: Create after a successful GRID install"
   ansible.builtin.file:
-    path:                              "/etc/sap_deployment_automation/oracle/gridinstall.txt"
+    path:                              "/etc/sap_deployment_automation/oracle/grid_install.txt"
     state:                             touch
     mode:                              '0755'
 
@@ -271,7 +255,7 @@
 # +------------------------------------4--------------------------------------*/
 
 
-- name:                                "SAP Oracle ASM: Oracle Post Processing - Run root.sh"
+- name:                                "ORACLE ASM: Oracle Post Processing - Run root.sh"
   become:                              true
   become_user:                         root
   ansible.builtin.shell: |
@@ -283,7 +267,7 @@
     executable:                        /bin/csh
     creates:                           "/etc/sap_deployment_automation/oracle/gridinstall_rootscript.txt"
 
-- name:                                "SAP Oracle ASM: creates after a successful post processing script execution"
+- name:                                "ORACLE ASM: creates after a successful post processing script execution"
   ansible.builtin.file:
     path:                              "/etc/sap_deployment_automation/oracle/gridinstall_rootscript.txt"
     state:                             touch
@@ -299,7 +283,7 @@
 # |                                                                            |
 # +------------------------------------4--------------------------------------*/
 
-- name:                                "SAP Oracle ASM: Execute ASM Config tools"
+- name:                                "ORACLE ASM: Execute ASM Config tools"
   become:                              true
   become_user:                         oracle
   ansible.builtin.shell: |
@@ -321,7 +305,7 @@
     chdir:                             /oracle/GRID/{{ ora_version }}/
     creates:                           /etc/sap_deployment_automation/oracle/asm_tools_install.txt
 
-- name:                                "SAP Oracle ASM: Create after a successful Config tool execution"
+- name:                                "ORACLE ASM: Create after a successful Config tool execution"
   ansible.builtin.file:
     path:                              "/etc/sap_deployment_automation/oracle/asm_tools_install.txt"
     state:                             touch
@@ -338,7 +322,7 @@
 # +------------------------------------4--------------------------------------*/
 
 
-- name:                                "SAP Oracle ASM: Create ASM Disk groups ARCH and RECO"
+- name:                                "ORACLE ASM: Create ASM Disk groups ARCH and RECO"
   become:                              true
   become_user:                         oracle
   ansible.builtin.shell: |
@@ -354,7 +338,7 @@
     chdir:                             "/oracle/GRID/{{ ora_version }}/bin"
     creates:                           /etc/sap_deployment_automation/oracle/diskgroups_created.txt
 
-- name:                                "SAP Oracle ASM: Created after a successful disk group creation"
+- name:                                "ORACLE ASM: Created after a successful disk group creation"
   ansible.builtin.file:
     path:                             "/etc/sap_deployment_automation/oracle/diskgroups_created.txt"
     state:                            touch

--- a/deploy/ansible/roles-db/4.1.1-ora-asm-grid/tasks/main.yaml
+++ b/deploy/ansible/roles-db/4.1.1-ora-asm-grid/tasks/main.yaml
@@ -196,7 +196,7 @@
     path:                              '{{ item }}'
     owner:                             oracle
     group:                             oinstall
-    mode:                              '755'
+    mode:                              '0755'
   loop:                                '{{ data_disk_list }}'
 
 - name:                                "ORACLE ASM: Make oracle:oinstall are the owners for ASM Archive Disks "
@@ -206,7 +206,7 @@
     path:                              '{{ item }}'
     owner:                             oracle
     group:                             oinstall
-    mode:                              '755'
+    mode:                              '0755'
   loop:                                '{{ arch_disk_list }}'
 
 - name:                                "ORACLE ASM: Make oracle:oinstall are the owners for ASM Recovery Disks "
@@ -216,7 +216,7 @@
     path:                              '{{ item }}'
     owner:                             oracle
     group:                             oinstall
-    mode:                              '755'
+    mode:                              '0755'
   loop:                                '{{ reco_disk_list }}'
 
 - name:                                "ORACLE ASM: Install Execute GRIDSETUP"

--- a/deploy/ansible/roles-db/4.1.2-ora-asm-db-install/tasks/main.yaml
+++ b/deploy/ansible/roles-db/4.1.2-ora-asm-db-install/tasks/main.yaml
@@ -28,6 +28,14 @@
   loop_control:
     loop_var: item_to_check
 
+- name:                                "Oracle ASM: - Set DB SID"
+  ansible.builtin.debug:
+    msg:
+                                       - "DB SID: {{ sap_sid | upper }}"
+                                       - "Oracle Version: {{ ora_version }}"
+                                       - "Oracle Release: {{ ora_release }}"
+                                       - "Oracle SBP Patch: {{ oracle_sbp_patch }}"
+
 - name:                                "Oracle ASM: Load the disk configuration settings"
   ansible.builtin.include_vars:        disks_config_asm.yml
 
@@ -38,6 +46,15 @@
     state:                             directory
     owner:                             oracle
     group:                             oinstall
+
+- name:                                "Oracle ASM: tmp folder"
+  ansible.builtin.file:
+    path:                              "{{ tmp_directory }}/{{ db_sid | upper }}/{{ ora_version }}/"
+    mode:                              '0755'
+    state:                             directory
+    owner:                             oracle
+    group:                             oinstall
+
 
 - name:                                "Oracle ASM: check if permissions are set"
   ansible.builtin.stat:
@@ -69,6 +86,7 @@
   ansible.builtin.stat:
     path:                              "/etc/sap_deployment_automation/{{ sap_sid | upper }}/grid_sbp_installed.txt"
   register:                            oracle_installed
+
 
 # /*---------------------------------------------------------------------------8
 # | Start of Oracle software installation using SAP RUNINSTALLER wrapper.      |
@@ -609,13 +627,13 @@
 
     - name:                            "Oracle ASM: Check if 'OPatch.bck' exists"
       ansible.builtin.stat:
-        path:                          /oracle/{{ db_sid | upper }}/{{ ora_version }}/OPatch.bck
+        path:                          "{{ tmp_directory }}/{{ db_sid | upper }}/{{ ora_version }}/OPatch.bck"
       register:                        opatch_stat
 
     - name:                            "Oracle ASM: backup OPatch"
       ansible.builtin.copy:
-        src:                           /oracle/{{ db_sid | upper }}/{{ ora_version }}/OPatch
-        dest:                          /oracle/{{ db_sid | upper }}/{{ ora_version }}/OPatch.bck
+        src:                           "/oracle/{{ db_sid | upper }}/{{ ora_version }}/OPatch"
+        dest:                          "{{ tmp_directory }}/{{ db_sid | upper }}/{{ ora_version }}/OPatch.bck"
         remote_src:                    true
         mode:                          '0755'
       when:
@@ -623,33 +641,28 @@
 
     - name:                            "Oracle ASM: remove old OPatch"
       ansible.builtin.file:
-        path:                          /oracle/{{ db_sid | upper }}/{{ ora_version }}/OPatch
+        path:                          "/oracle/{{ db_sid | upper }}/{{ ora_version }}/OPatch"
         state:                         absent
       when:
         - not opatch_stat.stat.exists
 
-    - name:                            "Oracle ASM: copy OPatch"
-      # become:                              true
-      # become_user:                         "{{ oracle_user_name }}"
+    - name:                            "ORACLE ASM: copy OPatch from {{ target_media_location }}/SBP/OPATCH/OPatch to /oracle/{{ db_sid | upper }}/{{ ora_version }}"
       ansible.builtin.copy:
         src:                           "{{ target_media_location }}/SBP/OPATCH/OPatch"
-        dest:                          /oracle/{{ db_sid | upper }}/{{ ora_version }}
+        dest:                          "/oracle/{{ db_sid | upper }}/{{ ora_version }}"
         remote_src:                    true
-        mode:                          '0755'
+        mode:                          0755
         owner:                         oracle
         group:                         oinstall
 
-    - name:                            "Oracle ASM: copy MOPatch"
-      # become:                              true
-      # become_user:                         "{{ oracle_user_name }}"
+    - name:                            "ORACLE ASM: copy MOPatch from {{ mopatch_path }} to /oracle/{{ db_sid | upper }}/{{ ora_version }}"
       ansible.builtin.copy:
         src:                           "{{ mopatch_path }}"
         dest:                          /oracle/{{ db_sid | upper }}/{{ ora_version }}
         remote_src:                    true
-        mode:                          '0777'
+        mode:                          0777
         owner:                         oracle
         group:                         oinstall
-
 
     - name:                            "Oracle ASM: Pre Processing set permissions"
       ansible.builtin.file:
@@ -666,7 +679,7 @@
     - name:                            "Oracle ASM: Post Processing - SBP Patching"
       become:                          true
       become_user:                     "{{ oracle_user_name }}"
-      ansible.builtin.shell:           $IHRDBMS/MOPatch/mopatch.sh -v -s {{ oracle_sbp_patch }}
+      ansible.builtin.shell:           "env ORACLE_HOME=$IHRDBMS $IHRDBMS/MOPatch/mopatch.sh -v -s {{ oracle_sbp_patch }}"
       environment:
         DB_SID:                        "{{ db_sid }}"
         CV_ASSUME_DISTID:              OL7

--- a/deploy/ansible/roles-db/4.1.2-ora-asm-db-install/tasks/main.yaml
+++ b/deploy/ansible/roles-db/4.1.2-ora-asm-db-install/tasks/main.yaml
@@ -651,7 +651,7 @@
         src:                           "{{ target_media_location }}/SBP/OPATCH/OPatch"
         dest:                          "/oracle/{{ db_sid | upper }}/{{ ora_version }}"
         remote_src:                    true
-        mode:                          0755
+        mode:                          '0755'
         owner:                         oracle
         group:                         oinstall
 
@@ -660,7 +660,7 @@
         src:                           "{{ mopatch_path }}"
         dest:                          /oracle/{{ db_sid | upper }}/{{ ora_version }}
         remote_src:                    true
-        mode:                          0777
+        mode:                          '0777'
         owner:                         oracle
         group:                         oinstall
 

--- a/deploy/ansible/roles-os/1.3-repository/tasks/1.3.1-repositories-RedHat.yaml
+++ b/deploy/ansible/roles-os/1.3-repository/tasks/1.3.1-repositories-RedHat.yaml
@@ -22,10 +22,9 @@
     - repos_for_tier | length > 0
 
 - name:                                "1.3 Repos: Add the repositories {{ ansible_os_family }}"
-  ansible.builtin.dnf:
+  ansible.builtin.yum_repository:
     name:                              "{{ item.url }}"
     state:                             "{{ item.state }}"
-    disable_gpg_check:                 true
   loop:                                "{{ repos_for_tier }}"
   register:                            zypresult
   ignore_errors:                       true
@@ -34,6 +33,16 @@
   ansible.builtin.debug:
     var:                               zypresult
     verbosity:                         2
+
+- name:                                "1.3 Repos: Add the HA repositories for OracleLinux"
+  ansible.builtin.dnf:
+    enablerepo:                        ol8_UEKR7
+    disable_gpg_check:                 true
+  changed_when:                        false
+  when:
+    - distribution_id in ['oraclelinux8']
+    - node_tier == 'ha'
+
 
 - name:                                "1.3 Repos: Add the HA repositories for RHEL"
   ansible.builtin.dnf:

--- a/deploy/ansible/roles-os/1.3-repository/tasks/1.3.3-repositories-Oracle-ASM.yaml
+++ b/deploy/ansible/roles-os/1.3-repository/tasks/1.3.3-repositories-Oracle-ASM.yaml
@@ -1,0 +1,27 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Returns bom object
+- name:                                "Oracle ASM: Register BoM"
+  ansible.builtin.include_role:
+    name:                              roles-sap/3.3.1-bom-utility
+    tasks_from:                        bom-register
+  vars:
+    bom_name:                          "{{ bom_base_name }}"
+    task_prefix:                       "Oracle ASM: "
+    sa_enabled:                        true
+  when:
+                                       - bom is undefined
+
+- name:                                "Oracle ASM: Add the repositories"
+  become:                              true
+  become_user:                         root
+  ansible.builtin.yum:
+    name:                              "{{ target_media_location }}/download_basket/{{ item.archive }}"
+    state:                             "present"
+    disable_gpg_check:                 true
+  loop:                                "{{ bom.materials.media | flatten(levels=1) }}"
+  when:
+    - bom is defined
+    - ( item.type is defined       and (item.type | lower) == 'rpm' )
+    - ( item.archive is defined    and (item.archive | trim | length) > 0 )

--- a/deploy/ansible/roles-sap-os/2.5-sap-users/tasks/main.yaml
+++ b/deploy/ansible/roles-sap-os/2.5-sap-users/tasks/main.yaml
@@ -61,7 +61,8 @@
     - { group: 'racdba',    gid: '{{ racdba_gid }}'    }
     - { group: 'oinstall',  gid: '{{ oinstall_gid }}'  }
   when:
-    - node_tier == "oracle-asm"
+    - node_tier in ['oracle-asm', 'observer']
+    - platform == "ORACLE-ASM"
 
 - name:                                "2.5.1 SAP Users: - Create SAP Groups for Oracle ASM on observer"
   ansible.builtin.group:
@@ -138,5 +139,5 @@
   #   # TODO: add user for WebDisp Functionality
     # - { tier: 'WEB',         user: 'webadm',                   uid: '32002',            group: 'sapsys', home: '/home/webadm',                 comment: 'SAP WebDisp Admin' }
   when:
-    - node_tier == "oracle-asm" or node_tier == "observer"
+    - node_tier in ["oracle-asm", "observer"]
     - platform == "ORACLE-ASM"

--- a/deploy/ansible/roles-sap/5.1-dbload/templates/dbload-inifile-param.j2
+++ b/deploy/ansible/roles-sap/5.1-dbload/templates/dbload-inifile-param.j2
@@ -99,10 +99,9 @@ storageBasedCopy.abapSchemaPassword                                   = {{ main_
 storageBasedCopy.javaSchemaPassword                                   = {{ main_password }}
 storageBasedCopy.ora.swowner                                          = oracle
 
-SAPINST.CD.PACKAGE.CD1                                                = {{ target_media_location }}/EXPORT/DATA_UNITS/EXP1
-SAPINST.CD.PACKAGE.CD2                                                = {{ target_media_location }}/EXPORT/DATA_UNITS/EXP2
-SAPINST.CD.PACKAGE.CD3                                                = {{ target_media_location }}/EXPORT/DATA_UNITS/EXP3
-SAPINST.CD.PACKAGE.CD4                                                = {{ target_media_location }}/EXPORT/DATA_UNITS/EXP4
+SAPINST.CD.PACKAGE.CD1                                                = {{ target_media_location }}/CD_EXPORT/DATA_UNITS/EXP1
+SAPINST.CD.PACKAGE.CD2                                                = {{ target_media_location }}/CD_EXPORT/DATA_UNITS/EXP2
+SAPINST.CD.PACKAGE.CD3                                                = {{ target_media_location }}/CD_EXPORT/DATA_UNITS/EXP3
 
 {% endif %}
 
@@ -127,9 +126,9 @@ ora.whatIsSHOH                                                        = false
 storageBasedCopy.abapSchemaPassword                                   = {{ main_password }}
 storageBasedCopy.javaSchemaPassword                                   = {{ main_password }}
 storageBasedCopy.ora.swowner                                          = oracle
-SAPINST.CD.PACKAGE.CD1                                                = {{ target_media_location }}/EXPORT/DATA_UNITS/EXP1
-SAPINST.CD.PACKAGE.CD2                                                = {{ target_media_location }}/EXPORT/DATA_UNITS/EXP2
-SAPINST.CD.PACKAGE.CD3                                                = {{ target_media_location }}/EXPORT/DATA_UNITS/EXP3
+SAPINST.CD.PACKAGE.CD1                                                = {{ target_media_location }}/CD_EXPORT/DATA_UNITS/EXP1
+SAPINST.CD.PACKAGE.CD2                                                = {{ target_media_location }}/CD_EXPORT/DATA_UNITS/EXP2
+SAPINST.CD.PACKAGE.CD3                                                = {{ target_media_location }}/CD_EXPORT/DATA_UNITS/EXP3
 {% endif %}
 
 


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the Oracle ASM installation and configuration workflow in the Ansible playbooks and roles. The main focus is on standardizing naming conventions, improving clarity, fixing file creation logic, and enhancing the handling of disk lists and permissions for Oracle ASM. The changes also ensure proper privilege escalation for critical tasks and add missing steps for Oracle ASM setup.

**Oracle ASM Installation and Configuration Improvements**

* Standardized and clarified task names throughout the Oracle ASM-related playbooks and roles, making it easier to follow each step of the process. [[1]](diffhunk://#diff-a21ce6ed49a0a8b2c487a1a7fa33b66455d54e06766b8dc88dd6b82a7b2e86ebL22-R22) [[2]](diffhunk://#diff-a21ce6ed49a0a8b2c487a1a7fa33b66455d54e06766b8dc88dd6b82a7b2e86ebL36-R36) [[3]](diffhunk://#diff-a21ce6ed49a0a8b2c487a1a7fa33b66455d54e06766b8dc88dd6b82a7b2e86ebL47-R63) [[4]](diffhunk://#diff-a21ce6ed49a0a8b2c487a1a7fa33b66455d54e06766b8dc88dd6b82a7b2e86ebL80-R98) [[5]](diffhunk://#diff-a21ce6ed49a0a8b2c487a1a7fa33b66455d54e06766b8dc88dd6b82a7b2e86ebL111-R145) [[6]](diffhunk://#diff-a21ce6ed49a0a8b2c487a1a7fa33b66455d54e06766b8dc88dd6b82a7b2e86ebL158-R222) [[7]](diffhunk://#diff-a21ce6ed49a0a8b2c487a1a7fa33b66455d54e06766b8dc88dd6b82a7b2e86ebL256-R244) [[8]](diffhunk://#diff-a21ce6ed49a0a8b2c487a1a7fa33b66455d54e06766b8dc88dd6b82a7b2e86ebL274-R258)
* Improved handling and display of disk lists for Oracle ASM by splitting comma-separated lists into arrays and updating debug outputs for better readability. [[1]](diffhunk://#diff-a21ce6ed49a0a8b2c487a1a7fa33b66455d54e06766b8dc88dd6b82a7b2e86ebL111-R145) [[2]](diffhunk://#diff-a21ce6ed49a0a8b2c487a1a7fa33b66455d54e06766b8dc88dd6b82a7b2e86ebL158-R222)
* Corrected file creation logic by updating file names for tracking successful unzips and installations, preventing duplicate or missed status files. [[1]](diffhunk://#diff-a21ce6ed49a0a8b2c487a1a7fa33b66455d54e06766b8dc88dd6b82a7b2e86ebL158-R222) [[2]](diffhunk://#diff-a21ce6ed49a0a8b2c487a1a7fa33b66455d54e06766b8dc88dd6b82a7b2e86ebL256-R244)
* Ensured proper privilege escalation (`become: true`) for critical configuration steps, such as resetting root passwords, modifying SSH configuration, and restarting services, improving security and reliability. [[1]](diffhunk://#diff-e2f8b2a96f59697d30df5b3f8efdbf1fa9066f716609fd67db77bc1c8ce2a0f8L291-R303) [[2]](diffhunk://#diff-e2f8b2a96f59697d30df5b3f8efdbf1fa9066f716609fd67db77bc1c8ce2a0f8R322) [[3]](diffhunk://#diff-e2f8b2a96f59697d30df5b3f8efdbf1fa9066f716609fd67db77bc1c8ce2a0f8R331)
* Added missing Oracle ASM setup steps to the main database installation playbook, including repository registration, package installation, disk setup, kernel parameter configuration, user/group creation, and file system mounting, providing a more complete and automated workflow.

**General Playbook and Role Enhancements**

* Switched from `include_role` to `import_role` for certain tasks to ensure variables and tags are properly inherited and always available.
* Added a new task to create a temporary directory for Oracle installations, improving organization and preparation for subsequent steps.
* Updated Oracle SBP patching to set the `ORACLE_HOME` environment variable explicitly, ensuring patches are applied to the correct Oracle home.
* Minor formatting and tag improvements for clarity and maintainability. [[1]](diffhunk://#diff-e2f8b2a96f59697d30df5b3f8efdbf1fa9066f716609fd67db77bc1c8ce2a0f8L717-R767) [[2]](diffhunk://#diff-e2f8b2a96f59697d30df5b3f8efdbf1fa9066f716609fd67db77bc1c8ce2a0f8L672)

These changes collectively enhance the reliability, readability, and completeness of the Oracle ASM deployment process in the automation framework.…add temporary directory creation and debug messages for DB SID and Oracle version.

## Problem
<Please describe what problem this PR is trying to resolve>

## Solution
<Please elaborate the solution for the problem>

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>