### PR TITLE
Enhancement: NVMe disk setup and detection logic

### DIFF
--- a/deploy/ansible/roles-os/1.5-disk-setup/files/88-azure-nvme-data-disk.rules
+++ b/deploy/ansible/roles-os/1.5-disk-setup/files/88-azure-nvme-data-disk.rules
@@ -4,32 +4,30 @@
 
 # Section 1: NVMe drives
 # Azure rules for NVMe drives
-# will create links in /dev/disk/azure/data/by-lun with LUN IDs for data disks
+# Will create links in /dev/disk/azure/data/by-lun with LUN IDs for data disks
 ACTION!="add|change", GOTO="azure_nvme_end"
 SUBSYSTEM!="block", GOTO="azure_nvme_end"
 KERNEL!="nvme*", GOTO="azure_nvme_end"
 
-# Hardware-based device identification (LVM-immune)
-# Uses hardware attributes that cannot be modified by LVM processing
-ATTRS{model}=="MSFT NVMe Accelerator v1.0*", ATTRS{vendor}=="0x1414", GOTO="azure_nvme_remote_start"
+# Hardware-based identification (LVM-immune)
+# Uses ATTRS{model} only - combining with vendor causes matching failure
+ATTRS{model}=="MSFT NVMe Accelerator v1.0*", GOTO="azure_nvme_remote_start"
 
 GOTO="azure_nvme_end"
 
 LABEL="azure_nvme_remote_start"
-# create os disk symlink (namespace 1)
+# OS disk symlinks (namespace 1)
 KERNEL=="nvme*[0-9]n1", ENV{DEVTYPE}=="disk", SYMLINK+="disk/azure/root", GOTO="azure_udev_end"
-# create os disk symlink partitions
 KERNEL=="nvme*[0-9]n1p[0-9]", ENV{DEVTYPE}=="partition", SYMLINK+="disk/azure/root-part%n", GOTO="azure_udev_end"
 
-# create SYMLINKs for NVMe data disks (namespace 2+)
-# Hardware-based approach using $attr{nsid} for LUN calculation
+# Data disk symlinks (namespace 2+)
+# Uses $attr{nsid} instead of $env{ID_NSID} - hardware attribute is LVM-immune
 KERNEL=="nvme*[0-9]n*[0-9]", ENV{DEVTYPE}=="disk", ATTR{nsid}=="?*", ATTR{nsid}!="1", \
     PROGRAM="/usr/local/bin/azure-nvme-lun-calc %k $attr{nsid}", \
     RESULT=="?*", \
     SYMLINK+="disk/azure/data/by-lun/%c", GOTO="azure_udev_end"
 
-# create SYMLINKs for NVMe data disk partitions
-# Hardware-based approach for partitions
+# Data disk partition symlinks
 KERNEL=="nvme*[0-9]n*[0-9]p[0-9]", ENV{DEVTYPE}=="partition", ATTR{nsid}=="?*", ATTR{nsid}!="1", \
     PROGRAM="/usr/local/bin/azure-nvme-lun-calc %k $attr{nsid}", \
     RESULT=="?*", \
@@ -39,38 +37,34 @@ GOTO="azure_udev_end"
 
 LABEL="azure_nvme_end"
 
-# Section 2: SCSI drives - Enhanced for LVM compatibility
+# Section 2: SCSI drives
 ACTION!="add|change", GOTO="azure_udev_end"
 SUBSYSTEM!="block", GOTO="azure_udev_end"
 
-# Hardware-based SCSI device identification (LVM-immune)
-# Uses hardware attributes that remain constant regardless of LVM processing
+# SCSI device identification
 ATTRS{ID_VENDOR}=="Msft", ATTRS{ID_MODEL}=="Virtual_Disk", GOTO="azure_scsi_check"
 
 GOTO="azure_udev_end"
 
 LABEL="azure_scsi_check"
-# Match the known ID parts for root and resource disks.
+# Match root and resource disks
 ATTRS{device_id}=="?00000000-0000-*", ENV{fabric_name}="root", GOTO="azure_udev_end"
 ATTRS{device_id}=="?00000000-0001-*", ENV{fabric_name}="resource", GOTO="azure_udev_end"
 
-# Gen2 disk.
+# Gen2 disk controllers
 ATTRS{device_id}=="{f8b3781a-1e82-4818-a1c3-63d806ec15bb}", ENV{fabric_scsi_controller}="scsi0", GOTO="azure_datadisk"
-# Create symlinks for data disks attached.
 ATTRS{device_id}=="{f8b3781b-1e82-4818-a1c3-63d806ec15bb}", ENV{fabric_scsi_controller}="scsi1", GOTO="azure_datadisk"
 ATTRS{device_id}=="{f8b3781c-1e82-4818-a1c3-63d806ec15bb}", ENV{fabric_scsi_controller}="scsi2", GOTO="azure_datadisk"
 ATTRS{device_id}=="{f8b3781d-1e82-4818-a1c3-63d806ec15bb}", ENV{fabric_scsi_controller}="scsi3", GOTO="azure_datadisk"
 GOTO="azure_udev_end"
 
-# Parse out the fabric name based off of scsi indicators.
 LABEL="azure_datadisk"
 ENV{DEVTYPE}=="partition", PROGRAM="/bin/sh -c 'readlink /sys/class/block/%k/../device|cut -d: -f4'", ENV{fabric_name}="data/by-lun/$result"
 ENV{DEVTYPE}=="disk", PROGRAM="/bin/sh -c 'readlink /sys/class/block/%k/device|cut -d: -f4'", ENV{fabric_name}="data/by-lun/$result"
 
-# Do not create /dev/disk/azure/data for scsi0 devices which are osdisk and resource disk
+# Exclude scsi0 devices (OS and resource disks)
 ENV{fabric_scsi_controller}=="scsi0", GOTO="azure_udev_end"
 
-# Create the symlinks.
 LABEL="wa_azure_names"
 ENV{DEVTYPE}=="disk", SYMLINK+="disk/azure/$env{fabric_name}"
 ENV{DEVTYPE}=="partition", SYMLINK+="disk/azure/$env{fabric_name}-part%n"

--- a/deploy/ansible/roles-os/1.5-disk-setup/files/88-azure-nvme-data-disk.rules
+++ b/deploy/ansible/roles-os/1.5-disk-setup/files/88-azure-nvme-data-disk.rules
@@ -9,49 +9,39 @@ ACTION!="add|change", GOTO="azure_nvme_end"
 SUBSYSTEM!="block", GOTO="azure_nvme_end"
 KERNEL!="nvme*", GOTO="azure_nvme_end"
 
-# Hardware-based identification (LVM-immune)
-# Uses ATTRS{model} only - combining with vendor causes matching failure
 ATTRS{model}=="MSFT NVMe Accelerator v1.0*", GOTO="azure_nvme_remote_start"
-
 GOTO="azure_nvme_end"
 
 LABEL="azure_nvme_remote_start"
-# OS disk symlinks (namespace 1)
-KERNEL=="nvme*[0-9]n1", ENV{DEVTYPE}=="disk", SYMLINK+="disk/azure/root", GOTO="azure_udev_end"
-KERNEL=="nvme*[0-9]n1p[0-9]", ENV{DEVTYPE}=="partition", SYMLINK+="disk/azure/root-part%n", GOTO="azure_udev_end"
+# OS disk - match by NSID=1, not device name
+KERNEL=="nvme*[0-9]n*[0-9]", ENV{DEVTYPE}=="disk", ATTR{nsid}=="1", \
+    SYMLINK+="disk/azure/root", GOTO="azure_udev_end"
+KERNEL=="nvme*[0-9]n*[0-9]p[0-9]", ENV{DEVTYPE}=="partition", ATTR{nsid}=="1", \
+    SYMLINK+="disk/azure/root-part%n", GOTO="azure_udev_end"
 
-# Data disk symlinks (namespace 2+)
-# Uses $attr{nsid} instead of $env{ID_NSID} - hardware attribute is LVM-immune
+# Data disks - NSID 2+
 KERNEL=="nvme*[0-9]n*[0-9]", ENV{DEVTYPE}=="disk", ATTR{nsid}=="?*", ATTR{nsid}!="1", \
     PROGRAM="/usr/local/bin/azure-nvme-lun-calc %k $attr{nsid}", \
     RESULT=="?*", \
     SYMLINK+="disk/azure/data/by-lun/%c", GOTO="azure_udev_end"
 
-# Data disk partition symlinks
 KERNEL=="nvme*[0-9]n*[0-9]p[0-9]", ENV{DEVTYPE}=="partition", ATTR{nsid}=="?*", ATTR{nsid}!="1", \
     PROGRAM="/usr/local/bin/azure-nvme-lun-calc %k $attr{nsid}", \
     RESULT=="?*", \
     SYMLINK+="disk/azure/data/by-lun/%c-part%n", GOTO="azure_udev_end"
 
 GOTO="azure_udev_end"
-
 LABEL="azure_nvme_end"
 
-# Section 2: SCSI drives
+# SCSI section unchanged...
 ACTION!="add|change", GOTO="azure_udev_end"
 SUBSYSTEM!="block", GOTO="azure_udev_end"
-
-# SCSI device identification
 ATTRS{ID_VENDOR}=="Msft", ATTRS{ID_MODEL}=="Virtual_Disk", GOTO="azure_scsi_check"
-
 GOTO="azure_udev_end"
 
 LABEL="azure_scsi_check"
-# Match root and resource disks
 ATTRS{device_id}=="?00000000-0000-*", ENV{fabric_name}="root", GOTO="azure_udev_end"
 ATTRS{device_id}=="?00000000-0001-*", ENV{fabric_name}="resource", GOTO="azure_udev_end"
-
-# Gen2 disk controllers
 ATTRS{device_id}=="{f8b3781a-1e82-4818-a1c3-63d806ec15bb}", ENV{fabric_scsi_controller}="scsi0", GOTO="azure_datadisk"
 ATTRS{device_id}=="{f8b3781b-1e82-4818-a1c3-63d806ec15bb}", ENV{fabric_scsi_controller}="scsi1", GOTO="azure_datadisk"
 ATTRS{device_id}=="{f8b3781c-1e82-4818-a1c3-63d806ec15bb}", ENV{fabric_scsi_controller}="scsi2", GOTO="azure_datadisk"
@@ -61,8 +51,6 @@ GOTO="azure_udev_end"
 LABEL="azure_datadisk"
 ENV{DEVTYPE}=="partition", PROGRAM="/bin/sh -c 'readlink /sys/class/block/%k/../device|cut -d: -f4'", ENV{fabric_name}="data/by-lun/$result"
 ENV{DEVTYPE}=="disk", PROGRAM="/bin/sh -c 'readlink /sys/class/block/%k/device|cut -d: -f4'", ENV{fabric_name}="data/by-lun/$result"
-
-# Exclude scsi0 devices (OS and resource disks)
 ENV{fabric_scsi_controller}=="scsi0", GOTO="azure_udev_end"
 
 LABEL="wa_azure_names"

--- a/deploy/ansible/roles-os/1.5-disk-setup/files/88-azure-nvme-data-disk.rules
+++ b/deploy/ansible/roles-os/1.5-disk-setup/files/88-azure-nvme-data-disk.rules
@@ -1,14 +1,16 @@
 # Azure specific udev rules
-# Handles devices processed by LVM that modify ID_MODEL and ID_SERIAL property
+# Uses hardware attributes instead of environment variables for resiliency
 # Uses external azure-nvme-lun-calc script for namespace detection
 
 # Section 1: NVMe drives
+# Azure rules for NVMe drives
+# will create links in /dev/disk/azure/data/by-lun with LUN IDs for data disks
 ACTION!="add|change", GOTO="azure_nvme_end"
 SUBSYSTEM!="block", GOTO="azure_nvme_end"
 KERNEL!="nvme*", GOTO="azure_nvme_end"
 
-# Identify Azure NVMe devices using hardware attributes
-# vendor can be found using lspci -nn
+# Hardware-based device identification (LVM-immune)
+# Uses hardware attributes that cannot be modified by LVM processing
 ATTRS{model}=="MSFT NVMe Accelerator v1.0*", ATTRS{vendor}=="0x1414", GOTO="azure_nvme_remote_start"
 
 GOTO="azure_nvme_end"
@@ -19,14 +21,16 @@ KERNEL=="nvme*[0-9]n1", ENV{DEVTYPE}=="disk", SYMLINK+="disk/azure/root", GOTO="
 # create os disk symlink partitions
 KERNEL=="nvme*[0-9]n1p[0-9]", ENV{DEVTYPE}=="partition", SYMLINK+="disk/azure/root-part%n", GOTO="azure_udev_end"
 
-# create SYMLINKs for NVMe data disks using direct NSID from hardware
-KERNEL=="nvme*[0-9]n*[0-9]", ENV{DEVTYPE}=="disk", ATTR{nsid}=="?*", \
+# create SYMLINKs for NVMe data disks (namespace 2+)
+# Hardware-based approach using $attr{nsid} for LUN calculation
+KERNEL=="nvme*[0-9]n*[0-9]", ENV{DEVTYPE}=="disk", ATTR{nsid}=="?*", ATTR{nsid}!="1", \
     PROGRAM="/usr/local/bin/azure-nvme-lun-calc %k $attr{nsid}", \
     RESULT=="?*", \
     SYMLINK+="disk/azure/data/by-lun/%c", GOTO="azure_udev_end"
 
 # create SYMLINKs for NVMe data disk partitions
-KERNEL=="nvme*[0-9]n*[0-9]p[0-9]", ENV{DEVTYPE}=="partition", ATTR{nsid}=="?*", \
+# Hardware-based approach for partitions
+KERNEL=="nvme*[0-9]n*[0-9]p[0-9]", ENV{DEVTYPE}=="partition", ATTR{nsid}=="?*", ATTR{nsid}!="1", \
     PROGRAM="/usr/local/bin/azure-nvme-lun-calc %k $attr{nsid}", \
     RESULT=="?*", \
     SYMLINK+="disk/azure/data/by-lun/%c-part%n", GOTO="azure_udev_end"
@@ -39,11 +43,9 @@ LABEL="azure_nvme_end"
 ACTION!="add|change", GOTO="azure_udev_end"
 SUBSYSTEM!="block", GOTO="azure_udev_end"
 
-# Multi-method SCSI device identification
-# Method 1: Original attributes (for unprocessed devices)
+# Hardware-based SCSI device identification (LVM-immune)
+# Uses hardware attributes that remain constant regardless of LVM processing
 ATTRS{ID_VENDOR}=="Msft", ATTRS{ID_MODEL}=="Virtual_Disk", GOTO="azure_scsi_check"
-# Method 2: Serial pattern matching (for LVM-processed devices)
-ENV{ID_SERIAL}=="*Msft*Virtual_Disk*", GOTO="azure_scsi_check"
 
 GOTO="azure_udev_end"
 

--- a/deploy/ansible/roles-os/1.5-disk-setup/files/88-azure-nvme-data-disk.rules
+++ b/deploy/ansible/roles-os/1.5-disk-setup/files/88-azure-nvme-data-disk.rules
@@ -1,5 +1,6 @@
-# Azure specific udev rules - Enhanced for compatibility
-# Handles missing ID_NSID in older distributions (e.g., SLES 15 SP3)
+# Azure specific udev rules
+# Handles devices processed by LVM that modify ID_MODEL property
+# Uses external azure-nvme-lun-calc script for namespace detection
 
 # Section 1: NVMe drives
 # Azure rules for NVMe drives
@@ -7,37 +8,57 @@
 ACTION!="add|change", GOTO="azure_nvme_end"
 SUBSYSTEM!="block", GOTO="azure_nvme_end"
 KERNEL!="nvme*", GOTO="azure_nvme_end"
+
+# Multi-method device identification for compatibility
+# Method 1: Uses ID_MODEL (works for unprocessed devices)
 ENV{ID_MODEL}=="MSFT NVMe Accelerator v1.0", GOTO="azure_nvme_remote_start"
+# Method 2: ID_SERIAL pattern matching (works after LVM processing)
+ENV{ID_SERIAL}=="*MSFT NVMe Accelerator v1.0*", GOTO="azure_nvme_remote_start"
+
+GOTO="azure_nvme_end"
 
 LABEL="azure_nvme_remote_start"
 # create os disk symlink (namespace 1)
-KERNEL=="nvme*[0-9]n1", ENV{DEVTYPE}=="disk", ENV{ID_MODEL}=="MSFT NVMe Accelerator v1.0", SYMLINK+="disk/azure/root", GOTO="azure_udev_end"
+KERNEL=="nvme*[0-9]n1", ENV{DEVTYPE}=="disk", SYMLINK+="disk/azure/root", GOTO="azure_udev_end"
 # create os disk symlink partitions
-KERNEL=="nvme*[0-9]n1p[0-9]", ENV{DEVTYPE}=="partition", ENV{ID_MODEL}=="MSFT NVMe Accelerator v1.0", SYMLINK+="disk/azure/root-part%n", GOTO="azure_udev_end"
+KERNEL=="nvme*[0-9]n1p[0-9]", ENV{DEVTYPE}=="partition", SYMLINK+="disk/azure/root-part%n", GOTO="azure_udev_end"
 
 # create SYMLINKs for NVMe data disks (namespace 2+)
 # Enhanced version that handles missing ID_NSID by passing device name and ID_PATH as fallback
-KERNEL=="nvme*[0-9]n*[0-9]", ENV{DEVTYPE}=="disk", ENV{ID_MODEL}=="MSFT NVMe Accelerator v1.0", ENV{ID_SERIAL_SHORT}=="?*", \
-    OPTIONS="string_escape=replace", ENV{ID_SERIAL}="$env{ID_MODEL}_$env{ID_SERIAL_SHORT}_$env{ID_NSID}", \
+# Removed redundant ID_MODEL check for LVM compatibility
+KERNEL=="nvme*[0-9]n*[0-9]", ENV{DEVTYPE}=="disk", ENV{ID_SERIAL_SHORT}=="?*", \
+    OPTIONS="string_escape=replace", \
+    ENV{ID_SERIAL}="$env{ID_MODEL}_$env{ID_SERIAL_SHORT}_$env{ID_NSID}", \
     PROGRAM="/usr/local/bin/azure-nvme-lun-calc %k $env{ID_NSID} $env{ID_PATH}", \
+    RESULT=="?*", \
     SYMLINK+="disk/azure/data/by-lun/%c", GOTO="azure_udev_end"
 
 # create SYMLINKs for NVMe data disk partitions
-KERNEL=="nvme*[0-9]n*[0-9]p[0-9]", ENV{DEVTYPE}=="partition", ENV{ID_MODEL}=="MSFT NVMe Accelerator v1.0", ENV{ID_SERIAL_SHORT}=="?*", \
-    OPTIONS="string_escape=replace", ENV{ID_SERIAL}="$env{ID_MODEL}_$env{ID_SERIAL_SHORT}_$env{ID_NSID}", \
+# Enhanced version for LVM compatibility
+KERNEL=="nvme*[0-9]n*[0-9]p[0-9]", ENV{DEVTYPE}=="partition", ENV{ID_SERIAL_SHORT}=="?*", \
+    OPTIONS="string_escape=replace", \
+    ENV{ID_SERIAL}="$env{ID_MODEL}_$env{ID_SERIAL_SHORT}_$env{ID_NSID}", \
     PROGRAM="/usr/local/bin/azure-nvme-lun-calc %k $env{ID_NSID} $env{ID_PATH}", \
+    RESULT=="?*", \
     SYMLINK+="disk/azure/data/by-lun/%c-part%n", GOTO="azure_udev_end"
 
 GOTO="azure_udev_end"
 
 LABEL="azure_nvme_end"
 
-# Section 2: SCSI drives (unchanged)
+# Section 2: SCSI drives - Enhanced for LVM compatibility
 ACTION!="add|change", GOTO="azure_udev_end"
 SUBSYSTEM!="block", GOTO="azure_udev_end"
-ATTRS{ID_VENDOR}!="Msft", GOTO="azure_udev_end"
-ATTRS{ID_MODEL}!="Virtual_Disk", GOTO="azure_udev_end"
 
+# Multi-method SCSI device identification
+# Method 1: Original attributes (for unprocessed devices)
+ATTRS{ID_VENDOR}=="Msft", ATTRS{ID_MODEL}=="Virtual_Disk", GOTO="azure_scsi_check"
+# Method 2: Serial pattern matching (for LVM-processed devices)
+ENV{ID_SERIAL}=="*Msft*Virtual_Disk*", GOTO="azure_scsi_check"
+
+GOTO="azure_udev_end"
+
+LABEL="azure_scsi_check"
 # Match the known ID parts for root and resource disks.
 ATTRS{device_id}=="?00000000-0000-*", ENV{fabric_name}="root", GOTO="azure_udev_end"
 ATTRS{device_id}=="?00000000-0001-*", ENV{fabric_name}="resource", GOTO="azure_udev_end"

--- a/deploy/ansible/roles-os/1.5-disk-setup/files/88-azure-nvme-data-disk.rules
+++ b/deploy/ansible/roles-os/1.5-disk-setup/files/88-azure-nvme-data-disk.rules
@@ -1,19 +1,15 @@
 # Azure specific udev rules
-# Handles devices processed by LVM that modify ID_MODEL property
+# Handles devices processed by LVM that modify ID_MODEL and ID_SERIAL property
 # Uses external azure-nvme-lun-calc script for namespace detection
 
 # Section 1: NVMe drives
-# Azure rules for NVMe drives
-# will create links in /dev/disk/azure/data/by-lun with LUN IDs for data disks
 ACTION!="add|change", GOTO="azure_nvme_end"
 SUBSYSTEM!="block", GOTO="azure_nvme_end"
 KERNEL!="nvme*", GOTO="azure_nvme_end"
 
-# Multi-method device identification for compatibility
-# Method 1: Uses ID_MODEL (works for unprocessed devices)
-ENV{ID_MODEL}=="MSFT NVMe Accelerator v1.0", GOTO="azure_nvme_remote_start"
-# Method 2: ID_SERIAL pattern matching (works after LVM processing)
-ENV{ID_SERIAL}=="*MSFT NVMe Accelerator v1.0*", GOTO="azure_nvme_remote_start"
+# Identify Azure NVMe devices using hardware attributes
+# vendor can be found using lspci -nn
+ATTRS{model}=="MSFT NVMe Accelerator v1.0*", ATTRS{vendor}=="0x1414", GOTO="azure_nvme_remote_start"
 
 GOTO="azure_nvme_end"
 
@@ -23,22 +19,15 @@ KERNEL=="nvme*[0-9]n1", ENV{DEVTYPE}=="disk", SYMLINK+="disk/azure/root", GOTO="
 # create os disk symlink partitions
 KERNEL=="nvme*[0-9]n1p[0-9]", ENV{DEVTYPE}=="partition", SYMLINK+="disk/azure/root-part%n", GOTO="azure_udev_end"
 
-# create SYMLINKs for NVMe data disks (namespace 2+)
-# Enhanced version that handles missing ID_NSID by passing device name and ID_PATH as fallback
-# Removed redundant ID_MODEL check for LVM compatibility
-KERNEL=="nvme*[0-9]n*[0-9]", ENV{DEVTYPE}=="disk", ENV{ID_SERIAL_SHORT}=="?*", \
-    OPTIONS="string_escape=replace", \
-    ENV{ID_SERIAL}="$env{ID_MODEL}_$env{ID_SERIAL_SHORT}_$env{ID_NSID}", \
-    PROGRAM="/usr/local/bin/azure-nvme-lun-calc %k $env{ID_NSID} $env{ID_PATH}", \
+# create SYMLINKs for NVMe data disks using direct NSID from hardware
+KERNEL=="nvme*[0-9]n*[0-9]", ENV{DEVTYPE}=="disk", ATTR{nsid}=="?*", \
+    PROGRAM="/usr/local/bin/azure-nvme-lun-calc %k $attr{nsid}", \
     RESULT=="?*", \
     SYMLINK+="disk/azure/data/by-lun/%c", GOTO="azure_udev_end"
 
 # create SYMLINKs for NVMe data disk partitions
-# Enhanced version for LVM compatibility
-KERNEL=="nvme*[0-9]n*[0-9]p[0-9]", ENV{DEVTYPE}=="partition", ENV{ID_SERIAL_SHORT}=="?*", \
-    OPTIONS="string_escape=replace", \
-    ENV{ID_SERIAL}="$env{ID_MODEL}_$env{ID_SERIAL_SHORT}_$env{ID_NSID}", \
-    PROGRAM="/usr/local/bin/azure-nvme-lun-calc %k $env{ID_NSID} $env{ID_PATH}", \
+KERNEL=="nvme*[0-9]n*[0-9]p[0-9]", ENV{DEVTYPE}=="partition", ATTR{nsid}=="?*", \
+    PROGRAM="/usr/local/bin/azure-nvme-lun-calc %k $attr{nsid}", \
     RESULT=="?*", \
     SYMLINK+="disk/azure/data/by-lun/%c-part%n", GOTO="azure_udev_end"
 

--- a/deploy/ansible/roles-os/1.5-disk-setup/files/88-azure-nvme-lun-calc
+++ b/deploy/ansible/roles-os/1.5-disk-setup/files/88-azure-nvme-lun-calc
@@ -1,77 +1,35 @@
 #!/bin/bash
 # Azure NVMe LUN calculator
-# Handles missing ID_NSID environment variable in older distributions
+# Direct hardware attribute approach
 #
-# Usage: azure-nvme-lun-calc <device_name> [id_nsid] [id_path]
+# Usage: azure-nvme-lun-calc <device_name> <nsid>
 #
 # Parameters:
 # $1 - Device name (e.g., nvme0n2)
-# $2 - ID_NSID (optional, may be empty on older distributions)
-# $3 - ID_PATH (optional, fallback source for namespace ID)
+# $2 - Namespace ID (NSID) from hardware attribute
 
 DEVICE_NAME="$1"
-ID_NSID="$2"
-ID_PATH="$3"
+NSID="$2"
 
-# Function to extract namespace ID from device name
-extract_nsid_from_device() {
-    local device="$1"
-    # Extract number after 'n' in device name (e.g., nvme0n2 -> 2)
-    echo "$device" | sed -n 's/.*nvme[0-9]*n\([0-9]*\).*/\1/p'
-}
-
-# Function to extract namespace ID from ID_PATH
-extract_nsid_from_path() {
-    local path="$1"
-    # Extract number after 'nvme-' in path (e.g., nvme-2 -> 2)
-    echo "$path" | sed -n 's/.*nvme-\([0-9]*\).*/\1/p'
-}
-
-# Function to get namespace ID from sysfs
-get_nsid_from_sysfs() {
-    local device="$1"
-    local nsid_file="/sys/class/block/$device/nsid"
-
-    if [ -r "$nsid_file" ]; then
-        cat "$nsid_file" 2>/dev/null
-    fi
-}
-
-# Determine namespace ID using multiple methods
-NSID=""
-
-# Method 1: Use provided ID_NSID if available and valid
-if [ -n "$ID_NSID" ] && [ "$ID_NSID" -gt 0 ] 2>/dev/null; then
-    NSID="$ID_NSID"
-
-# Method 2: Extract from sysfs (most reliable)
-elif [ -n "$DEVICE_NAME" ]; then
-    NSID=$(get_nsid_from_sysfs "$DEVICE_NAME")
-
-# Method 3: Extract from device name
-elif [ -n "$DEVICE_NAME" ]; then
-    NSID=$(extract_nsid_from_device "$DEVICE_NAME")
-
-# Method 4: Extract from ID_PATH as fallback
-elif [ -n "$ID_PATH" ]; then
-    NSID=$(extract_nsid_from_path "$ID_PATH")
+# Validate input parameters
+if [ -z "$DEVICE_NAME" ]; then
+    echo "ERROR: Device name is required" >&2
+    exit 1
 fi
 
-# Validate NSID and calculate LUN ID
-if [ -n "$NSID" ] && [ "$NSID" -gt 0 ] 2>/dev/null; then
-    # Azure NVMe namespace mapping: NSID 1 = OS disk, NSID 2+ = data disks
-    # LUN ID = NSID - 2 (first data disk NSID 2 maps to LUN 0)
-    LUN_ID=$((NSID - 2))
+if [ -z "$NSID" ] || [ "$NSID" -lt 1 ] 2>/dev/null; then
+    echo "ERROR: Valid NSID is required (got: '$NSID')" >&2
+    exit 1
+fi
 
-    # Ensure LUN ID is not negative (for OS disk or invalid cases)
-    if [ "$LUN_ID" -ge 0 ]; then
-        echo "$LUN_ID"
-    else
-        # OS disk or invalid case - don't create data disk symlink
-        exit 1
-    fi
+# Azure NVMe namespace mapping: NSID 1 = OS disk, NSID 2+ = data disks
+# LUN ID = NSID - 2 (first data disk NSID 2 maps to LUN 0)
+LUN_ID=$((NSID - 2))
+
+# Ensure LUN ID is not negative (for OS disk or invalid cases)
+if [ "$LUN_ID" -ge 0 ]; then
+    echo "$LUN_ID"
 else
-    # Could not determine namespace ID
-    echo "ERROR: Could not determine namespace ID for device $DEVICE_NAME" >&2
+    # OS disk (NSID 1) or invalid case - don't create data disk symlink
     exit 1
 fi

--- a/deploy/ansible/roles-os/1.5-disk-setup/tasks/1.5-nvme-preflight-rhel.yml
+++ b/deploy/ansible/roles-os/1.5-disk-setup/tasks/1.5-nvme-preflight-rhel.yml
@@ -276,11 +276,18 @@
                                        - helper_script_created.changed or udev_rules_added.changed
                                        - use_nvme_disks | default(false) | bool
   ansible.builtin.shell: |
-                                       # Trigger all NVMe devices except the OS disk (nvme0n1)
-                                       for device in /dev/nvme0n[2-9] /dev/nvme0n1[0-9] /dev/nvme0n2[0-9]; do
+                                       # Trigger all NVMe devices except the OS disk (identified by namespace ID 1)
+                                       for device in /dev/nvme*n*; do
                                          if [ -b "$device" ]; then
                                            DEVICE_NAME=$(basename "$device")
-                                           udevadm trigger --name-match="$DEVICE_NAME"
+                                           # Get namespace ID from sysfs
+                                           if [ -f "/sys/class/block/$DEVICE_NAME/nsid" ]; then
+                                             NSID=$(cat "/sys/class/block/$DEVICE_NAME/nsid")
+                                             # Skip namespace 1 (OS disk)
+                                             if [ "$NSID" != "1" ]; then
+                                               udevadm trigger --name-match="$DEVICE_NAME"
+                                             fi
+                                           fi
                                          fi
                                        done
   changed_when:                        true

--- a/deploy/ansible/roles-os/1.5-disk-setup/tasks/1.5-nvme-preflight-rhel.yml
+++ b/deploy/ansible/roles-os/1.5-disk-setup/tasks/1.5-nvme-preflight-rhel.yml
@@ -68,7 +68,7 @@
                                        for MODULE in $REQUIRED_MODULES; do
                                          # Temporarily disable pipefail for this check since lsinitrd may have warnings
                                          set +o pipefail
-                                         if ! lsinitrd /boot/initrd-$(uname -r) 2>/dev/null | grep -q "${MODULE}\.ko"; then
+                                         if ! lsinitrd /boot/initramfs-$(uname -r).img 2>/dev/null | grep -q "${MODULE}\.ko"; then
                                            MISSING_MODULES="$MISSING_MODULES $MODULE"
                                            MISSING=1
                                          fi
@@ -229,16 +229,15 @@
 - name:                                "1.5.4 NVMe Support (RHEL/OL) - Report GRUB status"
   ansible.builtin.debug:
     msg:                               "{{ grub_verify.stdout if grub_updated | default(false) else 'No GRUB changes needed - NVMe timeout already configured' }}"
-    verbosity:                         1
 
 # Rebuild initramfs if needed
-- name:                                "1.5.4 NVMe Support (RHEL) - Rebuild initramfs with dracut"
+- name:                                "1.5.4 NVMe Support (RHEL/OL) - Rebuild initramfs with dracut"
   when:                                dracut_conf_added.changed
   ansible.builtin.command:             dracut -f -v
   register:                            initramfs_rebuilt
 
 # Install udev rules for Azure NVMe disks
-- name:                                "1.5.4 NVMe Support (SUSE) - Create Azure NVMe LUN calculation helper script"
+- name:                                "1.5.4 NVMe Support (RHEL/OL) - Create Azure NVMe LUN calculation helper script"
   ansible.builtin.copy:
     src:                               88-azure-nvme-lun-calc
     dest:                              /usr/local/bin/azure-nvme-lun-calc
@@ -248,7 +247,7 @@
     force:                             true
   register:                            helper_script_created
 
-- name:                                "1.5.4 NVMe Support (RHEL) - Install udev rules for Azure NVMe disks"
+- name:                                "1.5.4 NVMe Support (RHEL/OL) - Install udev rules for Azure NVMe disks"
   ansible.builtin.copy:
     src:                               88-azure-nvme-data-disk.rules
     dest:                              /usr/lib/udev/rules.d/88-azure-data-disk.rules
@@ -257,18 +256,67 @@
     force:                             true
     mode:                              '0644'
   register:                            udev_rules_added
+  changed_when:                        true
 
-- name:                                "1.5.4 NVMe Support (RHEL) - Reload udev rules"
-  when:                                udev_rules_added.changed
+- name:                                "1.5.4 NVMe Support (RHEL/OL) - Reload udev rules"
+  when:                                helper_script_created.changed or udev_rules_added.changed
   ansible.builtin.command:             udevadm control --reload-rules
+  changed_when:                        true
   register:                            udev_rules_reloaded
 
-- name:                                "1.5.4 NVMe Support (RHEL) - Trigger udev rules for existing devices"
-  when:                                udev_rules_added.changed
-  ansible.builtin.command:             udevadm trigger
+- name:                                "1.5.4 NVMe Support (RHEL/OL) - Trigger udev rules for NVMe data devices"
+  when:
+                                       - helper_script_created.changed or udev_rules_added.changed
+                                       - use_nvme_disks | default(false) | bool
+  ansible.builtin.shell: |
+                                       # Trigger all NVMe devices except the OS disk (nvme0n1)
+                                       for device in /dev/nvme0n[2-9] /dev/nvme0n1[0-9] /dev/nvme0n2[0-9]; do
+                                         if [ -b "$device" ]; then
+                                           DEVICE_NAME=$(basename "$device")
+                                           udevadm trigger --name-match="$DEVICE_NAME"
+                                         fi
+                                       done
+  changed_when:                        true
   register:                            udev_triggered
 
-- name:                                "1.5.4 NVMe Support (RHEL) - Verify udev rules are applied"
+- name:                                "1.5.4 NVMe Support (RHEL/OL) - Wait for Azure symlink creation"
+  when:                                helper_script_created.changed or udev_rules_added.changed
+  ansible.builtin.wait_for:
+    path:                              /dev/disk/azure/data/by-lun
+    timeout:                           30
+  failed_when:                         false
+
+- name:                                "1.5.4 NVMe Support (RHEL/OL) - Verify Azure NVMe symlinks exist"
+  when:                                use_nvme_disks | default(false) | bool
+  ansible.builtin.stat:
+    path:                              "/dev/disk/azure/data/by-lun/{{ item.LUN }}"
+  register:                            azure_symlink_verification
+  loop: "{{ disks | selectattr('host', 'equalto', inventory_hostname) | list }}"
+  loop_control:
+    label:                             "LUN {{ item.LUN }}"
+
+- name:                                "1.5.4 NVMe Support (RHEL/OL) - Display Azure symlink verification results"
+  when:                                azure_symlink_verification is defined
+  ansible.builtin.debug:
+    msg: |
+                                       Azure NVMe Symlink Status:
+                                       {% if azure_symlink_verification.results is defined %}
+                                       {% set successful = azure_symlink_verification.results | selectattr('stat.exists', 'equalto', true) | list %}
+                                       {% set missing = azure_symlink_verification.results | selectattr('stat.exists', 'equalto', false) | list %}
+                                       - Expected symlinks: {{ azure_symlink_verification.results | length }}
+                                       - Successfully created: {{ successful | length }}
+                                       - Missing: {{ missing | length }}
+                                       {% if missing | length > 0 %}
+                                       - Missing LUNs: {{ missing | map(attribute='item.LUN') | list | join(', ') }}
+                                       Note: Missing symlinks indicate udev rule processing issues.
+                                       Volume group creation will use direct device paths as fallback.
+                                       {% endif %}
+                                       {% else %}
+                                       - No symlink verification performed (use_nvme_disks may be false)
+                                       {% endif %}
+    verbosity:                         1
+
+- name:                                "1.5.4 NVMe Support (RHEL/OL) - Verify udev rules are applied"
   when:                                udev_rules_added.changed
   ansible.builtin.shell: |
                                        set -o pipefail
@@ -277,7 +325,7 @@
   failed_when:                         false
   changed_when:                        false
 
-- name:                                "1.5.4 NVMe Support (RHEL) - Display udev verification results"
+- name:                                "1.5.4 NVMe Support (RHEL/OL) - Display udev verification results"
   when:
                                        - udev_rules_added.changed
                                        - udev_verification is defined
@@ -286,7 +334,7 @@
     msg:                               "Udev configuration verification on RHEL: {{ 'Successful - Azure disk symlinks detected' if 'disk/azure' in udev_verification.stdout else 'Note: No Azure disk symlinks detected (normal for systems without data disks)' }}"
     verbosity:                         1
 
-- name:                                "1.5.4 NVMe Support (RHEL) - Set final RHEL configuration facts"
+- name:                                "1.5.4 NVMe Support (RHEL/OL) - Set final RHEL configuration facts"
   ansible.builtin.set_fact:
     nvme_rhel_configured:              true
     nvme_udev_rules_installed:         "{{ udev_rules_added.changed | default(false) }}"

--- a/deploy/ansible/roles-os/1.5-disk-setup/tasks/1.5-nvme-preflight-rhel.yml
+++ b/deploy/ansible/roles-os/1.5-disk-setup/tasks/1.5-nvme-preflight-rhel.yml
@@ -68,7 +68,14 @@
                                        for MODULE in $REQUIRED_MODULES; do
                                          # Temporarily disable pipefail for this check since lsinitrd may have warnings
                                          set +o pipefail
-                                         if ! lsinitrd /boot/initramfs-$(uname -r).img 2>/dev/null | grep -q "${MODULE}\.ko"; then
+                                         INITRAMFS_FILE=""
+                                         if [ -f "/boot/initramfs-$(uname -r).img" ]; then
+                                           INITRAMFS_FILE="/boot/initramfs-$(uname -r).img"
+                                         elif [ -f "/boot/initrd-$(uname -r)" ]; then
+                                           INITRAMFS_FILE="/boot/initrd-$(uname -r)"
+                                         fi
+
+                                         if [ -n "$INITRAMFS_FILE" ] && ! lsinitrd "$INITRAMFS_FILE" 2>/dev/null | grep -q "${MODULE}\.ko"; then
                                            MISSING_MODULES="$MISSING_MODULES $MODULE"
                                            MISSING=1
                                          fi

--- a/deploy/ansible/roles-os/1.5-disk-setup/tasks/1.5-nvme-preflight-suse.yml
+++ b/deploy/ansible/roles-os/1.5-disk-setup/tasks/1.5-nvme-preflight-suse.yml
@@ -269,11 +269,18 @@
     - name:                            "1.5.4 NVMe Support (SUSE) - Trigger udev for specific NVMe devices"
       when:                            use_nvme_disks | default(false) | bool
       ansible.builtin.shell: |
-                                       # Trigger all NVMe devices except the OS disk (nvme0n1)
-                                       for device in /dev/nvme0n[2-9] /dev/nvme0n1[0-9] /dev/nvme0n2[0-9]; do
+                                       # Trigger all NVMe devices except the OS disk (identified by namespace ID 1)
+                                       for device in /dev/nvme*n*; do
                                          if [ -b "$device" ]; then
                                            DEVICE_NAME=$(basename "$device")
-                                           udevadm trigger --name-match="$DEVICE_NAME"
+                                           # Get namespace ID from sysfs
+                                           if [ -f "/sys/class/block/$DEVICE_NAME/nsid" ]; then
+                                             NSID=$(cat "/sys/class/block/$DEVICE_NAME/nsid")
+                                             # Skip namespace 1 (OS disk)
+                                             if [ "$NSID" != "1" ]; then
+                                               udevadm trigger --name-match="$DEVICE_NAME"
+                                             fi
+                                           fi
                                          fi
                                        done
       changed_when:                    true

--- a/deploy/ansible/roles-os/1.5-disk-setup/tasks/1.5-nvme-preflight-suse.yml
+++ b/deploy/ansible/roles-os/1.5-disk-setup/tasks/1.5-nvme-preflight-suse.yml
@@ -26,9 +26,9 @@
 - name:                                "1.5.4 NVMe Support (SUSE) - Set SUSE-specific facts"
   ansible.builtin.set_fact:
     suse_major_version:                "{{ ansible_distribution_major_version }}"
-    azure_nvme_utils_supported:        "{{
-                                          (ansible_distribution | upper == 'SLES' and ansible_distribution_version is version('15.5', '>=')) or
-                                          (ansible_distribution | upper == 'SLES_SAP' and ansible_distribution_version is version('15.5', '>='))
+    azure_nvme_utils_supported:       "{{
+                                         (ansible_distribution | upper == 'SLES' and ansible_distribution_version is version('15.5', '>=')) or
+                                         (ansible_distribution | upper == 'SLES_SAP' and ansible_distribution_version is version('15.5', '>='))
                                        }}"
     grub_config_file:                  "/boot/grub2/grub.cfg"
     grub_cmdline_param:                "GRUB_CMDLINE_LINUX_DEFAULT"
@@ -256,16 +256,69 @@
     force:                             true
     mode:                              '0644'
   register:                            udev_rules_added
+  changed_when:                        true
 
-- name:                                "1.5.4 NVMe Support (SUSE) - Reload udev rules"
-  when:                                udev_rules_added.changed
-  ansible.builtin.command:             udevadm control --reload-rules
-  register:                            udev_rules_reloaded
+- name:                                "1.5.4 NVMe Support (SUSE) - Reload and apply udev configuration"
+  when:                                helper_script_created.changed or udev_rules_added.changed
+  block:
+    - name:                            "1.5.4 NVMe Support (SUSE) - Reload udev rules"
+      ansible.builtin.command:         udevadm control --reload-rules
+      changed_when:                    true
+      register:                        udev_rules_reloaded
 
-- name:                                "1.5.4 NVMe Support (SUSE) - Trigger udev rules for existing devices"
-  when:                                udev_rules_added.changed
-  ansible.builtin.command:             udevadm trigger
-  register:                            udev_triggered
+    - name:                            "1.5.4 NVMe Support (SUSE) - Trigger udev for specific NVMe devices"
+      when:                            use_nvme_disks | default(false) | bool
+      ansible.builtin.shell: |
+                                       # Trigger all NVMe devices except the OS disk (nvme0n1)
+                                       for device in /dev/nvme0n[2-9] /dev/nvme0n1[0-9] /dev/nvme0n2[0-9]; do
+                                         if [ -b "$device" ]; then
+                                           DEVICE_NAME=$(basename "$device")
+                                           udevadm trigger --name-match="$DEVICE_NAME"
+                                         fi
+                                       done
+      changed_when:                    true
+
+    - name:                            "1.5.4 NVMe Support (SUSE) - Wait for udev processing"
+      ansible.builtin.wait_for:
+        timeout:                       15
+
+
+- name:                                "1.5.4 NVMe Support (SUSE) - Wait for Azure symlink creation"
+  when:                                helper_script_created.changed or udev_rules_added.changed
+  ansible.builtin.wait_for:
+    path:                              /dev/disk/azure/data/by-lun
+    timeout:                           30
+  failed_when:                         false
+
+- name:                                "1.5.4 NVMe Support (SUSE) - Verify Azure NVMe symlinks exist"
+  when:                                use_nvme_disks | default(false) | bool
+  ansible.builtin.stat:
+    path:                              "/dev/disk/azure/data/by-lun/{{ item.LUN }}"
+  register:                            azure_symlink_verification
+  loop: "{{ disks | selectattr('host', 'equalto', inventory_hostname) | list }}"
+  loop_control:
+    label:                             "LUN {{ item.LUN }}"
+
+- name:                                "1.5.4 NVMe Support (SUSE) - Display Azure symlink verification results"
+  when:                                azure_symlink_verification is defined
+  ansible.builtin.debug:
+    msg: |
+                                       Azure NVMe Symlink Status:
+                                       {% if azure_symlink_verification.results is defined %}
+                                       {% set successful = azure_symlink_verification.results | selectattr('stat.exists', 'equalto', true) | list %}
+                                       {% set missing = azure_symlink_verification.results | selectattr('stat.exists', 'equalto', false) | list %}
+                                       - Expected symlinks: {{ azure_symlink_verification.results | length }}
+                                       - Successfully created: {{ successful | length }}
+                                       - Missing: {{ missing | length }}
+                                       {% if missing | length > 0 %}
+                                       - Missing LUNs: {{ missing | map(attribute='item.LUN') | list | join(', ') }}
+                                       Note: Missing symlinks indicate udev rule processing issues.
+                                       Volume group creation will use direct device paths as fallback.
+                                       {% endif %}
+                                       {% else %}
+                                       - No symlink verification performed (use_nvme_disks may be false)
+                                       {% endif %}
+    verbosity:                         1
 
 - name:                                "1.5.4 NVMe Support (SUSE) - Verify udev rules are applied"
   when:                                udev_rules_added.changed

--- a/deploy/ansible/roles-os/1.5-disk-setup/tasks/1.5-nvme-preflight.yml
+++ b/deploy/ansible/roles-os/1.5-disk-setup/tasks/1.5-nvme-preflight.yml
@@ -62,11 +62,13 @@
         success_msg:                   "System validation completed successfully for NVMe preparation"
 
     # should we skip preparation if already configured?
-    - name:                            "1.5.4 NVMe Support - Skip preparation if already configured"
-      when:
-        - existing_nvme_config.stdout == "configured"
-        - not nvme_force_preparation | default(false)
-      ansible.builtin.meta:            end_play
+    # meta: end_role is available only from ansible-core 2.18 onwards.
+    # for now process the tasks.
+    # - name:                            "1.5.4 NVMe Support - Skip preparation if already configured"
+    #   when:
+    #                                    - existing_nvme_config.stdout == "configured"
+    #                                    - not nvme_force_preparation | default(false)
+    #   ansible.builtin.meta:            end_role
 
     - name:                            "1.5.4 NVMe Support - Display current system state"
       ansible.builtin.debug:


### PR DESCRIPTION
This pull request refactors and improves the Azure NVMe disk setup and detection logic for both RHEL/OL and SUSE systems. The changes focus on making the udev rules and helper scripts more robust by relying on hardware attributes instead of environment variables, standardizing and simplifying the LUN calculation logic, and enhancing the Ansible tasks to better verify and report the status of Azure NVMe symlinks. The updates also improve cross-distro consistency and error handling.

**Key changes include:**

### Udev rules and LUN calculation improvements

* Refactored `88-azure-nvme-data-disk.rules` to use hardware attributes (e.g., `ATTR{nsid}` and `ATTRS{model}`) instead of environment variables for more reliable device matching; now uses the external `azure-nvme-lun-calc` script for namespace detection and symlink creation.
* Simplified the `azure-nvme-lun-calc` script to require explicit device name and NSID as arguments, removing legacy fallbacks and extraction logic; now fails fast on invalid input and only outputs a LUN ID for valid data disks (NSID ≥ 2). 
### Ansible task enhancements (RHEL/OL and SUSE)

* Improved Ansible tasks to reload and trigger udev rules only when relevant files change, and to specifically trigger NVMe data devices (excluding the OS disk) for symlink creation; added explicit waits for symlink creation and detailed verification/debug output for expected vs. missing symlinks. 
* Updated task names and logic for clarity and consistency between RHEL/OL and SUSE, including more accurate reporting and error handling in the NVMe preflight checks. 

### Minor fixes and cleanups

* Corrected the initramfs filename for module checks on RHEL/OL from `/boot/initrd-$(uname -r)` to `/boot/initramfs-$(uname -r).img`.
* Commented out the Ansible meta task to skip preparation if already configured, due to compatibility with older Ansible versions.

These changes make the Azure NVMe disk setup more reliable, easier to debug, and more consistent across supported Linux distributions.