### PR TITLE
Update sudo logging configuration in Ansible tasks

### DIFF
--- a/deploy/ansible/roles-os/1.0-sudoers/tasks/main.yaml
+++ b/deploy/ansible/roles-os/1.0-sudoers/tasks/main.yaml
@@ -7,19 +7,38 @@
 #
 # -----------------------------------------------------------------------------
 
-- name:                                1.0 - Enable logging for sudo operations
-  become:                              true
+- name: Check if /etc/sudoers.d exists for SLES 16
+  become: true
+  ansible.builtin.stat:
+    path: /etc/sudoers.d
+  register: sudoersd_dir
+
+- name: Pick existing sudoers config location
+  ansible.builtin.set_fact:
+    sudoers_logging_file: >-
+      {{
+        '/etc/sudoers' if sudoers_file.stat.exists else
+        ('/etc/sudoers.d/99-sudo-logging' if sudoersd_dir.stat.exists and sudoersd_dir.stat.isdir else
+         '/etc/sudoers')
+      }}
+
+- name: 1.0 - Enable logging for sudo operations
+  become: true
   ansible.builtin.blockinfile:
-    path:                              /etc/sudoers
-    state:                             present
-    insertafter:                       'EOF'
-    validate:                          visudo -cf %s
+    path: >-
+      {{ '/etc/sudoers.d/99-sudo-logging'
+         if sudoersd_dir.stat.exists and sudoersd_dir.stat.isdir
+         else '/etc/sudoers' }}
+    state: present
+    insertafter: EOF
+    create: true
+    mode: '0440'
+    validate: visudo -cf %s
     block: |
-                                       Defaults logfile="/var/log/sudo.log"
-                                       Defaults iolog_dir="/var/log/sudo/${user}"
-                                       Defaults log_input
-#      Additional option to also logo outputs instead of inputs only
-#      Defaults log_input, log_output
+      Defaults logfile="/var/log/sudo.log"
+      Defaults iolog_dir="/var/log/sudo/${user}"
+      Defaults log_input
+#     Defaults log_input, log_output
 
 # /*----------------------------------------------------------------------------8
 # |                                    END                                      |


### PR DESCRIPTION
This pull request improves the way the Ansible role configures sudo logging by making the location of the sudoers configuration more robust and compliant with best practices. The changes ensure that, when possible, sudo logging configuration is placed in `/etc/sudoers.d/99-sudo-logging` instead of modifying the main `/etc/sudoers` file, and that the file is created with the correct permissions.

Key improvements to sudoers configuration:

* Added a check to determine if the `/etc/sudoers.d` directory exists, enabling conditional placement of the logging configuration.
* Updated the logic to select the appropriate sudoers file location, preferring `/etc/sudoers.d/99-sudo-logging` when available, and defaulting to `/etc/sudoers` otherwise.
* Modified the block that enables sudo logging to use the chosen file location, and ensured the file is created with mode `0440` for security.
