### PR TITLE
Refactor secret name handling in Ansible scripts and Terraform config

### DIFF
--- a/deploy/ansible/configuration_menu.sh
+++ b/deploy/ansible/configuration_menu.sh
@@ -53,8 +53,12 @@ sap_sid="$(awk '$1 == "sap_sid:" {print $2}' ${sap_params_file})"
 
 workload_vault_name="$(awk '$1 == "kv_name:" {print $2}' ${sap_params_file})"
 
-prefix="$(awk '$1 == "secret_prefix:" {print $2}' ${sap_params_file})"
-password_secret_name=$prefix-sid-password
+# Use the full secret name from sap-parameters.yaml if available, otherwise use shared/default naming pattern
+password_secret_name="$(awk '$1 == "password_secret_name:" {print $2}' ${sap_params_file})"
+if [[ -z "${password_secret_name}" ]]; then
+        prefix="$(awk '$1 == "secret_prefix:" {print $2}' ${sap_params_file})"
+        password_secret_name=$prefix-sid-password
+fi
 
 password_secret=$(az keyvault secret show --vault-name ${workload_vault_name} --name ${password_secret_name} --query value --output table)
 export ANSIBLE_PASSWORD=$password_secret

--- a/deploy/ansible/pb_get-sshkey.yaml
+++ b/deploy/ansible/pb_get-sshkey.yaml
@@ -19,9 +19,9 @@
       ansible.builtin.include_vars:    "{{ _workspace_directory }}/sap-parameters.yaml"
 
 
-    - name:                            Construct SSH key secret name
+    - name:                            Determine SSH key secret name
       ansible.builtin.set_fact:
-        secret_name:                   "{{ secret_prefix }}-sid-sshkey"
+        secret_name:                   "{{ sshkey_secret_name | default(secret_prefix + '-sid-sshkey') }}"
 
     - name:                            Retrieve SSH Key secret details and rescue on failure
       block:

--- a/deploy/ansible/roles-db/4.0.1-hdb-hsr/tasks/4.0.1.0-pre_checks.yml
+++ b/deploy/ansible/roles-db/4.0.1-hdb-hsr/tasks/4.0.1.0-pre_checks.yml
@@ -38,13 +38,13 @@
   changed_when:                        false
   failed_when:                         hana_replication_status.rc != 0
   environment:
-    PATH:                              /usr/sap/{{ db_sid | upper }}/HDB{{ db_instance_number }}:/usr/sap/{{ db_sid | upper }}/HDB{{ db_instance_number }}/exe
+    PATH:                              /usr/sap/{{ db_sid | upper }}/HDB{{ db_instance_number }}/exe:/usr/sap/{{ db_sid | upper }}/HDB{{ db_instance_number }}:/usr/bin:/bin
     HOME:                              /usr/sap/{{ db_sid | upper }}/home
     DIR_LIBRARY:                       /usr/sap/{{ db_sid | upper }}/HDB{{ db_instance_number }}/exe
     LD_LIBRARY_PATH:                   /usr/sap/{{ db_sid | upper }}/HDB{{ db_instance_number }}/exe
     SAPSYSTEMNAME:                     "{{ db_sid | upper }}"
-    SAP_RETRIEVAL_PATH:                "/usr/sap/{{ DB }}/{{ virtual_host }}"
-    SECUDIR:                           "/usr/sap/{{ DB }}/{{ virtual_host }}/sec"
+    SAP_RETRIEVAL_PATH:                "/usr/sap/{{ db_sid | upper }}/HDB{{ db_instance_number }}/{{ ansible_hostname }}"
+    SECUDIR:                           "/usr/sap/{{ db_sid | upper }}/HDB{{ db_instance_number }}/{{ ansible_hostname }}/sec"
 
 - name:                                "4.0.1.0 Hana System Replication - Show replication status"
   ansible.builtin.debug:

--- a/deploy/scripts/pipeline_scripts/v1/05-DB-and-SAP-installation-prepare.sh
+++ b/deploy/scripts/pipeline_scripts/v1/05-DB-and-SAP-installation-prepare.sh
@@ -162,14 +162,30 @@ else
 	new_parameters="$EXTRA_PARAMETERS $PIPELINE_EXTRA_PARAMETERS"
 fi
 
-echo "##vso[task.setvariable variable=SSH_KEY_NAME;isOutput=true]${workload_prefix}-sid-sshkey"
+# Read secret names from sap-parameters.yaml if available, otherwise use shared/default naming pattern
+SSH_KEY_NAME=$(grep "^sshkey_secret_name:" sap-parameters.yaml 2>/dev/null | awk '{print $2}')
+PASSWORD_KEY_NAME=$(grep "^password_secret_name:" sap-parameters.yaml 2>/dev/null | awk '{print $2}')
+USERNAME_KEY_NAME=$(grep "^username_secret_name:" sap-parameters.yaml 2>/dev/null | awk '{print $2}')
+
+# Fall back to shared/default naming pattern (landscape-level keys) if not found in sap-parameters.yaml
+if [ -z "${SSH_KEY_NAME}" ]; then
+	SSH_KEY_NAME="${workload_prefix}-sid-sshkey"
+fi
+if [ -z "${PASSWORD_KEY_NAME}" ]; then
+	PASSWORD_KEY_NAME="${workload_prefix}-sid-password"
+fi
+if [ -z "${USERNAME_KEY_NAME}" ]; then
+	USERNAME_KEY_NAME="${workload_prefix}-sid-username"
+fi
+
+echo "##vso[task.setvariable variable=SSH_KEY_NAME;isOutput=true]${SSH_KEY_NAME}"
 echo "##vso[task.setvariable variable=VAULT_NAME;isOutput=true]$workload_key_vault"
-echo "##vso[task.setvariable variable=PASSWORD_KEY_NAME;isOutput=true]${workload_prefix}-sid-password"
-echo "##vso[task.setvariable variable=USERNAME_KEY_NAME;isOutput=true]${workload_prefix}-sid-username"
+echo "##vso[task.setvariable variable=PASSWORD_KEY_NAME;isOutput=true]${PASSWORD_KEY_NAME}"
+echo "##vso[task.setvariable variable=USERNAME_KEY_NAME;isOutput=true]${USERNAME_KEY_NAME}"
 echo "##vso[task.setvariable variable=NEW_PARAMETERS;isOutput=true]${new_parameters}"
 echo "##vso[task.setvariable variable=ARM_SUBSCRIPTION_ID;isOutput=true]${control_plane_subscription}"
 
-az keyvault secret show --name "${workload_prefix}-sid-sshkey" --vault-name "$workload_key_vault" --subscription "$control_plane_subscription" --query value -o tsv >"artifacts/${SAP_SYSTEM_CONFIGURATION_NAME}_sshkey"
+az keyvault secret show --name "${SSH_KEY_NAME}" --vault-name "$workload_key_vault" --subscription "$control_plane_subscription" --query value -o tsv >"artifacts/${SAP_SYSTEM_CONFIGURATION_NAME}_sshkey"
 cp sap-parameters.yaml artifacts/.
 cp "${SID}_hosts.yaml" artifacts/.
 sudo chmod 600 artifacts/${SAP_SYSTEM_CONFIGURATION_NAME}_sshkey

--- a/deploy/scripts/pipeline_scripts/v1/05-run-ansible.sh
+++ b/deploy/scripts/pipeline_scripts/v1/05-run-ansible.sh
@@ -91,26 +91,34 @@ curdir=$(dirname "$SAP_PARAMS")
 
 cd "$curdir" || exit
 
-if [ ! -v SSH_KEY_NAME ]; then
-	SSH_KEY_NAME="${WORKLOAD_ZONE_NAME}-sid-sshkey"
-else
-  if [ -z "$SSH_KEY_NAME" ]; then
+# Try to read secret names from sap-parameters.yaml first
+if [ -f "sap-parameters.yaml" ]; then
+	_ssh_key=$(grep "^sshkey_secret_name:" sap-parameters.yaml 2>/dev/null | awk '{print $2}')
+	_password_key=$(grep "^password_secret_name:" sap-parameters.yaml 2>/dev/null | awk '{print $2}')
+	_username_key=$(grep "^username_secret_name:" sap-parameters.yaml 2>/dev/null | awk '{print $2}')
+fi
+
+# Use sap-parameters.yaml values if available, otherwise use passed variables, otherwise use shared/default naming pattern
+if [ ! -v SSH_KEY_NAME ] || [ -z "$SSH_KEY_NAME" ]; then
+	if [ -n "${_ssh_key:-}" ]; then
+		SSH_KEY_NAME="${_ssh_key}"
+	else
 		SSH_KEY_NAME="${WORKLOAD_ZONE_NAME}-sid-sshkey"
 	fi
 fi
 
-if [ ! -v PASSWORD_KEY_NAME ]; then
-	PASSWORD_KEY_NAME="${WORKLOAD_ZONE_NAME}-sid-password"
-else
-  if [ -z "$PASSWORD_KEY_NAME" ]; then
+if [ ! -v PASSWORD_KEY_NAME ] || [ -z "$PASSWORD_KEY_NAME" ]; then
+	if [ -n "${_password_key:-}" ]; then
+		PASSWORD_KEY_NAME="${_password_key}"
+	else
 		PASSWORD_KEY_NAME="${WORKLOAD_ZONE_NAME}-sid-password"
 	fi
 fi
 
-if [ ! -v USERNAME_KEY_NAME ]; then
-	USERNAME_KEY_NAME="${WORKLOAD_ZONE_NAME}-sid-username"
-else
-  if [ -z "$USERNAME_KEY_NAME" ]; then
+if [ ! -v USERNAME_KEY_NAME ] || [ -z "$USERNAME_KEY_NAME" ]; then
+	if [ -n "${_username_key:-}" ]; then
+		USERNAME_KEY_NAME="${_username_key}"
+	else
 		USERNAME_KEY_NAME="${WORKLOAD_ZONE_NAME}-sid-username"
 	fi
 fi

--- a/deploy/scripts/pipeline_scripts/v2/05-DB-and-SAP-installation-prepare.sh
+++ b/deploy/scripts/pipeline_scripts/v2/05-DB-and-SAP-installation-prepare.sh
@@ -165,13 +165,30 @@ az account set --subscription "$tfstate_subscription_id" --output none --only-sh
 echo "##vso[task.setvariable variable=FOLDER;isOutput=true]$CONFIG_REPO_PATH/SYSTEM/$SAP_SYSTEM_CONFIGURATION_NAME"
 echo "##vso[task.setvariable variable=HOSTS;isOutput=true]${SID}_hosts.yaml"
 echo "##vso[task.setvariable variable=NEW_PARAMETERS;isOutput=true]${new_parameters}"
-echo "##vso[task.setvariable variable=PASSWORD_KEY_NAME;isOutput=true]${WORKLOAD_ZONE_NAME}-sid-password"
 echo "##vso[task.setvariable variable=SAP_PARAMETERS;isOutput=true]sap-parameters.yaml"
 echo "##vso[task.setvariable variable=SID;isOutput=true]${SID}"
-echo "##vso[task.setvariable variable=SSH_KEY_NAME;isOutput=true]${WORKLOAD_ZONE_NAME}-sid-sshkey"
-echo "##vso[task.setvariable variable=USERNAME_KEY_NAME;isOutput=true]${WORKLOAD_ZONE_NAME}-sid-username"
 
-az keyvault secret show --name "${WORKLOAD_ZONE_NAME}-sid-sshkey" --vault-name "$key_vault" --subscription "$key_vault_subscription_id" --query value -o tsv >"artifacts/${SAP_SYSTEM_CONFIGURATION_NAME}_sshkey"
+# Read secret names from sap-parameters.yaml if available, otherwise use shared/default naming pattern
+SSH_KEY_NAME=$(grep "^sshkey_secret_name:" sap-parameters.yaml 2>/dev/null | awk '{print $2}')
+PASSWORD_KEY_NAME=$(grep "^password_secret_name:" sap-parameters.yaml 2>/dev/null | awk '{print $2}')
+USERNAME_KEY_NAME=$(grep "^username_secret_name:" sap-parameters.yaml 2>/dev/null | awk '{print $2}')
+
+# Fall back to shared/default naming pattern (landscape-level keys) if not found in sap-parameters.yaml
+if [ -z "${SSH_KEY_NAME}" ]; then
+	SSH_KEY_NAME="${WORKLOAD_ZONE_NAME}-sid-sshkey"
+fi
+if [ -z "${PASSWORD_KEY_NAME}" ]; then
+	PASSWORD_KEY_NAME="${WORKLOAD_ZONE_NAME}-sid-password"
+fi
+if [ -z "${USERNAME_KEY_NAME}" ]; then
+	USERNAME_KEY_NAME="${WORKLOAD_ZONE_NAME}-sid-username"
+fi
+
+echo "##vso[task.setvariable variable=PASSWORD_KEY_NAME;isOutput=true]${PASSWORD_KEY_NAME}"
+echo "##vso[task.setvariable variable=SSH_KEY_NAME;isOutput=true]${SSH_KEY_NAME}"
+echo "##vso[task.setvariable variable=USERNAME_KEY_NAME;isOutput=true]${USERNAME_KEY_NAME}"
+
+az keyvault secret show --name "${SSH_KEY_NAME}" --vault-name "$key_vault" --subscription "$key_vault_subscription_id" --query value -o tsv >"artifacts/${SAP_SYSTEM_CONFIGURATION_NAME}_sshkey"
 cp sap-parameters.yaml artifacts/.
 cp "${SID}_hosts.yaml" artifacts/.
 chmod 600 artifacts/${SAP_SYSTEM_CONFIGURATION_NAME}_sshkey

--- a/deploy/scripts/pipeline_scripts/v2/05-run-ansible.sh
+++ b/deploy/scripts/pipeline_scripts/v2/05-run-ansible.sh
@@ -113,26 +113,34 @@ key_vault_id=$(getVariableFromApplicationConfiguration "$APPLICATION_CONFIGURATI
 key_vault_subscription=$(echo "$key_vault_id" | cut -d '/' -f 3)
 key_vault_name=$(echo "$key_vault_id" | cut -d '/' -f 9)
 
-if [ ! -v SSH_KEY_NAME ]; then
-	SSH_KEY_NAME="${WORKLOAD_ZONE_NAME}-sid-sshkey"
-else
-  if [ -z "$SSH_KEY_NAME" ]; then
+# Try to read secret names from sap-parameters.yaml first
+if [ -f "sap-parameters.yaml" ]; then
+	_ssh_key=$(grep "^sshkey_secret_name:" sap-parameters.yaml 2>/dev/null | awk '{print $2}')
+	_password_key=$(grep "^password_secret_name:" sap-parameters.yaml 2>/dev/null | awk '{print $2}')
+	_username_key=$(grep "^username_secret_name:" sap-parameters.yaml 2>/dev/null | awk '{print $2}')
+fi
+
+# Use sap-parameters.yaml values if available, otherwise use passed variables, otherwise use shared/default naming pattern
+if [ ! -v SSH_KEY_NAME ] || [ -z "$SSH_KEY_NAME" ]; then
+	if [ -n "${_ssh_key:-}" ]; then
+		SSH_KEY_NAME="${_ssh_key}"
+	else
 		SSH_KEY_NAME="${WORKLOAD_ZONE_NAME}-sid-sshkey"
 	fi
 fi
 
-if [ ! -v PASSWORD_KEY_NAME ]; then
-	PASSWORD_KEY_NAME="${WORKLOAD_ZONE_NAME}-sid-password"
-else
-  if [ -z "$PASSWORD_KEY_NAME" ]; then
+if [ ! -v PASSWORD_KEY_NAME ] || [ -z "$PASSWORD_KEY_NAME" ]; then
+	if [ -n "${_password_key:-}" ]; then
+		PASSWORD_KEY_NAME="${_password_key}"
+	else
 		PASSWORD_KEY_NAME="${WORKLOAD_ZONE_NAME}-sid-password"
 	fi
 fi
 
-if [ ! -v USERNAME_KEY_NAME ]; then
-	USERNAME_KEY_NAME="${WORKLOAD_ZONE_NAME}-sid-username"
-else
-  if [ -z "$USERNAME_KEY_NAME" ]; then
+if [ ! -v USERNAME_KEY_NAME ] || [ -z "$USERNAME_KEY_NAME" ]; then
+	if [ -n "${_username_key:-}" ]; then
+		USERNAME_KEY_NAME="${_username_key}"
+	else
 		USERNAME_KEY_NAME="${WORKLOAD_ZONE_NAME}-sid-username"
 	fi
 fi

--- a/deploy/terraform/terraform-units/modules/sap_system/output_files/inventory.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/output_files/inventory.tf
@@ -248,6 +248,9 @@ resource "local_file" "sap-parameters_yml" {
                                             )
               scs_server_loadbalancer_ip  = var.scs_server_loadbalancer_ip
               secret_prefix               = local.secret_prefix,
+              sshkey_secret_name          = local.sshkey_secret_name,
+              password_secret_name        = local.password_secret_name,
+              username_secret_name        = local.username_secret_name,
               settings                    = local.settings
               sid                         = var.sap_sid,
               subnet_cidr_anf             = var.subnet_cidr_anf,
@@ -300,17 +303,17 @@ resource "local_file" "sap_inventory_md" {
               db_sid                      = var.db_sid
               key_vault_name              = local.key_vault_name,
               pas_server                  = try(var.naming.virtualmachine_names.APP_COMPUTERNAME[0], "")
-              password_secret_name        = local.use_local_credentials ? format("%s-%s-sid-password", local.secret_prefix, var.sap_sid) : format("%s-sid-password", local.secret_prefix)
+              password_secret_name        = local.password_secret_name
               platform                    = lower(var.platform)
               resource_group_name         = var.created_resource_group_name
               scs_high_availability       = var.scs_high_availability ? "Yes" : "No"
               scs_server_loadbalancer_ip  = length(var.scs_server_loadbalancer_ip) > 0 ? var.scs_server_loadbalancer_ip : try(var.scs_server_ips[0], "")
               scs_servers                 = join(",", var.naming.virtualmachine_names.SCS_COMPUTERNAME)
               sid                         = var.sap_sid,
-              ssh_secret_name             = local.use_local_credentials ? format("%s-%s-sid-sshkey", local.secret_prefix, var.sap_sid) : format("%s-sid-sshkey", local.secret_prefix)
+              ssh_secret_name             = local.sshkey_secret_name
               subscription_id             = var.created_resource_group_subscription_id
               url                         = format("https://portal.azure.com/#@%s/resource/subscriptions/%s/resourceGroups/%s/overview", data.azurerm_client_config.current.tenant_id, var.created_resource_group_subscription_id, var.created_resource_group_name)
-              username_secret_name        = local.use_local_credentials ? format("%s-%s-sid-username", local.secret_prefix, var.sap_sid) : format("%s-sid-username", local.secret_prefix)
+              username_secret_name        = local.username_secret_name
               webdisp_servers             = length(var.naming.virtualmachine_names.WEB_COMPUTERNAME) > 0 ? join(",", var.naming.virtualmachine_names.WEB_COMPUTERNAME) : ""
               key_vault_url               = format("https://portal.azure.com/#@%s/resource/subscriptions/%s/resourceGroups/%s/providers/Microsoft.KeyVault/vaults/%s/overview",
                                                     data.azurerm_client_config.current.tenant_id,
@@ -321,17 +324,17 @@ resource "local_file" "sap_inventory_md" {
               username_secret_url         = format("https://portal.azure.com/#@%s/asset/Microsoft_Azure_KeyVault/Secret/https://%s.vault.azure.net/secrets/%s",
                                                     data.azurerm_client_config.current.tenant_id,
                                                     local.key_vault_name,
-                                                    local.use_local_credentials ? format("%s-%s-sid-username", local.secret_prefix, var.sap_sid) : format("%s-sid-username", local.secret_prefix)
+                                                    local.username_secret_name
                                                     )
               password_secret_url         = format("https://portal.azure.com/#@%s/asset/Microsoft_Azure_KeyVault/Secret/https://%s.vault.azure.net/secrets/%s",
                                                     data.azurerm_client_config.current.tenant_id,
                                                     local.key_vault_name,
-                                                    local.use_local_credentials ? format("%s-%s-sid-password", local.secret_prefix, var.sap_sid) : format("%s-sid-password", local.secret_prefix)
+                                                    local.password_secret_name
                                                     )
               ssh_secret_url              = format("https://portal.azure.com/#@%s/asset/Microsoft_Azure_KeyVault/Secret/https://%s.vault.azure.net/secrets/%s",
                                                     data.azurerm_client_config.current.tenant_id,
                                                     local.key_vault_name,
-                                                    local.use_local_credentials ? format("%s-%s-sid-sshkey", local.secret_prefix, var.sap_sid) : format("%s-sid-sshkey", local.secret_prefix)
+                                                    local.sshkey_secret_name
                                                     )
 
               }

--- a/deploy/terraform/terraform-units/modules/sap_system/output_files/sap-parameters.tmpl
+++ b/deploy/terraform/terraform-units/modules/sap_system/output_files/sap-parameters.tmpl
@@ -173,6 +173,11 @@ kv_name:                       ${kv_name}
 # secret_prefix is the prefix for the name of the secret stored in key vault
 secret_prefix:                 ${secret_prefix}
 
+# Full secret names as stored in key vault (computed by Terraform)
+sshkey_secret_name:            ${sshkey_secret_name}
+password_secret_name:          ${password_secret_name}
+username_secret_name:          ${username_secret_name}
+
 # Set to true to instruct Ansible to update all the packages on the virtual machines
 upgrade_packages:              ${upgrade_packages}
 

--- a/deploy/terraform/terraform-units/modules/sap_system/output_files/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/output_files/variables_local.tf
@@ -72,4 +72,25 @@ locals {
 
   use_local_credentials                = length(var.authentication) > 0
 
+  # Compute the actual secret names that match what is created in key vaults
+  # When use_local_credentials=true: secrets are created as {SDU_PREFIX}-sshkey (no -sid-)
+  # When use_local_credentials=false: secrets are created as {WORKLOAD_ZONE_PREFIX}-sid-sshkey
+  sshkey_secret_name                   = var.use_local_credentials ? (
+                                           format("%s-sshkey", var.naming.prefix.SDU)
+                                         ) : (
+                                           format("%s-sid-sshkey", var.naming.prefix.WORKLOAD_ZONE)
+                                         )
+
+  password_secret_name                 = var.use_local_credentials ? (
+                                           format("%s-password", var.naming.prefix.SDU)
+                                         ) : (
+                                           format("%s-sid-password", var.naming.prefix.WORKLOAD_ZONE)
+                                         )
+
+  username_secret_name                 = var.use_local_credentials ? (
+                                           format("%s-username", var.naming.prefix.SDU)
+                                         ) : (
+                                           format("%s-sid-username", var.naming.prefix.WORKLOAD_ZONE)
+                                         )
+
 }


### PR DESCRIPTION
Issue
When users deploy SAP systems with custom SSH keys per SID by defining the authentication block in their tfvars, the Ansible playbooks fail because they cannot find the secret in the Key Vault. The error shows that Ansible is looking for a secret named like LAC-SECE-SAP04-X00-sid-sshkey, but the actual secret created by Terraform is named LAC-SECE-SAP04-X00-sshkey. The problem is that the sap_landscape module creates secrets with the -sid-sshkey suffix pattern for shared landscape-level keys, while the sap_system module creates secrets with just -sshkey suffix for per-SID custom keys. However, the Ansible playbooks and pipeline scripts were hardcoding the -sid-sshkey pattern regardless of which scenario was used.

Fix
Terraform now computes the correct secret names based on whether custom credentials are used and outputs them directly to sap-parameters.yaml as new variables: sshkey_secret_name, password_secret_name, and username_secret_name. The Ansible playbooks and pipeline scripts now read these variables from sap-parameters.yaml instead of constructing the secret names themselves. This ensures the secret names used for retrieval always match what was actually created in the Key Vault, regardless of whether shared landscape-level keys or per-SID custom keys are being used.