### PR TITLE
fix/kernel-param-ha-vm-swappiness

### DIFF
--- a/deploy/ansible/roles-os/1.9-kernelparameters/vars/parameters.yaml
+++ b/deploy/ansible/roles-os/1.9-kernelparameters/vars/parameters.yaml
@@ -56,6 +56,8 @@ parameters:
     # this is not required in newer kernels as per 2382421
     # - { tier: 'os', name: 'net.ipv4.tcp_tw_recycle',                       value: '0',                      state: 'present' }
     - { tier: 'os',    node_tier: 'all',     name: 'net.ipv4.tcp_tw_reuse',                      value: '0',                    state: 'present' }
+    # this is the recommended value as per 3586539
+    - { tier: 'os',    node_tier: 'all',     name: 'vm.swappiness',                              value: '60',                   state: 'present' }
     - { tier: 'os',    node_tier: 'all',     name: 'net.ipv6.conf.all.accept_redirects',         value: '0',                    state: 'present' }
     - { tier: 'os',    node_tier: 'all',     name: 'net.ipv6.conf.all.accept_source_route',      value: '0',                    state: 'present' }
     - { tier: 'os',    node_tier: 'all',     name: 'net.ipv6.conf.default.accept_redirects',     value: '0',                    state: 'present' }
@@ -63,7 +65,7 @@ parameters:
     - { tier: 'os',    node_tier: 'all',     name: 'kernel.sem',                                 value: '250 32000 100 4096',   state: 'present' }
     - { tier: 'os',    node_tier: 'all',     name: 'net.ipv4.tcp_keepalive_intvl',               value: '75',                   state: 'present' }
     - { tier: 'os',    node_tier: 'all',     name: 'net.ipv4.tcp_keepalive_probes',              value: '9',                    state: 'present' }
-    - { tier: 'os',    node_tier: 'all',     name: 'net.ipv4.tcp_slow_start_after_idle',         value:  '0',                   state: 'present' }
+    - { tier: 'os',    node_tier: 'all',     name: 'net.ipv4.tcp_slow_start_after_idle',         value: '0',                    state: 'present' }
 
   sles_sap15:
     - { tier: 'os',    node_tier: 'all',     name: 'fs.protected_hardlinks',                     value: '1',                    state: 'present' }
@@ -105,6 +107,8 @@ parameters:
     # this is not required in newer kernels as per 2382421
     # - { tier: 'os', name: 'net.ipv4.tcp_tw_recycle',                       value: '0',                      state: 'present' }
     - { tier: 'ha',    node_tier: 'all',     name: 'net.ipv4.tcp_tw_reuse',                      value: '0',                    state: 'present' }
+    # https://learn.microsoft.com/en-us/azure/sap/workloads/high-availability-guide-suse-pacemaker?tabs=msi#install-the-cluster
+    - { tier: 'ha',    node_tier: 'all',     name: 'vm.swappiness',                              value: '10',                   state: 'present' }
 
   sles_sap12:
     - { tier: 'os',    node_tier: 'all',     name: 'fs.protected_hardlinks',                     value: '1',                    state: 'present' }
@@ -144,6 +148,8 @@ parameters:
     # this is not required in newer kernels as per 2382421
     # - { tier: 'os', name: 'net.ipv4.tcp_tw_recycle',                       value: '0',                      state: 'present' }
     - { tier: 'ha',    node_tier: 'all',     name: 'net.ipv4.tcp_tw_reuse',                      value: '0',                    state: 'present' }
+    # https://learn.microsoft.com/en-us/azure/sap/workloads/high-availability-guide-suse-pacemaker?tabs=msi#install-the-cluster
+    - { tier: 'ha',    node_tier: 'all',     name: 'vm.swappiness',                              value: '10',                   state: 'present' }
 
   redhat7:
     - { tier: 'os',    node_tier: 'all',     name: 'kernel.yama.ptrace_scope',                   value: '1',                    state: 'present' }


### PR DESCRIPTION
## Problem

Currentæy sap-automation-qa pipelines fail on configurations checks on systems deployed with SDAF, as the kernel parameter vm.swappiness does not have the right value.

## Solution

Set the common kernel parameter for vm.swappiness to 60 and for HA on SUSE set it to 10 according to the documentation here:
https://learn.microsoft.com/en-us/azure/sap/workloads/high-availability-guide-suse-pacemaker?tabs=msi#install-the-cluster