### PR TITLE
#933: Updating ANF config to set a more restrictive export policy

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_landscape/anf.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/anf.tf
@@ -164,7 +164,7 @@ resource "azurerm_netapp_volume" "transport" {
   tags                                 = var.tags
 
   export_policy_rule {
-                       allowed_clients     = ["0.0.0.0/0"]
+                       allowed_clients     = length(var.ANF_settings.export_policy_client_access_list > 0) ? var.ANF_settings.export_policy_client_access_list : azurerm_virtual_network.vnet_sap.address_space 
                        protocol            = ["NFSv4.1"]
                        rule_index          = 1
                        unix_read_only      = false

--- a/deploy/terraform/terraform-units/modules/sap_landscape/variables_global.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/variables_global.tf
@@ -207,7 +207,7 @@ variable "ANF_settings"                                 {
                                                                       transport_volume_name         = ""
                                                                       transport_volume_size         = 32
                                                                       transport_volume_throughput   = 32
-
+                                                                      export_policy_client_access_list = []
                                                                       use_existing_install_volume   = false
                                                                       install_volume_name           = ""
                                                                       install_volume_size           = 128


### PR DESCRIPTION
## Problem
Avoid creating ANF volumes with an export policy of 0.0.0.0/0 which makes the volume open to the entire network

## Solution
Introduce a new variable parameter to allow use of a custom export policy list or else use the Vnet address space by default

## Tests
Run the code

