### PR TITLE
Fix issue #1008 by changing terraform plugin cache directory owner during deployer creation

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_deployer/templates/configure_deployer.sh.tmpl
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/templates/configure_deployer.sh.tmpl
@@ -625,6 +625,8 @@ sudo chmod 755 "$${tf_bin}/terraform"
 
 sudo rm "/$${asad_home}/$${tf_zip}"
 
+chown -R "$${local_user}" "$${tf_cache}" 
+
 # Uninstall Azure CLI - For some platforms
 case "$(get_distro_name)" in
 ubuntu | sles)

--- a/deploy/terraform/terraform-units/modules/sap_deployer/templates/configure_deployer.sh.tmpl
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/templates/configure_deployer.sh.tmpl
@@ -625,7 +625,7 @@ sudo chmod 755 "$${tf_bin}/terraform"
 
 sudo rm "/$${asad_home}/$${tf_zip}"
 
-chown -R "$${local_user}" "$${tf_cache}" 
+sudo chown -R "$${local_user}" "$${tf_cache}" 
 
 # Uninstall Azure CLI - For some platforms
 case "$(get_distro_name)" in


### PR DESCRIPTION
## Problem

Issue #1008  where during the SDAF deployer VM preparation, the plugin cache were owned by root, so the subsequent use of self-hosted agent for terraform execution would fail with access denied error (since the agent execution will be using user azureadm, not root)

## Solution
Change the terraform plugin cache ownership in the deployer configuration template file

## Tests
By running the pipeline Deploy workload zone

## Notes
