### PR TITLE
fix: update version comparison for cloud-netconfig-azure in Pacemaker

### DIFF
--- a/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.2-provision.yml
+++ b/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.2-provision.yml
@@ -24,7 +24,7 @@
     - name:                            "1.17 Generic Pacemaker - Ensure that network interface is not managed by cloud network plugin"
       when:
                                        - ansible_facts.packages['cloud-netconfig-azure']
-                                       - (ansible_facts.packages['cloud-netconfig-azure'][0].version | float) < 1.3
+                                       - ansible_facts.packages['cloud-netconfig-azure'][0].version is version('1.3', '<')
       become:                          true
       ansible.builtin.lineinfile:
         path:                          /etc/sysconfig/network/ifcfg-eth0

--- a/deploy/ansible/roles-os/1.18-scaleout-pacemaker/tasks/1.18.2.0-cluster-Suse.yml
+++ b/deploy/ansible/roles-os/1.18-scaleout-pacemaker/tasks/1.18.2.0-cluster-Suse.yml
@@ -47,7 +47,7 @@
     line:                              "CLOUD_NETCONFIG_MANAGE='no'"
   when:
                                        - ansible_facts.packages['cloud-netconfig-azure']
-                                       - (ansible_facts.packages['cloud-netconfig-azure'][0].version | float) < 1.3
+                                       - ansible_facts.packages['cloud-netconfig-azure'][0].version is version('1.3', '<')
                                        - node_tier == 'hana'
 
 - name:                                "1.18.2.0 Generic Pacemaker - Ensure Primary node initiates the Cluster"


### PR DESCRIPTION
This pull request updates the version comparison logic for the `cloud-netconfig-azure` package in Ansible playbooks to use the more robust `version` test instead of converting the version to a float. This change improves accuracy and reliability when checking package versions.

**Ansible playbook improvements:**

* Updated the version check for `cloud-netconfig-azure` in `1.17-generic-pacemaker` to use the `version` test for better reliability.
* Updated the version check for `cloud-netconfig-azure` in `1.18-scaleout-pacemaker` to use the `version` test for better reliability.