### PR TITLE
Fix: Resolve duplicate Key Vault Administrator role assignment in workload zone deployment

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_landscape/key_vault_sap_landscape.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/key_vault_sap_landscape.tf
@@ -100,7 +100,7 @@ resource "azurerm_management_lock" "key_vault" {
 
 resource "azurerm_role_assignment" "role_assignment_msi" {
   provider                             = azurerm.deployer
-  count                                = var.key_vault.enable_rbac_authorization && var.options.assign_permissions ? 1 : 0
+  count                                = var.key_vault.user.exists && var.key_vault.enable_rbac_authorization && var.options.assign_permissions ? 1 : 0
   scope                                = var.key_vault.user.exists ? (
                                            data.azurerm_key_vault.kv_user[0].id) : (
                                            azurerm_key_vault.kv_user[0].id
@@ -132,7 +132,7 @@ resource "azurerm_role_assignment" "role_assignment_vault_ssi" {
 
 resource "azurerm_role_assignment" "role_assignment_msi_officer" {
   provider                             = azurerm.deployer
-  count                                = var.key_vault.enable_rbac_authorization && var.options.assign_permissions ? 1 : 0
+  count                                = var.key_vault.user.exists && var.key_vault.enable_rbac_authorization && var.options.assign_permissions ? 1 : 0
   scope                                = var.key_vault.user.exists ? (
                                            data.azurerm_key_vault.kv_user[0].id) : (
                                            azurerm_key_vault.kv_user[0].id


### PR DESCRIPTION
## Summary
Fixes duplicate Key Vault Administrator role assignment error when deploying workload zones with existing Key Vaults.

## Problem
Workload zone deployments fail with error:

```
Error: RoleAssignmentExists: The role assignment already exists.
at: module.sap_landscape.azurerm_role_assignment.role_assignment_msi[0]
```


This occurs because when `var.key_vault.user.exists = true`, both:
- `role_assignment_msi` (line 103)
- `kv_user_msi_rbac` (line 183)

attempt to assign the Key Vault Administrator role to the MSI, creating a conflict.

## Solution
Modified role assignment count conditions in `key_vault_sap_landscape.tf`

This ensures MSI role assignments only apply to existing Key Vaults, while kv_user_msi_rbac handles new Key Vaults 

## Testing
 Validated against workload zone deployment scenario
