### PR TITLE
Fix: Handle SAP_PARAMS as file path in v1 ansible script

### DIFF
--- a/deploy/scripts/pipeline_scripts/v1/05-run-ansible.sh
+++ b/deploy/scripts/pipeline_scripts/v1/05-run-ansible.sh
@@ -89,7 +89,6 @@ set -eu
 curdir=$(dirname "$SAP_PARAMS")
 
 cd "$curdir" || exit
-echo "SSH Key name: $SSH_KEY_NAME"
 
 if [ ! -v SSH_KEY_NAME ]; then
 	SSH_KEY_NAME="${WORKLOAD_ZONE_NAME}-sid-sshkey"


### PR DESCRIPTION
This pull request makes a minor update to the `deploy/scripts/pipeline_scripts/v1/05-run-ansible.sh` script by changing the directory navigation logic. 

## Problem
The v1 ansible pipeline script fails when attempting to change directory:
`cd: /home/azureadm/agent/_work/14/s/config/WORKSPACES/SYSTEM/ANF-EUS2-SAP01-T01/artifacts/sap-parameters.yaml: Not a directory`

## Changes
* The script now changes to the directory containing the `SAP_PARAMS` file rather than the file itself. 