### PR TITLE
Fix: Resolve multiple bugs in setup WorkloadZone in ADO causing silent failures

### DIFF
--- a/deploy/scripts/pwsh/Output/SDAFUtilities/SDAFUtilities.psm1
+++ b/deploy/scripts/pwsh/Output/SDAFUtilities/SDAFUtilities.psm1
@@ -1917,9 +1917,6 @@ function New-SDAFADOWorkloadZone {
     Write-Verbose "  CreateConnections: $CreateConnections"
     Write-Verbose "  ServiceManagementReference: $ServiceManagementReference"
 
-    Write-Verbose "Setting Azure DevOps defaults: organization=$AdoOrganization project=$AdoProject"
-    az devops configure --defaults organization=$AdoOrganization project="$AdoProject"
-
     # Initialize error tracking
     $ErrorActionPreference = 'Stop'
     $script:DeploymentErrors = @()
@@ -2183,6 +2180,9 @@ function New-SDAFADOWorkloadZone {
         throw "Project not found"
       }
 
+      Write-Verbose "Setting Azure DevOps defaults: organization=$AdoOrganization project=$AdoProject"
+      az devops configure --defaults organization=$AdoOrganization project="$AdoProject"
+
       $ControlPlaneVariableGroupId = (az pipelines variable-group list --query "[?name=='$ControlPlanePrefix'].id | [0]" --only-show-errors)
       $AgentPoolName = ""
       if ($ControlPlaneVariableGroupId.Length -ne 0) {
@@ -2334,11 +2334,19 @@ function New-SDAFADOWorkloadZone {
           Write-Host "Service connection '$ServiceConnectionName' created successfully." -ForegroundColor Green
           $ServiceConnectionId = az devops service-endpoint list --query "[?name=='$ServiceConnectionName'].id" -o tsv
           az devops service-endpoint update --id $ServiceConnectionId --enable-for-all true --output none --only-show-errors
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Failed to enable service connection '$ServiceConnectionName' for all pipelines"
+            throw "Service connection update failed"
+          }
         }
         else {
           Write-Host "Service Endpoint already exists, recreating it with the updated credentials" -ForegroundColor Green
           $ServiceConnectionId = az devops service-endpoint list --query "[?name=='$ServiceConnectionName'].id" -o tsv
           az devops service-endpoint delete --id $ServiceConnectionId --yes
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Failed to delete existing service connection '$ServiceConnectionName'"
+            throw "Service connection deletion failed"
+          }
           az devops service-endpoint azurerm create --azure-rm-service-principal-id $WorkloadZoneClientId --azure-rm-subscription-id $WorkloadZoneSubscriptionId --azure-rm-subscription-name $WorkloadZoneSubscriptionName --azure-rm-tenant-id $WorkloadZoneTenantId --name $ServiceConnectionName --output none --only-show-errors
           if ($LASTEXITCODE -ne 0) {
             Write-Error "Failed to recreate service connection '$ServiceConnectionName'"
@@ -2347,6 +2355,10 @@ function New-SDAFADOWorkloadZone {
           Write-Host "Service connection '$ServiceConnectionName' recreated successfully." -ForegroundColor Green
           $ServiceConnectionId = az devops service-endpoint list --query "[?name=='$ServiceConnectionName'].id" -o tsv
           az devops service-endpoint update --id $ServiceConnectionId --enable-for-all true --output none --only-show-errors
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Failed to enable service connection '$ServiceConnectionName' for all pipelines"
+            throw "Service connection update failed"
+          }
         }
       }
 

--- a/deploy/scripts/pwsh/Output/SDAFUtilities/SDAFUtilities.psm1
+++ b/deploy/scripts/pwsh/Output/SDAFUtilities/SDAFUtilities.psm1
@@ -706,6 +706,10 @@ function New-SDAFADOProject {
 
       Write-Verbose "Creating service connection: $ConnectionName"
       az devops service-endpoint create --service-endpoint-configuration $JsonInputFile --organization $AdoOrganization --project $AdoProject --output none --only-show-errors
+      if ($LASTEXITCODE -ne 0) {
+        Write-Error "Failed to create service connection '$ConnectionName'"
+        throw "Service connection creation failed"
+      }
       Write-Host "Service connection '$ConnectionName' created successfully." -ForegroundColor Green
 
       if (Test-Path $JsonInputFile) {

--- a/deploy/scripts/pwsh/Output/SDAFUtilities/SDAFUtilities.psm1
+++ b/deploy/scripts/pwsh/Output/SDAFUtilities/SDAFUtilities.psm1
@@ -1913,6 +1913,9 @@ function New-SDAFADOWorkloadZone {
     Write-Verbose "  CreateConnections: $CreateConnections"
     Write-Verbose "  ServiceManagementReference: $ServiceManagementReference"
 
+    Write-Verbose "Setting Azure DevOps defaults: organization=$AdoOrganization project=$AdoProject"
+    az devops configure --defaults organization=$AdoOrganization project="$AdoProject"
+
     # Initialize error tracking
     $ErrorActionPreference = 'Stop'
     $script:DeploymentErrors = @()
@@ -1997,6 +2000,10 @@ function New-SDAFADOWorkloadZone {
 
       Write-Verbose "Creating service connection: $ConnectionName"
       az devops service-endpoint create --service-endpoint-configuration $JsonInputFile --organization $AdoOrganization --project $AdoProject --output none --only-show-errors
+      if ($LASTEXITCODE -ne 0) {
+        Write-Error "Failed to create service connection '$ConnectionName'"
+        throw "Service connection creation failed"
+      }
       Write-Host "Service connection '$ConnectionName' created successfully." -ForegroundColor Green
 
       if (Test-Path $JsonInputFile) {
@@ -2196,7 +2203,7 @@ function New-SDAFADOWorkloadZone {
 
         if ($ManagedIdentityId.Length -ne 0) {
           $ResourceGroupName = $ManagedIdentityId.Split("/")[4]
-          $ManagedIdentityClientId = $(az identity list --query "[?principalId=='$ManagedIdentityObjectId'].id" --subscription $ControlPlaneSubscriptionId --resource-group $ResourceGroupName --output tsv)
+          $ManagedIdentityClientId = $(az identity list --query "[?principalId=='$ManagedIdentityObjectId'].clientId" --subscription $ControlPlaneSubscriptionId --resource-group $ResourceGroupName --output tsv)
           Write-Verbose "Client ID of the Managed Identity: $ManagedIdentityClientId"
           if ($ManagedIdentityClientId.Length -eq 0) {
             Write-Error "Managed Identity with Object ID $ManagedIdentityObjectId was not found in subscription $ControlPlaneSubscriptionId"
@@ -2316,6 +2323,11 @@ function New-SDAFADOWorkloadZone {
         if ($ServiceConnectionExists.Length -eq 0) {
           Write-Host "Creating Service Endpoint" $ServiceConnectionName -ForegroundColor Green
           az devops service-endpoint azurerm create --azure-rm-service-principal-id $WorkloadZoneClientId --azure-rm-subscription-id $WorkloadZoneSubscriptionId --azure-rm-subscription-name $WorkloadZoneSubscriptionName --azure-rm-tenant-id $WorkloadZoneTenantId --name $ServiceConnectionName --output none --only-show-errors
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Failed to create service connection '$ServiceConnectionName'"
+            throw "Service connection creation failed"
+          }
+          Write-Host "Service connection '$ServiceConnectionName' created successfully." -ForegroundColor Green
           $ServiceConnectionId = az devops service-endpoint list --query "[?name=='$ServiceConnectionName'].id" -o tsv
           az devops service-endpoint update --id $ServiceConnectionId --enable-for-all true --output none --only-show-errors
         }
@@ -2324,6 +2336,11 @@ function New-SDAFADOWorkloadZone {
           $ServiceConnectionId = az devops service-endpoint list --query "[?name=='$ServiceConnectionName'].id" -o tsv
           az devops service-endpoint delete --id $ServiceConnectionId --yes
           az devops service-endpoint azurerm create --azure-rm-service-principal-id $WorkloadZoneClientId --azure-rm-subscription-id $WorkloadZoneSubscriptionId --azure-rm-subscription-name $WorkloadZoneSubscriptionName --azure-rm-tenant-id $WorkloadZoneTenantId --name $ServiceConnectionName --output none --only-show-errors
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Failed to recreate service connection '$ServiceConnectionName'"
+            throw "Service connection creation failed"
+          }
+          Write-Host "Service connection '$ServiceConnectionName' recreated successfully." -ForegroundColor Green
           $ServiceConnectionId = az devops service-endpoint list --query "[?name=='$ServiceConnectionName'].id" -o tsv
           az devops service-endpoint update --id $ServiceConnectionId --enable-for-all true --output none --only-show-errors
         }

--- a/deploy/scripts/pwsh/SDAFUtilities/Public/New-SDAFADOProject.ps1
+++ b/deploy/scripts/pwsh/SDAFUtilities/Public/New-SDAFADOProject.ps1
@@ -324,6 +324,10 @@ function New-SDAFADOProject {
 
       Write-Verbose "Creating service connection: $ConnectionName"
       az devops service-endpoint create --service-endpoint-configuration $JsonInputFile --organization $AdoOrganization --project $AdoProject --output none --only-show-errors
+      if ($LASTEXITCODE -ne 0) {
+        Write-Error "Failed to create service connection '$ConnectionName'"
+        throw "Service connection creation failed"
+      }
       Write-Host "Service connection '$ConnectionName' created successfully." -ForegroundColor Green
 
       if (Test-Path $JsonInputFile) {

--- a/deploy/scripts/pwsh/SDAFUtilities/Public/New-SDAFADOWorkloadZone.ps1
+++ b/deploy/scripts/pwsh/SDAFUtilities/Public/New-SDAFADOWorkloadZone.ps1
@@ -143,6 +143,9 @@ function New-SDAFADOWorkloadZone {
     Write-Verbose "  CreateConnections: $CreateConnections"
     Write-Verbose "  ServiceManagementReference: $ServiceManagementReference"
 
+    Write-Verbose "Setting Azure DevOps defaults: organization=$AdoOrganization project=$AdoProject"
+    az devops configure --defaults organization=$AdoOrganization project="$AdoProject"
+
     # Initialize error tracking
     $ErrorActionPreference = 'Stop'
     $script:DeploymentErrors = @()
@@ -227,6 +230,10 @@ function New-SDAFADOWorkloadZone {
 
       Write-Verbose "Creating service connection: $ConnectionName"
       az devops service-endpoint create --service-endpoint-configuration $JsonInputFile --organization $AdoOrganization --project $AdoProject --output none --only-show-errors
+      if ($LASTEXITCODE -ne 0) {
+        Write-Error "Failed to create service connection '$ConnectionName'"
+        throw "Service connection creation failed"
+      }
       Write-Host "Service connection '$ConnectionName' created successfully." -ForegroundColor Green
 
       if (Test-Path $JsonInputFile) {
@@ -427,7 +434,7 @@ function New-SDAFADOWorkloadZone {
 
         if ($ManagedIdentityId.Length -ne 0) {
           $ResourceGroupName = $ManagedIdentityId.Split("/")[4]
-          $ManagedIdentityClientId = $(az identity list --query "[?principalId=='$ManagedIdentityObjectId'].id" --subscription $ControlPlaneSubscriptionId --resource-group $ResourceGroupName --output tsv)
+          $ManagedIdentityClientId = $(az identity list --query "[?principalId=='$ManagedIdentityObjectId'].clientId" --subscription $ControlPlaneSubscriptionId --resource-group $ResourceGroupName --output tsv)
           Write-Verbose "Client ID of the Managed Identity: $ManagedIdentityClientId"
           if ($ManagedIdentityClientId.Length -eq 0) {
             Write-Error "Managed Identity with Object ID $ManagedIdentityObjectId was not found in subscription $ControlPlaneSubscriptionId"
@@ -547,6 +554,11 @@ function New-SDAFADOWorkloadZone {
         if ($ServiceConnectionExists.Length -eq 0) {
           Write-Host "Creating Service Endpoint" $ServiceConnectionName -ForegroundColor Green
           az devops service-endpoint azurerm create --azure-rm-service-principal-id $WorkloadZoneClientId --azure-rm-subscription-id $WorkloadZoneSubscriptionId --azure-rm-subscription-name $WorkloadZoneSubscriptionName --azure-rm-tenant-id $WorkloadZoneTenantId --name $ServiceConnectionName --output none --only-show-errors
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Failed to create service connection '$ServiceConnectionName'"
+            throw "Service connection creation failed"
+          }
+          Write-Host "Service connection '$ServiceConnectionName' created successfully." -ForegroundColor Green
           $ServiceConnectionId = az devops service-endpoint list --query "[?name=='$ServiceConnectionName'].id" -o tsv
           az devops service-endpoint update --id $ServiceConnectionId --enable-for-all true --output none --only-show-errors
         }
@@ -555,6 +567,11 @@ function New-SDAFADOWorkloadZone {
           $ServiceConnectionId = az devops service-endpoint list --query "[?name=='$ServiceConnectionName'].id" -o tsv
           az devops service-endpoint delete --id $ServiceConnectionId --yes
           az devops service-endpoint azurerm create --azure-rm-service-principal-id $WorkloadZoneClientId --azure-rm-subscription-id $WorkloadZoneSubscriptionId --azure-rm-subscription-name $WorkloadZoneSubscriptionName --azure-rm-tenant-id $WorkloadZoneTenantId --name $ServiceConnectionName --output none --only-show-errors
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Failed to recreate service connection '$ServiceConnectionName'"
+            throw "Service connection creation failed"
+          }
+          Write-Host "Service connection '$ServiceConnectionName' recreated successfully." -ForegroundColor Green
           $ServiceConnectionId = az devops service-endpoint list --query "[?name=='$ServiceConnectionName'].id" -o tsv
           az devops service-endpoint update --id $ServiceConnectionId --enable-for-all true --output none --only-show-errors
         }

--- a/deploy/scripts/pwsh/SDAFUtilities/Public/New-SDAFADOWorkloadZone.ps1
+++ b/deploy/scripts/pwsh/SDAFUtilities/Public/New-SDAFADOWorkloadZone.ps1
@@ -143,9 +143,6 @@ function New-SDAFADOWorkloadZone {
     Write-Verbose "  CreateConnections: $CreateConnections"
     Write-Verbose "  ServiceManagementReference: $ServiceManagementReference"
 
-    Write-Verbose "Setting Azure DevOps defaults: organization=$AdoOrganization project=$AdoProject"
-    az devops configure --defaults organization=$AdoOrganization project="$AdoProject"
-
     # Initialize error tracking
     $ErrorActionPreference = 'Stop'
     $script:DeploymentErrors = @()
@@ -409,6 +406,9 @@ function New-SDAFADOWorkloadZone {
         throw "Project not found"
       }
 
+      Write-Verbose "Setting Azure DevOps defaults: organization=$AdoOrganization project=$AdoProject"
+      az devops configure --defaults organization=$AdoOrganization project="$AdoProject"
+
       $ControlPlaneVariableGroupId = (az pipelines variable-group list --query "[?name=='$ControlPlanePrefix'].id | [0]" --only-show-errors)
       $AgentPoolName = ""
       if ($ControlPlaneVariableGroupId.Length -ne 0) {
@@ -561,11 +561,19 @@ function New-SDAFADOWorkloadZone {
           Write-Host "Service connection '$ServiceConnectionName' created successfully." -ForegroundColor Green
           $ServiceConnectionId = az devops service-endpoint list --query "[?name=='$ServiceConnectionName'].id" -o tsv
           az devops service-endpoint update --id $ServiceConnectionId --enable-for-all true --output none --only-show-errors
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Failed to enable service connection '$ServiceConnectionName' for all pipelines"
+            throw "Service connection update failed"
+          }
         }
         else {
           Write-Host "Service Endpoint already exists, recreating it with the updated credentials" -ForegroundColor Green
           $ServiceConnectionId = az devops service-endpoint list --query "[?name=='$ServiceConnectionName'].id" -o tsv
           az devops service-endpoint delete --id $ServiceConnectionId --yes
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Failed to delete existing service connection '$ServiceConnectionName'"
+            throw "Service connection deletion failed"
+          }
           az devops service-endpoint azurerm create --azure-rm-service-principal-id $WorkloadZoneClientId --azure-rm-subscription-id $WorkloadZoneSubscriptionId --azure-rm-subscription-name $WorkloadZoneSubscriptionName --azure-rm-tenant-id $WorkloadZoneTenantId --name $ServiceConnectionName --output none --only-show-errors
           if ($LASTEXITCODE -ne 0) {
             Write-Error "Failed to recreate service connection '$ServiceConnectionName'"
@@ -574,6 +582,10 @@ function New-SDAFADOWorkloadZone {
           Write-Host "Service connection '$ServiceConnectionName' recreated successfully." -ForegroundColor Green
           $ServiceConnectionId = az devops service-endpoint list --query "[?name=='$ServiceConnectionName'].id" -o tsv
           az devops service-endpoint update --id $ServiceConnectionId --enable-for-all true --output none --only-show-errors
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Failed to enable service connection '$ServiceConnectionName' for all pipelines"
+            throw "Service connection update failed"
+          }
         }
       }
 


### PR DESCRIPTION
## Summary
Fixes multiple bugs in `New-SDAFADOWorkloadZone` that caused false success reporting and resources created in wrong projects.

## Issues Addressed
- Variable groups created in wrong Azure DevOps project
- Service connection creation failing silently
- Wrong Managed Identity property causing authentication failures

## Changes

### 1. Add Azure DevOps configuration
**Files:** `New-SDAFADOWorkloadZone.ps1`, `SDAFUtilities.psm1`

The function now calls `az devops configure --defaults` at the beginning to ensure all operations target the correct organization and project. This matches the pattern used in `New-SDAFADOProject`.

### 2. Fix Managed Identity Client ID query

Changed `.id` to `.clientId` in the az identity list query:
```diff
- az identity list --query "[?principalId=='...'].id"
+ az identity list --query "[?principalId=='...'].clientId"
```

The previous code returned the full ARM resource ID instead of the client ID required for service connection authentication.

### 3. Add error handling for service connection creation

Added $LASTEXITCODE checks after all az devops service-endpoint commands. The function now properly reports failures instead of displaying false success messages.

```diff 
  az devops service-endpoint create --service-endpoint-configuration $JsonInputFile --organization $AdoOrganization --project $AdoProject --output none --only-show-errors
+ if ($LASTEXITCODE -ne 0) {
+     Write-Error "Failed to create service connection"
+     throw "Service connection creation failed"
+ }
  Write-Host "Service connection '$ConnectionName' created successfully." -ForegroundColor Green
```