### PR TITLE
Update to support PYOG and BYOL for SUSE subscriptions

### DIFF
--- a/deploy/ansible/roles-os/1.3-repository/tasks/1.3.0-preparation-Suse.yaml
+++ b/deploy/ansible/roles-os/1.3-repository/tasks/1.3.0-preparation-Suse.yaml
@@ -23,13 +23,50 @@
   rescue:
     # Attempt to configure the repos by re-registering instance
 
-    - name:                            "1.3.0 Repository - SUSE - Attempt to re-register SLE instance with Public Cloud Update Infrastructure and rescue"
+    # -------------------- BYOS / BYOL Registration Path --------------------8
+    - name:                            "1.3.0 Repository - SUSE - Re-register SLE instance (BYOS - using registration code)"
+      when:                            suse_subscription_id | default('') | length > 0
       block:
-        - name:                        "1.3.0 Repository - SUSE - Attempt to re-register SLE instance with Public Cloud Update Infrastructure cleanup"
+        - name:                        "1.3.0 Repository - SUSE - BYOS - Cleanup existing registration"
+          ansible.builtin.shell:      |
+                                          SUSEConnect --cleanup
+          environment:
+            ZYPP_LOCK_TIMEOUT:        "60"
+
+        - name:                        "1.3.0 Repository - SUSE - BYOS - Register with SUSE Customer Center"
+          ansible.builtin.command:     SUSEConnect -r {{ suse_subscription_id }}
+          register:                    byos_reg_result
+          environment:
+            ZYPP_LOCK_TIMEOUT:        "60"
+
+        - name:                        "1.3.0 Repository - SUSE - BYOS - Wait 30 secs before verifying"
+          ansible.builtin.wait_for:
+            timeout:                   30
+
+        - name:                        "1.3.0 Repository - SUSE - BYOS - Verify that zypper repos are configured after registration"
+          ansible.builtin.command:     zypper lr
+          register:                    zypper_lr_result
+          until:                       zypper_lr_result.rc == 0
+          retries:                     10
+          delay:                       30
+      rescue:
+        - name:                        "1.3.0 Repository - SUSE - BYOS - Print error details"
+          ansible.builtin.debug:
+            msg:                       "BYOS registration failed. Result: {{ byos_reg_result | default('N/A') }} Zypper: {{ zypper_lr_result | default('N/A') }}"
+
+        - name:                        "1.3.0 Repository - SUSE - BYOS - Error handling"
+          ansible.builtin.fail:
+            msg:                       "BYOS registration with SUSE Customer Center failed. Verify your suse_subscription_id is correct and the system has outbound connectivity to scc.suse.com."
+
+    # -------------------- PAYG Registration Path ---------------------------8
+    - name:                            "1.3.0 Repository - SUSE - Re-register SLE instance (PAYG - using registercloudguest)"
+      when:                            suse_subscription_id | default('') | length == 0
+      block:
+        - name:                        "1.3.0 Repository - SUSE - PAYG - Cleanup existing registration"
           ansible.builtin.shell:      |
                                           SUSEConnect --cleanup
 
-        - name:                        "1.3.0 Repository - SUSE - Attempt to re-register SLE instance with Public Cloud Update Infrastructure"
+        - name:                        "1.3.0 Repository - SUSE - PAYG - Re-register with Public Cloud Update Infrastructure"
           ansible.builtin.shell:      |
                                           rm -f /etc/SUSEConnect
                                           rm -f /etc/zypp/{repos,services,credentials}.d/*
@@ -44,22 +81,22 @@
           environment:
             ZYPP_LOCK_TIMEOUT:        "60"
 
-        - name:                        "1.3.0 Repository - SUSE - Wait 30 secs before retrying"
+        - name:                        "1.3.0 Repository - SUSE - PAYG - Wait 30 secs before retrying"
           ansible.builtin.wait_for:
             timeout:                   30
 
-        - name:                        "1.3.0 Repository - SUSE - Verify that zypper repos are configured after re-registering SLE instance"
+        - name:                        "1.3.0 Repository - SUSE - PAYG - Verify that zypper repos are configured after re-registering SLE instance"
           ansible.builtin.command:     zypper lr
           register:                    zypper_lr_result
           until:                       zypper_lr_result.rc == 0
           retries:                     10
           delay:                       30
       rescue:
-        - name:                        "1.3.0 Repository - SUSE - Print stderr before error handling"
+        - name:                        "1.3.0 Repository - SUSE - PAYG - Print stderr before error handling"
           ansible.builtin.debug:
             msg:                       "Result obj: {{ zypper_lr_result }}"
 
-        - name:                        "1.3.0 Repository - SUSE - Error handling: 1.3.0 Repository - Verify that zypper repos are configured after re-registering SLE instance"
+        - name:                        "1.3.0 Repository - SUSE - PAYG - Error handling: Verify that zypper repos are configured after re-registering SLE instance"
           ansible.builtin.fail:
             msg:                       "{{ zypper_lr_result.msg | try_get_error_code(task_tag='zypper_registration') }}"
 

--- a/deploy/ansible/roles-os/1.4-packages/tasks/1.4.0-packages-Suse-prep.yaml
+++ b/deploy/ansible/roles-os/1.4-packages/tasks/1.4.0-packages-Suse-prep.yaml
@@ -15,16 +15,18 @@
     - tier == 'os'
   block:
     - name:                            "1.4 Packages - SUSE12 - Activate public cloud extension ({{ ansible_distribution_major_version }})"
-      ansible.builtin.command: |
+      ansible.builtin.command: >-
                                        SUSEConnect -p sle-module-public-cloud/12/x86_64
+                                       {{ '-r ' ~ suse_subscription_id if suse_subscription_id | default('') | length > 0 else '' }}
       register:                        cloud_extension
   rescue:
     - name:                            "1.4 Packages - SUSE12 - Wait 10 secs before retrying"
       ansible.builtin.wait_for:
         timeout:                       10
     - name:                            "1.4 Packages - SUSE12 - Activate public cloud extension ({{ ansible_distribution_major_version }})"
-      ansible.builtin.command: |
+      ansible.builtin.command: >-
                                        SUSEConnect -p sle-module-public-cloud/12/x86_64
+                                       {{ '-r ' ~ suse_subscription_id if suse_subscription_id | default('') | length > 0 else '' }}
       register:                        cloud_extension
 
 # SUSE 15 Activate public cloud extension
@@ -34,8 +36,9 @@
     - tier == 'os'
   block:
     - name:                            "1.4 Packages - SUSE15 - Activate public cloud extension ({{ ansible_distribution_major_version }})"
-      ansible.builtin.command: |
+      ansible.builtin.command: >-
                                        SUSEConnect -p sle-module-public-cloud/{{ ansible_distribution_version }}/x86_64
+                                       {{ '-r ' ~ suse_subscription_id if suse_subscription_id | default('') | length > 0 else '' }}
       register:                        cloud_extension
       environment:
         ZYPP_LOCK_TIMEOUT:              "60"
@@ -45,8 +48,9 @@
       ansible.builtin.wait_for:
         timeout:                       10
     - name:                            "1.4 Packages - SUSE15 - Activate public cloud extension ({{ ansible_distribution_major_version }})"
-      ansible.builtin.command: |
+      ansible.builtin.command: >-
                                        SUSEConnect -p sle-module-public-cloud/{{ ansible_distribution_version }}/x86_64
+                                       {{ '-r ' ~ suse_subscription_id if suse_subscription_id | default('') | length > 0 else '' }}
       register:                        cloud_extension
 
 # /*----------------------------------------------------------------------------8

--- a/deploy/ansible/vars/ansible-input-api.yaml
+++ b/deploy/ansible/vars/ansible-input-api.yaml
@@ -17,6 +17,7 @@ SDAF_Version:                           "3.17.0.1"
 chrony_pool:                            ""
 chrony_servers:                         []
 timezone:                               "Etc/GMT"
+suse_subscription_id:                   ""                                      # SUSE registration code for BYOS/BYOL images. Leave empty for PAYG marketplace images.
 # -------------------- End - OS Config Settings variables --------------------8
 
 # --------------------- Begin - BOM Processing variables ---------------------8

--- a/deploy/terraform/run/sap_system/module.tf
+++ b/deploy/terraform/run/sap_system/module.tf
@@ -474,6 +474,7 @@ module "output_files" {
   #########################################################################################
   use_simple_mount                              = local.validated_use_simple_mount
   upgrade_packages                              = var.upgrade_packages
+  suse_subscription_id                          = var.suse_subscription_id
   scale_out                                     = var.database_HANA_use_scaleout_scenario
   scale_out_no_standby_role                     = var.database_HANA_no_standby_role
 

--- a/deploy/terraform/run/sap_system/tfvar_variables.tf
+++ b/deploy/terraform/run/sap_system/tfvar_variables.tf
@@ -1595,6 +1595,11 @@ variable "upgrade_packages"                     {
                                                   default     = false
                                                 }
 
+variable "suse_subscription_id"                  {
+                                                  description = "If defined, the SUSE registration code for BYOS/BYOL images. Leave empty for PAYG marketplace images."
+                                                  default     = ""
+                                                }
+
 variable "tags"                                 {
                                                   description = "If provided, tags for all resources"
                                                   default     = {}

--- a/deploy/terraform/terraform-units/modules/sap_system/output_files/inventory.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/output_files/inventory.tf
@@ -256,6 +256,7 @@ resource "local_file" "sap-parameters_yml" {
               subnet_cidr_db              = trimspace(coalesce(var.subnet_cidr_db," ")),
               subnet_cidr_storage         = trimspace(coalesce(var.subnet_cidr_storage," ")),
               upgrade_packages            = var.upgrade_packages ? "true" : "false"
+              suse_subscription_id        = var.suse_subscription_id
               use_msi_for_clusters        = var.use_msi_for_clusters
               usr_sap                     = length(var.usr_sap) > 1 ? (
                                               format("usr_sap_mountpoint:            %s", var.usr_sap)) : (

--- a/deploy/terraform/terraform-units/modules/sap_system/output_files/sap-parameters.tmpl
+++ b/deploy/terraform/terraform-units/modules/sap_system/output_files/sap-parameters.tmpl
@@ -176,6 +176,9 @@ secret_prefix:                 ${secret_prefix}
 # Set to true to instruct Ansible to update all the packages on the virtual machines
 upgrade_packages:              ${upgrade_packages}
 
+# SUSE registration code for BYOS/BYOL images. Leave empty for PAYG marketplace images.
+suse_subscription_id:          ${suse_subscription_id}
+
 ${settings}
 
 #############################################################################

--- a/deploy/terraform/terraform-units/modules/sap_system/output_files/variables_global.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/output_files/variables_global.tf
@@ -193,6 +193,10 @@ variable "sid_keyvault_user_id"                 { description = "Defines the nam
 variable "subnet_cidr_storage"                { description = "address prefix for the storage subnet" }
 variable "tfstate_resource_id"                  { description = "Resource ID for tf state file" }
 variable "upgrade_packages"                     { description = "Upgrade packages" }
+variable "suse_subscription_id"                  {
+                                                  description = "SUSE registration code for BYOS/BYOL images"
+                                                  default     = ""
+                                                }
 variable "use_custom_dns_a_registration"        {
                                                   description = "Boolean value indicating if a custom dns a record should be created when using private endpoints"
                                                   default     = false


### PR DESCRIPTION
This pull request introduces support for handling both BYOS/BYOL (Bring Your Own Subscription/License) and PAYG (Pay-As-You-Go) registration flows for SUSE Linux systems in the deployment automation. It adds a new variable, `suse_subscription_id`, which allows users to specify a SUSE registration code for BYOS/BYOL images, while leaving it empty for PAYG marketplace images. The Ansible and Terraform code is updated to use this variable, ensuring the correct registration path is followed and improving error handling for both scenarios.

Key changes grouped by theme:

**SUSE Registration Logic and Ansible Improvements:**

* Refactored the SUSE registration process in `1.3.0-preparation-Suse.yaml` to support both BYOS/BYOL (using `suse_subscription_id`) and PAYG (no registration code) paths, with enhanced error handling and verification steps for each scenario. [[1]](diffhunk://#diff-421c1f8760081f47970b37e3834b022511ce0234b24ac522321cc343f88f61a3L26-R69) [[2]](diffhunk://#diff-421c1f8760081f47970b37e3834b022511ce0234b24ac522321cc343f88f61a3L47-R99)
* Updated SUSE public cloud extension activation tasks in `1.4.0-packages-Suse-prep.yaml` to use the registration code when provided, supporting both SUSE 12 and 15. [[1]](diffhunk://#diff-9d233c75314cd6b43a776a14a52dab469fd8dc95567080433f0bd53dcc934a60L18-R29) [[2]](diffhunk://#diff-9d233c75314cd6b43a776a14a52dab469fd8dc95567080433f0bd53dcc934a60L37-R41) [[3]](diffhunk://#diff-9d233c75314cd6b43a776a14a52dab469fd8dc95567080433f0bd53dcc934a60L48-R53)

**Variable and Template Propagation:**

* Introduced the `suse_subscription_id` variable in Ansible defaults and Terraform variable files, with documentation clarifying its use for BYOS/BYOL and PAYG images. [[1]](diffhunk://#diff-d9cca76007a90a0df0f87ef6d5e920c391d2df8098b98ff3bcd324088b4e3918R20) [[2]](diffhunk://#diff-9f378baec8c5d4b8f375f7ac7ff5ae530a9d76e2e44db65e5b274cf56e67fdf5R1598-R1602) [[3]](diffhunk://#diff-4d44d12e94d786ead6ecc1068318466440f4b2162be8bfb3afceff73538a8a75R196-R199)
* Propagated the `suse_subscription_id` variable through Terraform modules and output templates, ensuring it is available to Ansible and included in generated configuration files. [[1]](diffhunk://#diff-f308feab46874404e1d0e929889f9151c802de5e378849f89cc90a9f25605397R477) [[2]](diffhunk://#diff-cc4cb007e96fe313cba3d8b0733cf8cbb3d5e9d1c3d1a72316b2786d1f3585daR259) [[3]](diffhunk://#diff-bb4bb05b8da6e4433c6dda2973aa5451ed4da2ba91b10c540f9636f233df04c1R179-R181)