### PR TITLE
Fix items2dict filter compatibility for newer Ansible versions

### DIFF
--- a/deploy/ansible/roles-os/1.9-kernelparameters/tasks/main.yaml
+++ b/deploy/ansible/roles-os/1.9-kernelparameters/tasks/main.yaml
@@ -58,9 +58,10 @@
   ansible.builtin.set_fact:
     params_by_name: >-
                                        {{
-                                         dict((common_params + distro_params) |
-                                         map(attribute='name') |
-                                         zip(common_params + distro_params))
+                                         dict(zip(
+                                           (common_params + distro_params) | map(attribute='name'),
+                                           common_params + distro_params
+                                         ))
                                        }}
   vars:
     common_params: >-


### PR DESCRIPTION
## Problem
The `items2dict` filter with `key_attr` parameter is not supported in newer Ansible versions, causing failures on RHEL environments with the error:

list_of_dict_key_value_elements_to_dict() got an unexpected keyword argument 'key_attr'


## Solution
Replaced the deprecated `items2dict(key_attr='name')` syntax with a combination of standard Jinja2 filters:
- `map(attribute='name')` - Extract the 'name' attribute from each item
- `zip()` - Pair names with their corresponding items
- `dict()` - Convert pairs to a dictionary

## Changes
- Modified `deploy/ansible/roles-os/1.9-kernelparameters/tasks/main.yaml`

## Testing
Tested on RHEL systems 

## Impact
- Maintains the same functionality: builds a dictionary keyed by parameter name with distribution params overriding common params

- Compatible with both older and newer Ansible versions
- No changes to logic or behavior