### PR TITLE
Refactor parameter handling to use dict with zip for improved clarity

### DIFF
--- a/deploy/ansible/roles-os/1.9-kernelparameters/tasks/main.yaml
+++ b/deploy/ansible/roles-os/1.9-kernelparameters/tasks/main.yaml
@@ -58,8 +58,9 @@
   ansible.builtin.set_fact:
     params_by_name: >-
                                        {{
-                                         (common_params + distro_params) |
-                                         items2dict(key_attr='name')
+                                         dict((common_params + distro_params) |
+                                         map(attribute='name') |
+                                         zip(common_params + distro_params))
                                        }}
   vars:
     common_params: >-


### PR DESCRIPTION
## Problem
This pull request updates the `deploy/ansible/roles-os/1.9-kernelparameters/tasks/main.yaml` file with improvements to how kernel parameters are managed and displayed. The main changes focus on refactoring the way parameters are stored and adjusting the verbosity of debug output.

## Solution

Parameter management refactor:

* Changed the construction of the `params_by_name` dictionary to use a more explicit mapping and zipping approach, improving clarity and reliability in how parameters are organized.


## Tests
Tested successfully in a pipeline run 
