### PR TITLE
Feature/january/aznfs

### DIFF
--- a/.github/workflows/github-actions-ansible-lint.yml
+++ b/.github/workflows/github-actions-ansible-lint.yml
@@ -33,7 +33,7 @@ jobs:
           ansible-galaxy collection install ansible.utils --force
           ansible-galaxy collection install ansible.netcommon:5.1.2 --force
           ansible-galaxy collection install community.windows --force
-          ansible-galaxy collection install community.general --force
+          ansible-galaxy collection install community.general:11.4.1 --force
           ansible-galaxy collection install microsoft.ad --force
 
       - name: Run ansible-lint

--- a/Webapp/SDAF/Models/LandscapeModel.cs
+++ b/Webapp/SDAF/Models/LandscapeModel.cs
@@ -19,7 +19,7 @@ namespace SDAFWebApp.Models
                 network_logical_name != null
                 ;
         }
-        
+
         [DisplayName("Workload zone ID")]
         public string Id { get; set; }
 
@@ -352,6 +352,8 @@ namespace SDAFWebApp.Models
         public bool? use_AFS_for_installation_media { get; set; } = true;
 
         public bool? use_AFS_for_shared_storage { get; set; } = true;
+
+        public bool? AFS_enable_encryption_in_transit { get; set; } = true;
 
         public bool? create_transport_storage { get; set; } = true;
 

--- a/Webapp/SDAF/ParameterDetails/LandscapeDetails.json
+++ b/Webapp/SDAF/ParameterDetails/LandscapeDetails.json
@@ -1074,6 +1074,15 @@
         "Display": 2
       },
       {
+        "Name": "AFS_enable_encryption_in_transit",
+        "Required": false,
+        "Description": "Defines if encryption in transit is enabled for Azure Files.",
+        "Type": "checkbox",
+        "Options": [],
+        "Overrules": "",
+        "Display": 2
+      },
+      {
         "Name": "create_transport_storage",
         "Required": false,
         "Description": "Defines if the workload zone will host storage for the transport data.",

--- a/Webapp/SDAF/ParameterDetails/LandscapeTemplate.txt
+++ b/Webapp/SDAF/ParameterDetails/LandscapeTemplate.txt
@@ -474,6 +474,9 @@ $$NFS_provider$$
 # use_AFS_for_shared_storage defines if shared media is on AFS even when using ANF for data
 $$use_AFS_for_shared_storage$$
 
+# Defines if encryption in transit is enabled for AFS on NFS shares
+$$AFS_enable_encryption_in_transit$$
+
 #########################################################################################
 #                                                                                       #
 #  Azure NetApp files support                                                           #

--- a/deploy/ansible/roles-os/1.1-swap/files/88-azure-nvme-swap-conf
+++ b/deploy/ansible/roles-os/1.1-swap/files/88-azure-nvme-swap-conf
@@ -1,0 +1,170 @@
+#!/bin/bash
+
+# Script requirements:
+#   nvme-cli
+#   mdadm
+#   gdisk
+
+readonly USAGE="Usage: $(basename "$0") <filesystem> <filesystem mount point (optional)>"
+
+# Label used to identify the NVMe array file system and associated disks
+# Can't exceed 16 characters
+readonly RAID0_FILESYSTEM_LABEL="azure_nvme_temp"
+# Device path used for the RAID 0 NVMe array
+# Choose any unoccupied device path of format /dev/mdX (X = 0 to 99)
+readonly RAID0_DEVICE_PATH="/dev/md0"
+# Formatted RAID 0 partition is mounted here
+readonly DEFAULT_MOUNT_POINT="/mnt/${RAID0_FILESYSTEM_LABEL}"
+
+filesystem="$1"
+if [ ! "$filesystem" ]; then
+    printf "No filesystem specified. Usage: $USAGE\n"
+    exit 1
+fi
+if ! [ -x "$(command -v mkfs.$filesystem)" ]; then
+    printf "Filesystem \"$filesystem\" not supported by mkfs\n$USAGE\n"
+    exit 1
+fi
+
+mount_point="$2"
+if [ ! "$mount_point" ]; then
+    printf "No mount point specified. Using default: $DEFAULT_MOUNT_POINT\n"
+    mount_point=$DEFAULT_MOUNT_POINT
+fi
+
+# Make sure mdadm.conf is present
+mdadm_conf_path=""
+if [ -e "/etc/mdadm/mdadm.conf" ]; then
+    mdadm_conf_path="/etc/mdadm/mdadm.conf"
+elif [ -e "/etc/mdadm.conf" ]; then
+    mdadm_conf_path="/etc/mdadm.conf"
+else
+    printf "Couldn't find mdadm.conf file"
+    exit 1
+fi
+
+# Enumerate unmounted NVMe direct disks
+devices=$(lsblk -p -o NAME,TYPE,MOUNTPOINT | grep "nvme" | awk '$2 == "disk" && $3 == "" {print $1}')
+nvme_direct_disks=()
+for device in $devices
+do
+    if nvme id-ctrl "$device" | grep -q "Microsoft NVMe Direct Disk"; then
+        nvme_direct_disks+=("$device")
+    fi
+done
+nvme_direct_disk_count=${#nvme_direct_disks[@]}
+printf "Found $nvme_direct_disk_count NVMe Direct Disks\n"
+
+# Check if there's already an NVMe Direct Disk RAID 0 disk (or remnant data)
+if grep "$RAID0_FILESYSTEM_LABEL" /etc/fstab > /dev/null; then
+    fstab_entry_present=true
+fi
+if grep "$RAID0_FILESYSTEM_LABEL" $mdadm_conf_path > /dev/null; then
+    mdadm_conf_entry_present=true
+fi
+if [ -e $RAID0_DEVICE_PATH ]; then
+    nvme_raid0_present=true
+fi
+if [ "$fstab_entry_present" = true ] || [ "$mdadm_conf_entry_present" = true ] || [ "$nvme_raid0_present" = true ]; then
+    # Check if the RAID 0 volume and associated configurations are still intact or need to be reinitialized
+    #
+    # If reinitialization is needed, clear the old RAID 0 information and associated files
+
+    reinit_raid0=false
+    if [ "$fstab_entry_present" = true ] && [ "$mdadm_conf_entry_present" = true ] && [ "$nvme_raid0_present" = true ]; then
+        # Check RAID 0 device status
+        if ! mdadm --detail --test $RAID0_DEVICE_PATH &> /dev/null; then
+            reinit_raid0=true
+        # Test the NVMe direct disks for valid mdadm superblocks
+        else
+            for device in "${nvme_direct_disks[@]}"
+            do
+                if ! mdadm --examine $device &> /dev/null; then
+                    reinit_raid0=true
+                    break
+                fi
+            done
+        fi
+    else
+        reinit_raid0=true
+    fi
+
+    if [ "$reinit_raid0" = true ]; then
+        echo "Errors found in NVMe RAID 0 temp array device or configuration. Reinitializing."
+
+        # Remove the file system and partition table, and stop the RAID 0 array
+        if [ "$nvme_raid0_present" = true ]; then
+            if [ -e ${RAID0_DEVICE_PATH}p1 ]; then
+                umount ${RAID0_DEVICE_PATH}p1
+                wipefs -a -f ${RAID0_DEVICE_PATH}p1
+            fi
+            sgdisk -o $RAID0_DEVICE_PATH &> /dev/null
+            mdadm --stop $RAID0_DEVICE_PATH
+        fi
+
+        # Remove any mdadm metadata from all NVMe Direct Disks
+        for device in "${nvme_direct_disks[@]}"
+        do
+            printf "Clearing mdadm superblock from $device\n"
+            mdadm --zero-superblock $device &> /dev/null
+        done
+
+        # Remove any associated entries in fstab and mdadm.conf
+        sed -i.bak "/$RAID0_FILESYSTEM_LABEL/d" /etc/fstab
+        sed -i.bak "/$RAID0_FILESYSTEM_LABEL/d" $mdadm_conf_path
+    else
+        printf "Valid NVMe RAID 0 array present and no additional Direct Disks found. Skipping\n"
+        exit 0
+    fi
+fi
+
+if [ "$nvme_direct_disk_count" -eq 0 ]; then
+    printf "No NVMe Direct Disks found\n"
+    exit 1
+elif [ "$nvme_direct_disk_count" -eq 1 ]; then
+    additional_mdadm_params="--force"
+fi
+
+# Initialize enumerated disks as RAID 0
+printf "Creating RAID 0 array from:\n"
+printf "${nvme_direct_disks[*]}\n\n"
+if ! mdadm --create $RAID0_DEVICE_PATH --verbose $additional_mdadm_params --name=$RAID0_FILESYSTEM_LABEL --level=0 --raid-devices=$nvme_direct_disk_count ${nvme_direct_disks[*]}; then
+    printf "Failed to create RAID 0 array\n"
+    exit 1
+fi
+
+# Create a GPT partition entry
+readonly GPT_PARTITION_TYPE_GUID="0FC63DAF-8483-4772-8E79-3D69D8477DE4"
+printf "\nCreating GPT on $RAID0_DEVICE_PATH..\n"
+sgdisk -o $RAID0_DEVICE_PATH &> /dev/null
+if ! sgdisk --new 1::0 --typecode 1:$GPT_PARTITION_TYPE_GUID $RAID0_DEVICE_PATH  &> /dev/null; then
+    printf "Failed to create partition on $RAID0_DEVICE_PATH\n"
+    exit 1
+fi
+
+# Format the partition
+partition_path="${RAID0_DEVICE_PATH}p1"
+printf "\nCreating $filesystem filesystem..\n"
+if ! mkfs.$filesystem -q -L $RAID0_FILESYSTEM_LABEL $partition_path; then
+    printf "Failed to create $filesystem filesystem\n"
+    exit 1
+fi
+printf "The operation has completed successfully.\n"
+
+# Add the partition to /etc/fstab
+echo "LABEL=$RAID0_FILESYSTEM_LABEL $mount_point $filesystem defaults,nofail 0 0" >> /etc/fstab
+
+# Add RAID 0 array to mdadm.conf
+mdadm --detail --scan >> $mdadm_conf_path
+update-initramfs -u
+
+# Mount the partition
+printf "\nMounting filesystem to $mount_point..\n"
+mkdir $mount_point &> /dev/null
+if ! mount -a; then
+    printf "Failed to automount partition\n"
+    exit 1
+fi
+printf "The operation has completed successfully.\n"
+
+exit 0

--- a/deploy/ansible/roles-os/1.1-swap/files/88-azure-nvme-swap-conf
+++ b/deploy/ansible/roles-os/1.1-swap/files/88-azure-nvme-swap-conf
@@ -156,7 +156,24 @@ echo "LABEL=$RAID0_FILESYSTEM_LABEL $mount_point $filesystem defaults,nofail 0 0
 
 # Add RAID 0 array to mdadm.conf
 mdadm --detail --scan >> $mdadm_conf_path
-update-initramfs -u
+# Update initramfs to include the new mdadm configuration for OS other than RHEL/OracleLinux
+if ! grep -E "ID=RHEL|ID=\"OracleLinux\"" /etc/os-release > /dev/null; then
+    printf "\nUpdating initramfs with new mdadm configuration..\n"
+    update-initramfs -u
+    if [ $? -ne 0 ]; then
+        printf "Failed to update initramfs\n"
+        exit 1
+    fi
+    printf "The operation has completed successfully.\n"
+elif grep -E "ID=RHEL|ID=\"OracleLinux\"" /etc/os-release > /dev/null;  then
+    printf "\nUpdating dracut with new mdadm configuration..\n"
+    dracut -f
+    if [ $? -ne 0 ]; then
+        printf "Failed to update initramfs\n"
+        exit 1
+    fi
+    printf "The operation has completed successfully.\n"
+fi
 
 # Mount the partition
 printf "\nMounting filesystem to $mount_point..\n"

--- a/deploy/ansible/roles-os/1.1-swap/tasks/main.yaml
+++ b/deploy/ansible/roles-os/1.1-swap/tasks/main.yaml
@@ -71,6 +71,34 @@
     msg:                               "Swap size: {{ swap_size }}"
     verbosity:                         2
 
+- name:                                "1.1 Swap - Configure NVMe VMs for Swap"
+  when:                                use_nvme_disks and swap_size == 0
+  block:
+    # copy nvme disk config script for temporary disks
+    - name:                            "1.1 Swap - Create Azure NVMe temp disk configuration helper script"
+      ansible.builtin.copy:
+        src:                           88-azure-nvme-swap-conf
+        dest:                          /usr/local/bin/azure-nvme-swap-conf
+        mode:                          '0755'
+        owner:                         root
+        group:                         root
+        force:                         true
+      register:                        helper_script_created
+
+    # touch /etc/mdadm/mdadm.conf to avoid errors in the script
+    - name:                            "1.1 Swap - Ensure /etc/mdadm/mdadm.conf exists"
+      ansible.builtin.file:
+        path:                          /etc/mdadm/mdadm.conf
+        mode:                          '0644'
+        state:                         touch
+      when:                            helper_script_created is changed
+
+    # run the nvme disk config script
+    - name:                            "1.1 Swap - Run Azure NVMe temp disk configuration helper script"
+      ansible.builtin.command:         /usr/local/bin/azure-nvme-swap-conf
+      register:                        nvme_swap_configured
+      changed_when:                    nvme_swap_configured.rc == 0 and "'No changes were necessary' not in nvme_swap_configured.stdout"
+
 - name:                                "1.1 Swap - Check for (waagent_conf)"
   ansible.builtin.stat:
     path:                              /etc/waagent.conf

--- a/deploy/ansible/roles-os/1.1-swap/tasks/main.yaml
+++ b/deploy/ansible/roles-os/1.1-swap/tasks/main.yaml
@@ -95,7 +95,7 @@
 
     # run the nvme disk config script
     - name:                            "1.1 Swap - Run Azure NVMe temp disk configuration helper script"
-      ansible.builtin.command:         /usr/local/bin/azure-nvme-swap-conf
+      ansible.builtin.command:         /usr/local/bin/azure-nvme-swap-conf ext4 /mnt/resource
       register:                        nvme_swap_configured
       changed_when:                    nvme_swap_configured.rc == 0 and "'No changes were necessary' not in nvme_swap_configured.stdout"
 

--- a/deploy/ansible/roles-os/1.3-repository/tasks/1.3.4-eit-setup-RedHat.yaml
+++ b/deploy/ansible/roles-os/1.3-repository/tasks/1.3.4-eit-setup-RedHat.yaml
@@ -1,0 +1,69 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+---
+# Azure Files NFS Encryption in Transit requires:
+# - RHEL for SAP 8.8, 8.10, 9.x and higher
+# - Microsoft packages repository
+# - aznfs package
+
+- name:                                "1.3.4 EiT - RHEL - Validate OS version meets minimum requirements"
+  block:
+    - name:                            "1.3.4 EiT - RHEL - Parse RHEL version"
+      ansible.builtin.set_fact:
+        rhel_major:                    "{{ ansible_distribution_version.split('.')[0] | int }}"
+        rhel_minor:                    "{{ ansible_distribution_version.split('.')[1] | int if ansible_distribution_version.split('.') | length > 1 else 0 | int }}"
+
+    - name:                            "1.3.4 EiT - RHEL - Validate version requirements"
+      when:
+                                       - rhel_major | int < 8
+                                       - (rhel_major | int == 8 and rhel_minor | int < 8)
+                                       - (rhel_major | int == 8 and rhel_minor | int == 9)
+                                       - (rhel_major | int == 8 and rhel_minor | int > 10)
+      ansible.builtin.fail:
+        msg: |
+                                       Azure Files NFS Encryption in Transit requires:
+                                       - RHEL 8.8, 8.10, or
+                                       - RHEL 9.0 and higher
+                                       Current version: {{ ansible_distribution }} {{ ansible_distribution_version }}
+
+- name:                                "1.3.4 EiT - RHEL - Download Microsoft packages repository RPM"
+  ansible.builtin.get_url:
+    url:                               "https://packages.microsoft.com/config/{{ ansible_distribution | lower }}/{{ ansible_distribution_version.split('.')[0] }}/packages-microsoft-prod.rpm"
+    dest:                              "/tmp/packages-microsoft-prod.rpm"
+    mode:                              '0644'
+  register:                            ms_repo_download
+  retries:                             4
+  delay:                               30
+  until:                               ms_repo_download is succeeded
+
+- name:                                "1.3.4 EiT - RHEL - Install Microsoft packages repository"
+  ansible.builtin.dnf:
+    name:                              "/tmp/packages-microsoft-prod.rpm"
+    state:                             present
+    disable_gpg_check:                 true
+  register:                            ms_repo_install
+
+- name:                                "1.3.4 EiT - RHEL - Update dnf cache"
+  ansible.builtin.dnf:
+    update_cache:                      true
+  when:                                ms_repo_install is changed
+  changed_when:                        false
+
+- name:                                "1.3.4 EiT - RHEL - Install aznfs package"
+  ansible.builtin.dnf:
+    name:                              aznfs
+    state:                             present
+  register:                            aznfs_install
+
+- name:                                "1.3.4 EiT - RHEL - Cleanup temporary repository RPM"
+  ansible.builtin.file:
+    path:                              "/tmp/packages-microsoft-prod.rpm"
+    state:                             absent
+
+- name:                                "1.3.4 EiT - RHEL - Display installation result"
+  ansible.builtin.debug:
+    msg:
+      - "Microsoft repository installed: {{ ms_repo_install is changed }}"
+      - "aznfs package installed: {{ aznfs_install is changed }}"
+    verbosity: 2

--- a/deploy/ansible/roles-os/1.3-repository/tasks/1.3.4-eit-setup-Suse.yaml
+++ b/deploy/ansible/roles-os/1.3-repository/tasks/1.3.4-eit-setup-Suse.yaml
@@ -1,0 +1,65 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+---
+# Azure Files NFS Encryption in Transit requires:
+# - SLES for SAP 15 SP4 and higher
+# - Microsoft packages repository
+# - aznfs package
+
+- name:                                "1.3.4 EiT - SUSE - Validate OS version meets minimum requirements"
+  block:
+    - name:                            "1.3.4 EiT - SUSE - Parse SLES version"
+      ansible.builtin.set_fact:
+        sles_major:                    "{{ ansible_distribution_version.split('.')[0] | int }}"
+        sles_minor:                    "{{ ansible_distribution_version.split('.')[1] | int if ansible_distribution_version.split('.') | length > 1 else 0 | int }}"
+
+    - name:                            "1.3.4 EiT - SUSE - Fail if OS version is not supported"
+      when:
+                                       - sles_major | int < 15 or (sles_major | int == 15 and sles_minor | int < 4)
+      ansible.builtin.fail:
+        msg: |
+                                       Azure Files NFS Encryption in Transit requires SLES for SAP 15 SP4 or higher.
+                                       Current version: {{ ansible_distribution }} {{ ansible_distribution_version }}
+                                       Minimum required: SLES 15.4
+
+- name:                                "1.3.4 EiT - SUSE - Download Microsoft packages repository RPM"
+  ansible.builtin.get_url:
+    url:                               "https://packages.microsoft.com/config/{{ ansible_distribution | lower }}/{{ ansible_distribution_version.split('.')[0] }}/packages-microsoft-prod.rpm"
+    dest:                              "/tmp/packages-microsoft-prod.rpm"
+    mode:                              '0644'
+  register:                            ms_repo_download
+  retries:                             4
+  delay:                               30
+  until:                               ms_repo_download is succeeded
+
+- name:                                "1.3.4 EiT - SUSE - Install Microsoft packages repository"
+  community.general.zypper:
+    name:                              "/tmp/packages-microsoft-prod.rpm"
+    state:                             present
+    disable_gpg_check:                 true
+  register:                            ms_repo_install
+
+- name:                                "1.3.4 EiT - SUSE - Refresh zypper repositories"
+  ansible.builtin.command:             zypper refresh
+  changed_when:                        false
+  when:                                ms_repo_install is changed
+
+- name:                                "1.3.4 EiT - SUSE - Install aznfs package"
+  community.general.zypper:
+    name:                              aznfs
+    state:                             present
+    update_cache:                      "{{ ms_repo_install is changed }}"
+  register:                            aznfs_install
+
+- name:                                "1.3.4 EiT - SUSE - Cleanup temporary repository RPM"
+  ansible.builtin.file:
+    path:                              "/tmp/packages-microsoft-prod.rpm"
+    state:                             absent
+
+- name:                                "1.3.4 EiT - SUSE - Display installation result"
+  ansible.builtin.debug:
+    msg:
+      - "Microsoft repository installed: {{ ms_repo_install is changed }}"
+      - "aznfs package installed: {{ aznfs_install is changed }}"
+    verbosity: 2

--- a/deploy/ansible/roles-os/1.3-repository/tasks/main.yaml
+++ b/deploy/ansible/roles-os/1.3-repository/tasks/main.yaml
@@ -132,4 +132,18 @@
     - custom_repos_for_tier is defined
     - ansible_os_family | upper != 'SUSE'
 
+- name:                                "1.3 Repository - Setup Azure Files NFS Encryption in Transit (SUSE)"
+  when:
+                                       - use_eit_for_afs | default(false) | bool
+                                       - ansible_os_family | upper == 'SUSE'
+                                       - node_tier == 'ha'
+  ansible.builtin.include_tasks:       "1.3.4-eit-setup-Suse.yaml"
+
+
+- name:                                "1.3 Repository - Setup Azure Files NFS Encryption in Transit (RHEL)"
+  ansible.builtin.include_tasks:       "1.3.4-eit-setup-RedHat.yaml"
+  when:
+                                       - use_eit_for_afs | default(false) | bool
+                                       - ansible_os_family | upper == 'REDHAT'
+                                       - node_tier == 'ha'
 ...

--- a/deploy/ansible/roles-os/1.4-packages/vars/os-packages.yaml
+++ b/deploy/ansible/roles-os/1.4-packages/vars/os-packages.yaml
@@ -211,6 +211,7 @@ packages:
     - { tier: 'os',     package: 'NetworkManager-cloud-setup',                   node_tier: 'all',            state: 'present' }
     - { tier: 'ha',     package: 'NetworkManager-cloud-setup',                   node_tier: 'all',            state: 'absent'  }
   redhat8.8:
+    - { tier: 'os',     package: 'aznfs',                                        node_tier: 'all',            state: 'present' }
     - { tier: 'os',     package: 'NetworkManager-cloud-setup',                   node_tier: 'all',            state: 'present' }
     - { tier: 'iscsi',  package: 'targetcli',                                    node_tier: 'iscsi',          state: 'present' }
     - { tier: 'ha',     package: 'NetworkManager-cloud-setup',                   node_tier: 'all',            state: 'absent'  }
@@ -219,6 +220,7 @@ packages:
     - { tier: 'iscsi',  package: 'targetcli',                                    node_tier: 'iscsi',          state: 'present' }
     - { tier: 'ha',     package: 'NetworkManager-cloud-setup',                   node_tier: 'all',            state: 'absent'  }
   redhat8.10:
+    - { tier: 'os',     package: 'aznfs',                                        node_tier: 'all',            state: 'present' }
     - { tier: 'os',     package: 'NetworkManager-cloud-setup',                   node_tier: 'all',            state: 'present' }
     - { tier: 'iscsi',  package: 'targetcli',                                    node_tier: 'iscsi',          state: 'present' }
     - { tier: 'ha',     package: 'NetworkManager-cloud-setup',                   node_tier: 'all',            state: 'absent'  }
@@ -275,6 +277,8 @@ packages:
     - { tier: 'os',     package: 'sudo',                                         node_tier: 'all',            state: 'present' }
     - { tier: 'os',     package: 'sysstat',                                      node_tier: 'all',            state: 'present' }
     - { tier: 'os',     package: 'tcsh',                                         node_tier: 'all',            state: 'present' }
+    - { tier: 'os',     package: 'aznfs',                                        node_tier: 'all',            state: 'present' }
+    # - { tier: 'os',     package: 'unar',                                         node_tier: 'scs',            state: 'present' }
     - { tier: 'os',     package: 'xfsprogs',                                     node_tier: 'all',            state: 'present' }
     # --------------------------- Begin - Packages required for DB2 -----------------------------------------8
     # https://www.ibm.com/docs/en/db2/11.5?topic=servers-linux
@@ -372,6 +376,7 @@ packages:
     - { tier: 'os',     package: 'sg3_utils',                                    node_tier: 'all',            state: 'present' }
     - { tier: 'os',     package: 'sudo',                                         node_tier: 'all',            state: 'present' }
     - { tier: 'os',     package: 'tcsh',                                         node_tier: 'all',            state: 'present' }
+    - { tier: 'os',     package: 'aznfs',                                        node_tier: 'all',            state: 'present' }
     # - { tier: 'os',     package: 'unar',                                         node_tier: 'scs',            state: 'present' }
     - { tier: 'os',     package: 'xfsprogs',                                     node_tier: 'all',            state: 'present' }
     - { tier: 'iscsi',  package: 'targetcli',                                    node_tier: 'iscsi',          state: 'present' }
@@ -511,7 +516,7 @@ packages:
     - { tier: 'os',     package: 'libstdc++.so.6',                               node_tier: 'db2',            state: 'present' }
     - { tier: 'os',     package: 'unzip',                                        node_tier: 'db2',            state: 'present' }
     - { tier: 'os',     package: 'libpam.so.0',                                  node_tier: 'db2',            state: 'present' }
-    - { tier: 'db2',    package: 'acl',                                          node_tier: 'db2',             state: 'present' }
+    - { tier: 'db2',    package: 'acl',                                          node_tier: 'db2',            state: 'present' }
     # --------------------------- End - Packages required for DB2 -------------------------------------------8
     - { tier: 'os',     package: 'cloud-regionsrv-client',                       node_tier: 'all',            state: 'present' }
     - { tier: 'os',     package: 'cloud-regionsrv-client-plugin-azure',          node_tier: 'all',            state: 'present' }
@@ -593,6 +598,7 @@ packages:
   sles_sap15.4:
     #  - { tier: 'os',     package: 'sle-module-public-cloud',                                  state: 'present' }
     - { tier: 'os',     package: 'python3-xml',                                  node_tier: 'all',            state: 'present' }
+    - { tier: 'os',     package: 'aznfs',                                        node_tier: 'all',            state: 'present' }
     #  SLES15 SP4 has removed python 2, no python2-rpm package. Additionally, python-xml is now part of
     # python-base and referenced as python3-xml
     - { tier: 'db2',    package: 'system-user-bin',                              node_tier: 'db2',            state: 'present' }
@@ -607,6 +613,7 @@ packages:
     - { tier: 'os',     package: 'azure-vm-utils',                               node_tier: 'all',            state: 'present' }
     #  SLES15 SP4 has removed python 2, no python2-rpm package. Additionally, python-xml is now part of
     # python-base and referenced as python3-xml
+    - { tier: 'os',     package: 'aznfs',                                        node_tier: 'all',            state: 'present' }
     - { tier: 'db2',    package: 'system-user-bin',                              node_tier: 'db2',            state: 'present' }
     - { tier: 'ha',     package: 'sapstartsrv-resource-agents',                  node_tier: 'scs',            state: 'present' }
     - { tier: 'ha',     package: 'sapstartsrv-resource-agents',                  node_tier: 'ers',            state: 'present' }
@@ -620,9 +627,10 @@ packages:
     - { tier: 'os',     package: 'python3-xml',                                  node_tier: 'all',            state: 'present' }
     - { tier: 'os',     package: 'python3-rpm',                                  node_tier: 'all',            state: 'present' }
     - { tier: 'os',     package: 'azure-vm-utils',                               node_tier: 'all',            state: 'present' }
+    - { tier: 'os',     package: 'aznfs',                                        node_tier: 'all',            state: 'present' }
     #  SLES15 SP4 has removed python 2, no python2-rpm package. Additionally, python-xml is now part of
     # python-base and referenced as python3-xml
-    - { tier: 'db2',    package: 'system-user-bin',                              node_tier: 'db2',             state: 'present' }
+    - { tier: 'db2',    package: 'system-user-bin',                              node_tier: 'db2',            state: 'present' }
     - { tier: 'ha',     package: 'sapstartsrv-resource-agents',                  node_tier: 'scs',            state: 'present' }
     - { tier: 'ha',     package: 'sapstartsrv-resource-agents',                  node_tier: 'ers',            state: 'present' }
     # These package cause issues on SLES15 SP5 due to changes to the public cloud SDKs
@@ -634,7 +642,8 @@ packages:
     - { tier: 'os',     package: 'python3-xml',                                  node_tier: 'all',            state: 'present' }
     - { tier: 'os',     package: 'python3-rpm',                                  node_tier: 'all',            state: 'present' }
     - { tier: 'os',     package: 'azure-vm-utils',                               node_tier: 'all',            state: 'present' }
-    - { tier: 'db2',    package: 'system-user-bin',                              node_tier: 'db2',             state: 'present' }
+    - { tier: 'os',     package: 'aznfs',                                        node_tier: 'all',            state: 'present' }
+    - { tier: 'db2',    package: 'system-user-bin',                              node_tier: 'db2',            state: 'present' }
     - { tier: 'ha',     package: 'sapstartsrv-resource-agents',                  node_tier: 'scs',            state: 'present' }
     - { tier: 'ha',     package: 'sapstartsrv-resource-agents',                  node_tier: 'ers',            state: 'present' }
     - { tier: 'ha',     package: 'fence-agents-azure-arm',                       node_tier: 'scs',            state: 'present' }

--- a/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.0-afs-mounts.yaml
+++ b/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.0-afs-mounts.yaml
@@ -19,6 +19,7 @@
         'pas_inst_no': '{{ pas_instance_number }}',
         'app_inst_no': '{{ app_instance_number }}'
       }
+    nfs_fs_type:                       "{% if use_eit_for_afs %}'aznfs'{% else %}'nfs4'{% endif %}"
 
 - name:                                "2.6.0 AFS Mounts - Create list of all_sap_mounts to support "
   ansible.builtin.set_fact:
@@ -33,7 +34,11 @@
 
 - name:                                "2.6.0 AFS Mounts - Set the NFSmount options"
   ansible.builtin.set_fact:
-    afs_mnt_options:                   'noresvport,vers=4,minorversion=1,sec=sys'
+    afs_mnt_options: |-
+                                       {% if use_eit_for_afs %}
+                                       'noresvport,vers=4,minorversion=1,sec=sys,nolock,proto=tcp,nofail,_netdev'
+                                       {% else %}
+                                       'noresvport,vers=4,minorversion=1,sec=sys'
 
 - name:                                "2.6.0 AFS Mounts - Create list of all_sap_mounts to support"
   ansible.builtin.debug:
@@ -94,7 +99,7 @@
               ansible.posix.mount:
                 src:                   "{{ sap_mnt }}"
                 path:                  "/saptmp"
-                fstype:                "nfs4"
+                fstype:                "{{ nfs_fs_type }}"
                 opts:                  "{{ afs_mnt_options }}"
                 state:                 mounted
 
@@ -111,7 +116,7 @@
               ansible.posix.mount:
                 src:                   "{{ sap_mnt }}"
                 path:                  "/saptmp"
-                fstype:                "nfs4"
+                fstype:                "{{ nfs_fs_type }}"
                 opts:                  "{{ afs_mnt_options }}"
                 state:                 mounted
 
@@ -163,7 +168,7 @@
           ansible.posix.mount:
             src:                       "{{ sap_mnt }}"
             path:                      "/saptmp"
-            fstype:                    "nfs4"
+            fstype:                    "{{ nfs_fs_type }}"
             opts:                      "{{ afs_mnt_options }}"
             state:                     absent
 
@@ -284,7 +289,7 @@
         opts:                          "{{ afs_mnt_options }}"
         state:                         mounted
       loop:
-        - { type: 'nfs4',  src: '{{ sap_mnt }}/sapmnt{{ sap_sid | upper }}',    path: '/sapmnt/{{ sap_sid | upper }}'      }
+        - { type: "{{ nfs_fs_type }}",  src: '{{ sap_mnt }}/sapmnt{{ sap_sid | upper }}',    path: '/sapmnt/{{ sap_sid | upper }}'      }
   rescue:
     - name:                            "2.6.0 AFS Mounts - sapmnt/{{ sap_sid | upper }} - Standalone"
       ansible.posix.mount:
@@ -294,7 +299,7 @@
         opts:                          "{{ afs_mnt_options }}"
         state:                         unmounted
       loop:
-        - { type: 'nfs4',  src: '{{ sap_mnt }}/sapmnt{{ sap_sid | upper }}',    path: '/sapmnt/{{ sap_sid | upper }}'      }
+        - { type: "{{ nfs_fs_type }}",  src: '{{ sap_mnt }}/sapmnt{{ sap_sid | upper }}',    path: '/sapmnt/{{ sap_sid | upper }}'      }
 
     - name:                            "2.6.0 AFS Mounts - Pause for 15 seconds"
       ansible.builtin.pause:
@@ -311,7 +316,7 @@
         opts:                          "{{ afs_mnt_options }}"
         state:                         mounted
       loop:
-        - { type: 'nfs4',  src: '{{ sap_mnt }}/sapmnt{{ sap_sid | upper }}',    path: '/sapmnt/{{ sap_sid | upper }}'      }
+        - { type: "{{ nfs_fs_type }}",  src: '{{ sap_mnt }}/sapmnt{{ sap_sid | upper }}',    path: '/sapmnt/{{ sap_sid | upper }}'      }
 
 
 - name:                                "2.6.0 AFS Mounts - sapmnt/{{ sap_sid | upper }} - Standalone MULTI_SIDS"
@@ -324,7 +329,7 @@
   ansible.posix.mount:
     src:                               "{{ sap_mnt }}/sapmnt{{ item.sid }}"
     path:                              "/sapmnt/{{ item.sid }}"
-    fstype:                            'nfs4'
+    fstype:                            "{{ nfs_fs_type }}"
     opts:                              "{{ afs_mnt_options }}"
     state:                             mounted
   loop:                                "{{ MULTI_SIDS }}"
@@ -340,7 +345,7 @@
       ansible.posix.mount:
         src:                           "{{ sap_mnt }}/sapmnt{{ sap_sid | upper }}"
         path:                          "/sapmnt/{{ sap_sid | upper }}"
-        fstype:                        nfs4
+        fstype:                        "{{ nfs_fs_type }}"
         opts:                          "{{ afs_mnt_options }}"
         state:                         mounted
   rescue:
@@ -351,7 +356,7 @@
       ansible.posix.mount:
         src:                           "{{ sap_mnt }}/sapmnt{{ sap_sid | upper }}"
         path:                          "/sapmnt/{{ sap_sid | upper }}"
-        fstype:                        nfs4
+        fstype:                        "{{ nfs_fs_type }}"
         opts:                          "{{ afs_mnt_options }}"
         state:                         mounted
 
@@ -371,7 +376,7 @@
         state:                         mounted
       register:                        sys_mounted
       loop:
-        - { type: 'nfs4',  src: '{{ sap_mnt }}/usrsap{{ sap_sid | upper }}sys', path: '/usr/sap/{{ sap_sid | upper }}/SYS' }
+        - { type: "{{ nfs_fs_type }}",  src: '{{ sap_mnt }}/usrsap{{ sap_sid | upper }}sys', path: '/usr/sap/{{ sap_sid | upper }}/SYS' }
   rescue:
     - name:                            "2.6.0 AFS Mounts - Pause for 15 seconds"
       ansible.builtin.pause:
@@ -393,7 +398,7 @@
         state:                         mounted
 
       loop:
-        - { type: 'nfs4',  src: '{{ sap_mnt }}/usrsap{{ sap_sid | upper }}sys', path: '/usr/sap/{{ sap_sid | upper }}/SYS' }
+        - { type: "{{ nfs_fs_type }}",  src: '{{ sap_mnt }}/usrsap{{ sap_sid | upper }}sys', path: '/usr/sap/{{ sap_sid | upper }}/SYS' }
   tags:
     - sap_app_ha_sys_mount
 

--- a/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.0.1-afs-mount.yaml
+++ b/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.0.1-afs-mount.yaml
@@ -38,7 +38,7 @@
           ansible.posix.mount:
             src:                       "{{ item.mount }}"
             path:                      "/{{ item.temppath }}"
-            fstype:                    "nfs4"
+            fstype:                    "{{ nfs_fs_type }}"
             opts:                      "{{ item.opts }}"
             state:                      mounted
       rescue:
@@ -53,7 +53,7 @@
           ansible.posix.mount:
             src:                       "{{ item.mount }}"
             path:                      "/{{ item.temppath }}"
-            fstype:                    "nfs4"
+            fstype:                    "{{ nfs_fs_type }}"
             opts:                      "{{ item.opts }}"
             state:                      mounted
 
@@ -79,7 +79,7 @@
       ansible.posix.mount:
         src:                           "{{ item.mount }}"
         path:                          "/{{ item.temppath }}"
-        fstype:                        "nfs4"
+        fstype:                        "{{ nfs_fs_type }}"
         opts:                          "{{ item.opts }}"
         state:                         absent
 
@@ -126,7 +126,7 @@
       ansible.posix.mount:
         src:                           "{% if item.create_temp_folders %}{{ item.mount }}/{{ item.folder }}{% else %}{{ item.mount }}{% endif %}"
         path:                          "{{ item.path }}"
-        fstype:                        "nfs4"
+        fstype:                        "{{ nfs_fs_type }}"
         opts:                          "{{ item.opts }}"
         state:                         mounted
   rescue:
@@ -138,6 +138,6 @@
       ansible.posix.mount:
         src:                           "{% if item.create_temp_folders %}{{ item.mount }}/{{ item.folder }}{% else %}{{ item.mount }}{% endif %}"
         path:                          "{{ item.path }}"
-        fstype:                        "nfs4"
+        fstype:                        "{{ nfs_fs_type }}"
         opts:                          "{{ item.opts }}"
         state:                         mounted

--- a/deploy/ansible/roles-sap/5.8-hanadb-scaleout-pacemaker/tasks/5.8.4.1-cluster-ScaleOut-RedHat.yml
+++ b/deploy/ansible/roles-sap/5.8-hanadb-scaleout-pacemaker/tasks/5.8.4.1-cluster-ScaleOut-RedHat.yml
@@ -40,7 +40,7 @@
         - ansible_distribution_major_version == "7"
       block:
         - name:                        "5.8 HANA Pacemaker Scale-out - Get existing cluster resources and constraints"
-          ansible.builtin.shell:       pcs resource show --full
+          ansible.builtin.shell:       pcs resource show
           register:                    existing_resources
           changed_when:                false
           failed_when:                 false
@@ -145,13 +145,13 @@
                                        - ansible_distribution_major_version in ["8", "9", "10"]
       block:
         - name:                        "5.8 HANA Pacemaker Scale-out - Get existing cluster resources and constraints"
-          ansible.builtin.shell:       pcs resource show --full
+          ansible.builtin.shell:       pcs resource config --output-format json
           register:                    existing_resources
           changed_when:                false
           failed_when:                 false
 
         - name:                        "5.8 HANA Pacemaker Scale-out - Get existing cluster constraints"
-          ansible.builtin.shell:       pcs constraint show --full
+          ansible.builtin.shell:       pcs constraint config --full
           register:                    existing_constraints
           changed_when:                false
           failed_when:                 false

--- a/deploy/ansible/roles-sap/5.8-hanadb-scaleout-pacemaker/tasks/5.8.4.1-cluster-ScaleOut-RedHat.yml
+++ b/deploy/ansible/roles-sap/5.8-hanadb-scaleout-pacemaker/tasks/5.8.4.1-cluster-ScaleOut-RedHat.yml
@@ -215,7 +215,7 @@
         - name:                        "5.8 HANA Pacemaker Scale-out - Ensure the order constraint for the SAP HANA Topology is configured"
           ansible.builtin.shell: >
                                        pcs constraint order SAPHanaTopology_{{ db_sid | upper }}_HDB{{ db_instance_number }}-clone \
-                                       then SAPHana_{{ db_sid | upper }}_HDB{{ db_instance_number }}-clone
+                                       then SAPHana_{{ db_sid | upper }}_HDB{{ db_instance_number }}-clone --force
           when:                        "'SAPHanaTopology_' + (db_sid | upper) + '_HDB' + db_instance_number + '-clone then start resource SAPHana_' + (db_sid | upper) + '_HDB' + db_instance_number + '-clone' not in existing_constraints.stdout"
           register:                    order
           failed_when:                 order.rc > 0
@@ -223,7 +223,7 @@
         - name:                        "5.8 HANA Pacemaker Scale-out - Ensure the Virtual IP group colocation constraint is configured"
           ansible.builtin.shell: >
                                        pcs constraint colocation add g_ip_{{ db_sid | upper }}_{{ db_instance_number }} \
-                                       with {{ pcs_sap_hana_role_prim }} SAPHana_{{ db_sid | upper }}_HDB{{ db_instance_number }}-clone score=4000
+                                       with {{ pcs_sap_hana_role_prim }} SAPHana_{{ db_sid | upper }}_HDB{{ db_instance_number }}-clone score=4000 --force
           when:                        "'g_ip_' + (db_sid | upper) + '_' + db_instance_number not in existing_constraints.stdout or 'SAPHana_' + (db_sid | upper) + '_HDB' + db_instance_number + '-clone' not in existing_constraints.stdout"
           register:                    colocation
           failed_when:                 colocation.rc > 0
@@ -232,7 +232,7 @@
         - name:                        "5.8 HANA Pacemaker Scale-out - Ensure that SAP HANA resources avoids running on the majority maker node"
           ansible.builtin.shell: >
                                        pcs constraint location SAPHana_{{ db_sid | upper }}_HDB{{ db_instance_number }}-clone \
-                                       avoids {{ majority_maker }}
+                                       avoids {{ majority_maker }} --force
           when:
             - majority_maker | length > 0
             - "'SAPHana_' + (db_sid | upper) + '_HDB' + db_instance_number + '-clone' not in existing_constraints.stdout or 'avoids node ' + majority_maker not in existing_constraints.stdout"
@@ -242,7 +242,7 @@
         - name:                        "5.8 HANA Pacemaker Scale-out - Ensure that HANA Resource topology avoids running on the majority maker node"
           ansible.builtin.shell: >
                                        pcs constraint location SAPHanaTopology_{{ db_sid | upper }}_HDB{{ db_instance_number }}-clone \
-                                       avoids {{ majority_maker }}
+                                       avoids {{ majority_maker }} --force
           when:
             - majority_maker | length > 0
             - "'SAPHanaTopology_' + (db_sid | upper) + '_HDB' + db_instance_number + '-clone' not in existing_constraints.stdout or 'avoids node ' + majority_maker not in existing_constraints.stdout"
@@ -252,7 +252,7 @@
         - name:                        "5.8 HANA Pacemaker Scale-out - Ensure that IP Resource avoids running on the majority maker node"
           ansible.builtin.shell: >
                                        pcs constraint location g_ip_{{ db_sid | upper }}_{{ db_instance_number }} \
-                                       avoids {{ majority_maker }}
+                                       avoids {{ majority_maker }} --force
           when:
             - majority_maker | length > 0
             - "'g_ip_' + (db_sid | upper) + '_' + db_instance_number not in existing_constraints.stdout or 'avoids node ' + majority_maker not in existing_constraints.stdout"
@@ -263,7 +263,7 @@
         - name:                        "5.8 HANA Pacemaker Scale-out - Ensure the HANA resources and NFS filesystem constraint is configured"
           ansible.builtin.shell: >
                                        pcs constraint location SAPHanaTopology_{{ db_sid | upper }}_HDB{{ db_instance_number }}-clone \
-                                       rule resource-discovery=never score=-INFINITY hana_nfs_s1_active ne true and hana_nfs_s2_active ne true
+                                       rule resource-discovery=never score=-INFINITY hana_nfs_s1_active ne true and hana_nfs_s2_active ne true --force
           when:                        "'hana_nfs_s1_active ne true' not in existing_constraints.stdout and 'hana_nfs_s2_active ne true' not in existing_constraints.stdout"
           register:                    nfs_constraint
           failed_when:                 nfs_constraint.rc > 0

--- a/deploy/ansible/roles-sap/5.8-hanadb-scaleout-pacemaker/tasks/5.8.4.1-cluster-ScaleOut-RedHat.yml
+++ b/deploy/ansible/roles-sap/5.8-hanadb-scaleout-pacemaker/tasks/5.8.4.1-cluster-ScaleOut-RedHat.yml
@@ -39,12 +39,25 @@
       when:
         - ansible_distribution_major_version == "7"
       block:
+        - name:                        "5.8 HANA Pacemaker Scale-out - Get existing cluster resources and constraints"
+          ansible.builtin.shell:       pcs resource show --full
+          register:                    existing_resources
+          changed_when:                false
+          failed_when:                 false
+
+        - name:                        "5.8 HANA Pacemaker Scale-out - Get existing cluster constraints"
+          ansible.builtin.shell:       pcs constraint show --full
+          register:                    existing_constraints
+          changed_when:                false
+          failed_when:                 false
+
         - name:                        "5.8 HANA Pacemaker Scale-out - Ensure the SAP topology resource is configured and cloned"
           ansible.builtin.shell:  >
                                        pcs resource create SAPHanaTopology_{{ db_sid | upper }}_HDB{{ db_instance_number }} SAPHanaTopologyScale-out \
                                        SID={{ db_sid | upper }} InstanceNumber={{ db_instance_number }} \
                                        op start timeout=600 op stop timeout=300 op monitor interval=10 timeout=600 \
                                        clone meta clone-node-max=1 interleave=true
+          when:                        "'SAPHanaTopology_' + (db_sid | upper) + '_HDB' + db_instance_number not in existing_resources.stdout"
           register:                    hana_t
           failed_when:                 hana_t.rc > 0
 
@@ -54,6 +67,7 @@
                                        SID={{ db_sid | upper }} InstanceNumber={{ db_instance_number }} PREFER_SITE_TAKEOVER=true DUPLICATE_PRIMARY_TIMEOUT=7200 AUTOMATED_REGISTER=true \
                                        op start interval=0 timeout=3600 op stop interval=0 timeout=3600 op promote interval=0 timeout=3600 \
                                        op monitor interval=60 role="Master" timeout=700 op monitor interval=61 role="Slave" timeout=700
+          when:                        "'SAPHana_' + (db_sid | upper) + '_HDB' + db_instance_number not in existing_resources.stdout and 'msl_SAPHana_' + (db_sid | upper) + '_HDB' + db_instance_number not in existing_resources.stdout"
           register:                    sap_hana
           failed_when:                 sap_hana.rc > 0
 
@@ -61,55 +75,68 @@
           ansible.builtin.shell: >
                                        pcs resource master msl_SAPHana_{{ db_sid | upper }}_HDB{{ db_instance_number }} SAPHana_{{ db_sid | upper }}_HDB{{ db_instance_number }} \
                                        meta master-max="1" clone-node-max=1 interleave=true
+          when:                        "'msl_SAPHana_' + (db_sid | upper) + '_HDB' + db_instance_number not in existing_resources.stdout"
           register:                     msl_sap_hana
           failed_when:                  msl_sap_hana.rc > 0
 
         - name:                        "5.8 HANA Pacemaker Scale-out - Ensure the netcat resource for the Load Balancer Healthprobe is created"
           ansible.builtin.shell:       pcs resource create nc_{{ db_sid | upper }}_{{ db_instance_number }} azure-lb port=625{{ db_instance_number }}
+          when:                        "'nc_' + (db_sid | upper) + '_' + db_instance_number not in existing_resources.stdout"
           register:                    netcat
           failed_when:                 netcat.rc > 0
 
         - name:                        "5.8 HANA Pacemaker Scale-out - Ensure the Virtual IP resource for the Load Balancer Front End IP is created"
           ansible.builtin.shell:       pcs resource create vip_{{ db_sid | upper }}_{{ db_instance_number }} ocf:heartbeat:IPaddr2 ip={{ database_loadbalancer_ip }} op monitor interval="10s" timeout="20s"
+          when:                        "'vip_' + (db_sid | upper) + '_' + db_instance_number not in existing_resources.stdout"
           register:                    vip
           failed_when:                 vip.rc > 0
 
         - name:                        "Ensure the Virtual IP group resource is created"
           ansible.builtin.shell:       pcs resource group add g_ip_{{ db_sid | upper }}_{{ db_instance_number }} nc_{{ db_sid | upper }}_{{ db_instance_number }} vip_{{ db_sid | upper }}_{{ db_instance_number }}
+          when:                        "'g_ip_' + (db_sid | upper) + '_' + db_instance_number not in existing_resources.stdout"
           register:                    vip_g
           failed_when:                 vip_g.rc > 0
 
         - name:                        "Ensure the order constraint for the SAP HANA Topology is configured"
           ansible.builtin.shell:       pcs constraint order SAPHanaTopology_{{ db_sid | upper }}_HDB{{ db_instance_number }}-clone then msl_SAPHana_{{ db_sid | upper }}_HDB{{ db_instance_number }}
+          when:                        "'SAPHanaTopology_' + (db_sid | upper) + '_HDB' + db_instance_number + '-clone then msl_SAPHana_' + (db_sid | upper) + '_HDB' + db_instance_number not in existing_constraints.stdout"
           register:                    order
           failed_when:                 order.rc > 0
 
         - name:                        "Ensure the Virtual IP group colocation constraint is configured"
           ansible.builtin.shell:       pcs constraint colocation add g_ip_{{ db_sid | upper }}_{{ db_instance_number }} with master msl_SAPHana_{{ db_sid | upper }}_HDB{{ db_instance_number }} 4000
+          when:                        "'g_ip_' + (db_sid | upper) + '_' + db_instance_number not in existing_constraints.stdout or 'msl_SAPHana_' + (db_sid | upper) + '_HDB' + db_instance_number not in existing_constraints.stdout"
           register:                    colocation
           failed_when:                 colocation.rc > 0
 
           # Ref : https://access.redhat.com/articles/6093611#5123-constraints
         - name:                        "Ensure that SAP HANA master-slave resources avoids running on the majority maker node"
           ansible.builtin.shell:       pcs constraint location msl_SAPHana_{{ db_sid | upper }}_HDB{{ db_instance_number }} avoids {{ majority_maker }}
-          when:                        majority_maker | length > 0
+          when:
+            - majority_maker | length > 0
+            - "'msl_SAPHana_' + (db_sid | upper) + '_HDB' + db_instance_number not in existing_constraints.stdout or 'avoids: ' + majority_maker not in existing_constraints.stdout"
           register:                    msl_mm_location
           failed_when:                 msl_mm_location.rc > 0
 
         - name:                        "Ensure that HANA Resource topology avoids running on the majority maker node"
           ansible.builtin.shell:       pcs constraint location SAPHanaTopology_{{ db_sid | upper }}_HDB{{ db_instance_number }}-clone avoids {{ majority_maker }}
-          when:                        majority_maker | length > 0
+          when:
+            - majority_maker | length > 0
+            - "'SAPHanaTopology_' + (db_sid | upper) + '_HDB' + db_instance_number + '-clone' not in existing_constraints.stdout or 'avoids: ' + majority_maker not in existing_constraints.stdout"
           register:                    hana_mm_location
           failed_when:                 hana_mm_location.rc > 0
 
         - name:                        "Ensure that IP Resource avoids running on the majority maker node"
           ansible.builtin.shell:       pcs constraint location g_ip_{{ db_sid | upper }}_{{ db_instance_number }} avoids {{ majority_maker }}
-          when:                        majority_maker | length > 0
+          when:
+            - majority_maker | length > 0
+            - "'g_ip_' + (db_sid | upper) + '_' + db_instance_number not in existing_constraints.stdout or 'avoids: ' + majority_maker not in existing_constraints.stdout"
           register:                    vip_mm_location
           failed_when:                 vip_mm_location.rc > 0
 
         - name:                        "Ensure the HANA resources and NFS filesystem constraint is configured"
           ansible.builtin.shell:       pcs constraint location SAPHanaTopology_{{ db_sid | upper }}_HDB{{ db_instance_number }}-clone rule resource-discovery=never score=-INFINITY hana_nfs_s1_active ne true and hana_nfs_s2_active ne true
+          when:                        "'hana_nfs_s1_active ne true and hana_nfs_s2_active ne true' not in existing_constraints.stdout"
           register:                    nfs_constraint
           failed_when:                 nfs_constraint.rc > 0
 
@@ -117,6 +144,18 @@
       when:
                                        - ansible_distribution_major_version in ["8", "9", "10"]
       block:
+        - name:                        "5.8 HANA Pacemaker Scale-out - Get existing cluster resources and constraints"
+          ansible.builtin.shell:       pcs resource show --full
+          register:                    existing_resources
+          changed_when:                false
+          failed_when:                 false
+
+        - name:                        "5.8 HANA Pacemaker Scale-out - Get existing cluster constraints"
+          ansible.builtin.shell:       pcs constraint show --full
+          register:                    existing_constraints
+          changed_when:                false
+          failed_when:                 false
+
         - name:                        "5.8 HANA Pacemaker Scale-out - Ensure the SAP topology resource is configured and cloned"
           ansible.builtin.shell:  >
                                        pcs resource create SAPHanaTopology_{{ db_sid | upper }}_HDB{{ db_instance_number }} SAPHanaTopology \
@@ -124,6 +163,7 @@
                                        op methods interval=0s timeout=5 \
                                        op start timeout=600 op stop timeout=300 op monitor interval=10 timeout=600 \
                                        clone meta clone-node-max=1 interleave=true
+          when:                        "'SAPHanaTopology_' + (db_sid | upper) + '_HDB' + db_instance_number not in existing_resources.stdout"
           register:                    hana_t
           failed_when:                 hana_t.rc > 0
 
@@ -136,6 +176,7 @@
                                        op start interval=0 timeout=3600 op stop interval=0 timeout=3600 op promote interval=0 timeout=3600 \
                                        op monitor interval=60 role="{{ pcs_sap_hana_role_prim }}" timeout=700 \
                                        op monitor interval=61 role="{{ pcs_sap_hana_role_sec }}" timeout=700
+          when:                        "'SAPHana_' + (db_sid | upper) + '_HDB' + db_instance_number + '-clone' not in existing_resources.stdout"
           register:                    sap_hana
           failed_when:                 sap_hana.rc > 0
 
@@ -143,6 +184,7 @@
           ansible.builtin.shell:  >
                                        pcs resource promotable SAPHana_{{ db_sid | upper }}_HDB{{ db_instance_number }} \
                                        meta master-max="1" clone-node-max=1 interleave=true
+          when:                        "'SAPHana_' + (db_sid | upper) + '_HDB' + db_instance_number + '-clone' not in existing_resources.stdout"
           register:                    promo_sap_hana
           failed_when:                 promo_sap_hana.rc > 0
 
@@ -150,6 +192,7 @@
           ansible.builtin.shell: >
                                        pcs resource create nc_{{ db_sid | upper }}_{{ db_instance_number }} \
                                        azure-lb port=625{{ db_instance_number }}
+          when:                        "'nc_' + (db_sid | upper) + '_' + db_instance_number not in existing_resources.stdout"
           register:                    netcat
           failed_when:                 netcat.rc > 0
 
@@ -157,6 +200,7 @@
           ansible.builtin.shell: >
                                        pcs resource create vip_{{ db_sid | upper }}_{{ db_instance_number }} ocf:heartbeat:IPaddr2 \
                                        ip={{ database_loadbalancer_ip }} op monitor interval="10s" timeout="20s"
+          when:                        "'vip_' + (db_sid | upper) + '_' + db_instance_number not in existing_resources.stdout"
           register:                    vip
           failed_when:                 vip.rc > 0
 
@@ -164,6 +208,7 @@
           ansible.builtin.shell: >
                                        pcs resource group add g_ip_{{ db_sid | upper }}_{{ db_instance_number }} \
                                        nc_{{ db_sid | upper }}_{{ db_instance_number }} vip_{{ db_sid | upper }}_{{ db_instance_number }}
+          when:                        "'g_ip_' + (db_sid | upper) + '_' + db_instance_number not in existing_resources.stdout"
           register:                    vip_g
           failed_when:                 vip_g.rc > 0
 
@@ -171,6 +216,7 @@
           ansible.builtin.shell: >
                                        pcs constraint order SAPHanaTopology_{{ db_sid | upper }}_HDB{{ db_instance_number }}-clone \
                                        then SAPHana_{{ db_sid | upper }}_HDB{{ db_instance_number }}-clone
+          when:                        "'SAPHanaTopology_' + (db_sid | upper) + '_HDB' + db_instance_number + '-clone then SAPHana_' + (db_sid | upper) + '_HDB' + db_instance_number + '-clone' not in existing_constraints.stdout"
           register:                    order
           failed_when:                 order.rc > 0
 
@@ -178,6 +224,7 @@
           ansible.builtin.shell: >
                                        pcs constraint colocation add g_ip_{{ db_sid | upper }}_{{ db_instance_number }} \
                                        with {{ pcs_sap_hana_role_prim }} SAPHana_{{ db_sid | upper }}_HDB{{ db_instance_number }}-clone score=4000
+          when:                        "'g_ip_' + (db_sid | upper) + '_' + db_instance_number not in existing_constraints.stdout or 'SAPHana_' + (db_sid | upper) + '_HDB' + db_instance_number + '-clone' not in existing_constraints.stdout"
           register:                    colocation
           failed_when:                 colocation.rc > 0
 
@@ -186,7 +233,9 @@
           ansible.builtin.shell: >
                                        pcs constraint location SAPHana_{{ db_sid | upper }}_HDB{{ db_instance_number }}-clone \
                                        avoids {{ majority_maker }}
-          when:                        majority_maker | length > 0
+          when:
+            - majority_maker | length > 0
+            - "'SAPHana_' + (db_sid | upper) + '_HDB' + db_instance_number + '-clone' not in existing_constraints.stdout or 'avoids: ' + majority_maker not in existing_constraints.stdout"
           register:                    msl_mm_location
           failed_when:                 msl_mm_location.rc > 0
 
@@ -194,7 +243,9 @@
           ansible.builtin.shell: >
                                        pcs constraint location SAPHanaTopology_{{ db_sid | upper }}_HDB{{ db_instance_number }}-clone \
                                        avoids {{ majority_maker }}
-          when:                        majority_maker | length > 0
+          when:
+            - majority_maker | length > 0
+            - "'SAPHanaTopology_' + (db_sid | upper) + '_HDB' + db_instance_number + '-clone' not in existing_constraints.stdout or 'avoids: ' + majority_maker not in existing_constraints.stdout"
           register:                    hana_mm_location
           failed_when:                 hana_mm_location.rc > 0
 
@@ -202,7 +253,9 @@
           ansible.builtin.shell: >
                                        pcs constraint location g_ip_{{ db_sid | upper }}_{{ db_instance_number }} \
                                        avoids {{ majority_maker }}
-          when:                        majority_maker | length > 0
+          when:
+            - majority_maker | length > 0
+            - "'g_ip_' + (db_sid | upper) + '_' + db_instance_number not in existing_constraints.stdout or 'avoids: ' + majority_maker not in existing_constraints.stdout"
           register:                    vip_mm_location
           failed_when:                 vip_mm_location.rc > 0
 
@@ -211,6 +264,7 @@
           ansible.builtin.shell: >
                                        pcs constraint location SAPHanaTopology_{{ db_sid | upper }}_HDB{{ db_instance_number }}-clone \
                                        rule resource-discovery=never score=-INFINITY hana_nfs_s1_active ne true and hana_nfs_s2_active ne true
+          when:                        "'hana_nfs_s1_active ne true and hana_nfs_s2_active ne true' not in existing_constraints.stdout"
           register:                    nfs_constraint
           failed_when:                 nfs_constraint.rc > 0
 

--- a/deploy/ansible/roles-sap/5.8-hanadb-scaleout-pacemaker/tasks/5.8.4.1-cluster-ScaleOut-RedHat.yml
+++ b/deploy/ansible/roles-sap/5.8-hanadb-scaleout-pacemaker/tasks/5.8.4.1-cluster-ScaleOut-RedHat.yml
@@ -216,7 +216,7 @@
           ansible.builtin.shell: >
                                        pcs constraint order SAPHanaTopology_{{ db_sid | upper }}_HDB{{ db_instance_number }}-clone \
                                        then SAPHana_{{ db_sid | upper }}_HDB{{ db_instance_number }}-clone
-          when:                        "'SAPHanaTopology_' + (db_sid | upper) + '_HDB' + db_instance_number + '-clone then SAPHana_' + (db_sid | upper) + '_HDB' + db_instance_number + '-clone' not in existing_constraints.stdout"
+          when:                        "'SAPHanaTopology_' + (db_sid | upper) + '_HDB' + db_instance_number + '-clone then start resource SAPHana_' + (db_sid | upper) + '_HDB' + db_instance_number + '-clone' not in existing_constraints.stdout"
           register:                    order
           failed_when:                 order.rc > 0
 
@@ -235,7 +235,7 @@
                                        avoids {{ majority_maker }}
           when:
             - majority_maker | length > 0
-            - "'SAPHana_' + (db_sid | upper) + '_HDB' + db_instance_number + '-clone' not in existing_constraints.stdout or 'avoids: ' + majority_maker not in existing_constraints.stdout"
+            - "'SAPHana_' + (db_sid | upper) + '_HDB' + db_instance_number + '-clone' not in existing_constraints.stdout or 'avoids node ' + majority_maker not in existing_constraints.stdout"
           register:                    msl_mm_location
           failed_when:                 msl_mm_location.rc > 0
 
@@ -245,7 +245,7 @@
                                        avoids {{ majority_maker }}
           when:
             - majority_maker | length > 0
-            - "'SAPHanaTopology_' + (db_sid | upper) + '_HDB' + db_instance_number + '-clone' not in existing_constraints.stdout or 'avoids: ' + majority_maker not in existing_constraints.stdout"
+            - "'SAPHanaTopology_' + (db_sid | upper) + '_HDB' + db_instance_number + '-clone' not in existing_constraints.stdout or 'avoids node ' + majority_maker not in existing_constraints.stdout"
           register:                    hana_mm_location
           failed_when:                 hana_mm_location.rc > 0
 
@@ -255,7 +255,7 @@
                                        avoids {{ majority_maker }}
           when:
             - majority_maker | length > 0
-            - "'g_ip_' + (db_sid | upper) + '_' + db_instance_number not in existing_constraints.stdout or 'avoids: ' + majority_maker not in existing_constraints.stdout"
+            - "'g_ip_' + (db_sid | upper) + '_' + db_instance_number not in existing_constraints.stdout or 'avoids node ' + majority_maker not in existing_constraints.stdout"
           register:                    vip_mm_location
           failed_when:                 vip_mm_location.rc > 0
 
@@ -264,7 +264,7 @@
           ansible.builtin.shell: >
                                        pcs constraint location SAPHanaTopology_{{ db_sid | upper }}_HDB{{ db_instance_number }}-clone \
                                        rule resource-discovery=never score=-INFINITY hana_nfs_s1_active ne true and hana_nfs_s2_active ne true
-          when:                        "'hana_nfs_s1_active ne true and hana_nfs_s2_active ne true' not in existing_constraints.stdout"
+          when:                        "'hana_nfs_s1_active ne true' not in existing_constraints.stdout and 'hana_nfs_s2_active ne true' not in existing_constraints.stdout"
           register:                    nfs_constraint
           failed_when:                 nfs_constraint.rc > 0
 

--- a/deploy/ansible/roles-sap/5.8-hanadb-scaleout-pacemaker/tasks/5.8.4.1-cluster-ScaleOut-RedHat.yml
+++ b/deploy/ansible/roles-sap/5.8-hanadb-scaleout-pacemaker/tasks/5.8.4.1-cluster-ScaleOut-RedHat.yml
@@ -24,7 +24,7 @@
 - name:                                "5.8 HANA Pacemaker Scale-out - Optimise the Pacemaker cluster for SAP HANA"
   block:
     - name:                            "5.8 HANA Pacemaker Scale-out - Get the cluster maintenance mode status"
-      ansible.builtin.shell:           pcs property show maintenance-mode
+      ansible.builtin.shell:           "{{ pcs_check_maintenance_mode }}"
       register:                        get_status_maintenance_mode
       changed_when:                    false
       ignore_errors:                   true
@@ -41,199 +41,219 @@
       block:
         - name:                        "5.8 HANA Pacemaker Scale-out - Ensure the SAP topology resource is configured and cloned"
           ansible.builtin.shell:  >
-                                            pcs resource create SAPHanaTopology_{{ db_sid | upper }}_HDB{{ db_instance_number }} SAPHanaTopologyScale-out \
-                                            SID={{ db_sid | upper }} InstanceNumber={{ db_instance_number }} \
-                                            op start timeout=600 op stop timeout=300 op monitor interval=10 timeout=600 \
-                                            clone meta clone-node-max=1 interleave=true
+                                       pcs resource create SAPHanaTopology_{{ db_sid | upper }}_HDB{{ db_instance_number }} SAPHanaTopologyScale-out \
+                                       SID={{ db_sid | upper }} InstanceNumber={{ db_instance_number }} \
+                                       op start timeout=600 op stop timeout=300 op monitor interval=10 timeout=600 \
+                                       clone meta clone-node-max=1 interleave=true
           register:                    hana_t
           failed_when:                 hana_t.rc > 0
 
         - name:                        "5.8 HANA Pacemaker Scale-out - Ensure the SAP HANA instance resource is created"
           ansible.builtin.shell:  >
-                                            pcs resource create SAPHana_{{ db_sid | upper }}_HDB{{ db_instance_number }} SAPHanaController \
-                                            SID={{ db_sid | upper }} InstanceNumber={{ db_instance_number }} PREFER_SITE_TAKEOVER=true DUPLICATE_PRIMARY_TIMEOUT=7200 AUTOMATED_REGISTER=true \
-                                            op start interval=0 timeout=3600 op stop interval=0 timeout=3600 op promote interval=0 timeout=3600 \
-                                            op monitor interval=60 role="Master" timeout=700 op monitor interval=61 role="Slave" timeout=700
+                                       pcs resource create SAPHana_{{ db_sid | upper }}_HDB{{ db_instance_number }} SAPHanaController \
+                                       SID={{ db_sid | upper }} InstanceNumber={{ db_instance_number }} PREFER_SITE_TAKEOVER=true DUPLICATE_PRIMARY_TIMEOUT=7200 AUTOMATED_REGISTER=true \
+                                       op start interval=0 timeout=3600 op stop interval=0 timeout=3600 op promote interval=0 timeout=3600 \
+                                       op monitor interval=60 role="Master" timeout=700 op monitor interval=61 role="Slave" timeout=700
           register:                    sap_hana
           failed_when:                 sap_hana.rc > 0
 
         - name:                        "5.8 HANA Pacemaker Scale-out - Ensure master-slave (msl) resource for managing an SAP HANA instance is created"
           ansible.builtin.shell: >
-                                            pcs resource master msl_SAPHana_{{ db_sid | upper }}_HDB{{ db_instance_number }} SAPHana_{{ db_sid | upper }}_HDB{{ db_instance_number }} \
-                                            meta master-max="1" clone-node-max=1 interleave=true
+                                       pcs resource master msl_SAPHana_{{ db_sid | upper }}_HDB{{ db_instance_number }} SAPHana_{{ db_sid | upper }}_HDB{{ db_instance_number }} \
+                                       meta master-max="1" clone-node-max=1 interleave=true
           register:                     msl_sap_hana
           failed_when:                  msl_sap_hana.rc > 0
 
-        - name:                         "5.8 HANA Pacemaker Scale-out - Ensure the netcat resource for the Load Balancer Healthprobe is created"
-          ansible.builtin.shell:            pcs resource create nc_{{ db_sid | upper }}_{{ db_instance_number }} azure-lb port=625{{ db_instance_number }}
-          register:                     netcat
-          failed_when:                  netcat.rc > 0
+        - name:                        "5.8 HANA Pacemaker Scale-out - Ensure the netcat resource for the Load Balancer Healthprobe is created"
+          ansible.builtin.shell:       pcs resource create nc_{{ db_sid | upper }}_{{ db_instance_number }} azure-lb port=625{{ db_instance_number }}
+          register:                    netcat
+          failed_when:                 netcat.rc > 0
 
-        - name:                         "5.8 HANA Pacemaker Scale-out - Ensure the Virtual IP resource for the Load Balancer Front End IP is created"
-          ansible.builtin.shell:            pcs resource create vip_{{ db_sid | upper }}_{{ db_instance_number }} ocf:heartbeat:IPaddr2 ip={{ database_loadbalancer_ip }} op monitor interval="10s" timeout="20s"
-          register:                         vip
-          failed_when:                      vip.rc > 0
+        - name:                        "5.8 HANA Pacemaker Scale-out - Ensure the Virtual IP resource for the Load Balancer Front End IP is created"
+          ansible.builtin.shell:       pcs resource create vip_{{ db_sid | upper }}_{{ db_instance_number }} ocf:heartbeat:IPaddr2 ip={{ database_loadbalancer_ip }} op monitor interval="10s" timeout="20s"
+          register:                    vip
+          failed_when:                 vip.rc > 0
 
-        - name:                             Ensure the Virtual IP group resource is created
-          ansible.builtin.shell:            pcs resource group add g_ip_{{ db_sid | upper }}_{{ db_instance_number }} nc_{{ db_sid | upper }}_{{ db_instance_number }} vip_{{ db_sid | upper }}_{{ db_instance_number }}
-          register:                         vip_g
-          failed_when:                      vip_g.rc > 0
+        - name:                        "Ensure the Virtual IP group resource is created"
+          ansible.builtin.shell:       pcs resource group add g_ip_{{ db_sid | upper }}_{{ db_instance_number }} nc_{{ db_sid | upper }}_{{ db_instance_number }} vip_{{ db_sid | upper }}_{{ db_instance_number }}
+          register:                    vip_g
+          failed_when:                 vip_g.rc > 0
 
-        - name:                             Ensure the order constraint for the SAP HANA Topology is configured
-          ansible.builtin.shell:            pcs constraint order SAPHanaTopology_{{ db_sid | upper }}_HDB{{ db_instance_number }}-clone then msl_SAPHana_{{ db_sid | upper }}_HDB{{ db_instance_number }}
-          register:                         order
-          failed_when:                      order.rc > 0
+        - name:                        "Ensure the order constraint for the SAP HANA Topology is configured"
+          ansible.builtin.shell:       pcs constraint order SAPHanaTopology_{{ db_sid | upper }}_HDB{{ db_instance_number }}-clone then msl_SAPHana_{{ db_sid | upper }}_HDB{{ db_instance_number }}
+          register:                    order
+          failed_when:                 order.rc > 0
 
-        - name:                             Ensure the Virtual IP group colocation constraint is configured
-          ansible.builtin.shell:            pcs constraint colocation add g_ip_{{ db_sid | upper }}_{{ db_instance_number }} with master msl_SAPHana_{{ db_sid | upper }}_HDB{{ db_instance_number }} 4000
-          register:                         colocation
-          failed_when:                      colocation.rc > 0
+        - name:                        "Ensure the Virtual IP group colocation constraint is configured"
+          ansible.builtin.shell:       pcs constraint colocation add g_ip_{{ db_sid | upper }}_{{ db_instance_number }} with master msl_SAPHana_{{ db_sid | upper }}_HDB{{ db_instance_number }} 4000
+          register:                    colocation
+          failed_when:                 colocation.rc > 0
 
           # Ref : https://access.redhat.com/articles/6093611#5123-constraints
-        - name:                             Ensure that SAP HANA master-slave resources avoids running on the majority maker node
-          ansible.builtin.shell:            pcs constraint location msl_SAPHana_{{ db_sid | upper }}_HDB{{ db_instance_number }} avoids {{ majority_maker }}
-          when:                             majority_maker | length > 0
-          register:                         msl_mm_location
-          failed_when:                      msl_mm_location.rc > 0
+        - name:                        "Ensure that SAP HANA master-slave resources avoids running on the majority maker node"
+          ansible.builtin.shell:       pcs constraint location msl_SAPHana_{{ db_sid | upper }}_HDB{{ db_instance_number }} avoids {{ majority_maker }}
+          when:                        majority_maker | length > 0
+          register:                    msl_mm_location
+          failed_when:                 msl_mm_location.rc > 0
 
-        - name:                             Ensure that HANA Resource topology avoids running on the majority maker node
-          ansible.builtin.shell:            pcs constraint location SAPHanaTopology_{{ db_sid | upper }}_HDB{{ db_instance_number }}-clone avoids {{ majority_maker }}
-          when:                             majority_maker | length > 0
-          register:                         hana_mm_location
-          failed_when:                      hana_mm_location.rc > 0
+        - name:                        "Ensure that HANA Resource topology avoids running on the majority maker node"
+          ansible.builtin.shell:       pcs constraint location SAPHanaTopology_{{ db_sid | upper }}_HDB{{ db_instance_number }}-clone avoids {{ majority_maker }}
+          when:                        majority_maker | length > 0
+          register:                    hana_mm_location
+          failed_when:                 hana_mm_location.rc > 0
 
-        - name:                             Ensure that IP Resource avoids running on the majority maker node
-          ansible.builtin.shell:            pcs constraint location g_ip_{{ db_sid | upper }}_{{ db_instance_number }} avoids {{ majority_maker }}
-          when:                             majority_maker | length > 0
-          register:                         vip_mm_location
-          failed_when:                      vip_mm_location.rc > 0
+        - name:                        "Ensure that IP Resource avoids running on the majority maker node"
+          ansible.builtin.shell:       pcs constraint location g_ip_{{ db_sid | upper }}_{{ db_instance_number }} avoids {{ majority_maker }}
+          when:                        majority_maker | length > 0
+          register:                    vip_mm_location
+          failed_when:                 vip_mm_location.rc > 0
 
-        - name:                             Ensure the HANA resources and NFS filesystem constraint is configured
-          ansible.builtin.shell:            pcs constraint location SAPHanaTopology_{{ db_sid | upper }}_HDB{{ db_instance_number }}-clone rule resource-discovery=never score=-INFINITY hana_nfs_s1_active ne true and hana_nfs_s2_active ne true
-          register:                         nfs_constraint
-          failed_when:                      nfs_constraint.rc > 0
+        - name:                        "Ensure the HANA resources and NFS filesystem constraint is configured"
+          ansible.builtin.shell:       pcs constraint location SAPHanaTopology_{{ db_sid | upper }}_HDB{{ db_instance_number }}-clone rule resource-discovery=never score=-INFINITY hana_nfs_s1_active ne true and hana_nfs_s2_active ne true
+          register:                    nfs_constraint
+          failed_when:                 nfs_constraint.rc > 0
 
-    - name:                                 "5.5.4.1 HANA cluster resource configuration - RHEL 8/9/10"
+    - name:                            "5.5.4.1 HANA cluster resource configuration - RHEL 8/9/10"
       when:
-        - ansible_distribution_major_version in ["8", "9", "10"]
+                                       - ansible_distribution_major_version in ["8", "9", "10"]
       block:
-        - name:                             Ensure the SAP topology resource is configured and cloned
+        - name:                        "5.8 HANA Pacemaker Scale-out - Ensure the SAP topology resource is configured and cloned"
           ansible.builtin.shell:  >
-                                            pcs resource create SAPHanaTopology_{{ db_sid | upper }}_HDB{{ db_instance_number }} SAPHanaTopology \
-                                            SID={{ db_sid | upper }} InstanceNumber={{ db_instance_number }} meta clone-node-max=1 interleave=true \
-                                            op methods interval=0s timeout=5 \
-                                            op start timeout=600 op stop timeout=300 op monitor interval=10 timeout=600 \
-                                            clone meta clone-node-max=1 interleave=true
-          register:                         hana_t
-          failed_when:                      hana_t.rc > 0
+                                       pcs resource create SAPHanaTopology_{{ db_sid | upper }}_HDB{{ db_instance_number }} SAPHanaTopology \
+                                       SID={{ db_sid | upper }} InstanceNumber={{ db_instance_number }} meta clone-node-max=1 interleave=true \
+                                       op methods interval=0s timeout=5 \
+                                       op start timeout=600 op stop timeout=300 op monitor interval=10 timeout=600 \
+                                       clone meta clone-node-max=1 interleave=true
+          register:                    hana_t
+          failed_when:                 hana_t.rc > 0
 
-        - name:                             Ensure the SAP HANA instance is created
+        - name:                        "5.8 HANA Pacemaker Scale-out - Ensure the SAP HANA instance is created"
           ansible.builtin.shell:  >
-                                            pcs resource create SAPHana_{{ db_sid | upper }}_HDB{{ db_instance_number }} SAPHanaController \
-                                            SID={{ db_sid | upper }} InstanceNumber={{ db_instance_number }} PREFER_SITE_TAKEOVER=true DUPLICATE_PRIMARY_TIMEOUT=7200 AUTOMATED_REGISTER=true \
-                                            op demote interval=0s timeout=320 op methods interval=0s timeout=5 \
-                                            op start interval=0 timeout=3600 op stop interval=0 timeout=3600 op promote interval=0 timeout=3600 \
-                                            op monitor interval=60 role="Master" timeout=700 op monitor interval=61 role="Slave" timeout=700
-          register:                         sap_hana
-          failed_when:                      sap_hana.rc > 0
+                                       pcs resource create SAPHana_{{ db_sid | upper }}_HDB{{ db_instance_number }} SAPHanaController \
+                                       SID={{ db_sid | upper }} InstanceNumber={{ db_instance_number }} PREFER_SITE_TAKEOVER=true \
+                                       DUPLICATE_PRIMARY_TIMEOUT=7200 AUTOMATED_REGISTER=true \
+                                       op demote interval=0s timeout=320 op methods interval=0s timeout=5 \
+                                       op start interval=0 timeout=3600 op stop interval=0 timeout=3600 op promote interval=0 timeout=3600 \
+                                       op monitor interval=60 role="{{ pcs_sap_hana_role_prim }}" timeout=700 \
+                                       op monitor interval=61 role="{{ pcs_sap_hana_role_sec }}" timeout=700
+          register:                    sap_hana
+          failed_when:                 sap_hana.rc > 0
 
-        - name:                             Ensure that the SAP HANA instance is promotable
+        - name:                        "5.8 HANA Pacemaker Scale-out - Ensure that the SAP HANA instance is promotable"
           ansible.builtin.shell:  >
-                                            pcs resource promotable SAPHana_{{ db_sid | upper }}_HDB{{ db_instance_number }} \
-                                            meta master-max="1" clone-node-max=1 interleave=true
-          register:                         promo_sap_hana
-          failed_when:                      promo_sap_hana.rc > 0
+                                       pcs resource promotable SAPHana_{{ db_sid | upper }}_HDB{{ db_instance_number }} \
+                                       meta master-max="1" clone-node-max=1 interleave=true
+          register:                    promo_sap_hana
+          failed_when:                 promo_sap_hana.rc > 0
 
-        - name:                             Ensure the netcat resource for the Load Balancer Healthprobe is created
-          ansible.builtin.shell:            pcs resource create nc_{{ db_sid | upper }}_{{ db_instance_number }} azure-lb port=625{{ db_instance_number }}
-          register:                         netcat
-          failed_when:                      netcat.rc > 0
+        - name:                        "5.8 HANA Pacemaker Scale-out - Ensure the netcat resource for the Load Balancer Healthprobe is created"
+          ansible.builtin.shell: >
+                                       pcs resource create nc_{{ db_sid | upper }}_{{ db_instance_number }} \
+                                       azure-lb port=625{{ db_instance_number }}
+          register:                    netcat
+          failed_when:                 netcat.rc > 0
 
-        - name:                             Ensure the Virtual IP resource for the Load Balancer Front End IP is created
-          ansible.builtin.shell:            pcs resource create vip_{{ db_sid | upper }}_{{ db_instance_number }} ocf:heartbeat:IPaddr2 ip={{ database_loadbalancer_ip }} op monitor interval="10s" timeout="20s"
-          register:                         vip
-          failed_when:                      vip.rc > 0
+        - name:                        "5.8 HANA Pacemaker Scale-out - Ensure the Virtual IP resource for the Load Balancer Front End IP is created"
+          ansible.builtin.shell: >
+                                       pcs resource create vip_{{ db_sid | upper }}_{{ db_instance_number }} ocf:heartbeat:IPaddr2 \
+                                       ip={{ database_loadbalancer_ip }} op monitor interval="10s" timeout="20s"
+          register:                    vip
+          failed_when:                 vip.rc > 0
 
-        - name:                             Ensure the Virtual IP group resource is created
-          ansible.builtin.shell:            pcs resource group add g_ip_{{ db_sid | upper }}_{{ db_instance_number }} nc_{{ db_sid | upper }}_{{ db_instance_number }} vip_{{ db_sid | upper }}_{{ db_instance_number }}
-          register:                         vip_g
-          failed_when:                      vip_g.rc > 0
+        - name:                        "5.8 HANA Pacemaker Scale-out - Ensure the Virtual IP group resource is created"
+          ansible.builtin.shell: >
+                                       pcs resource group add g_ip_{{ db_sid | upper }}_{{ db_instance_number }} \
+                                       nc_{{ db_sid | upper }}_{{ db_instance_number }} vip_{{ db_sid | upper }}_{{ db_instance_number }}
+          register:                    vip_g
+          failed_when:                 vip_g.rc > 0
 
-        - name:                             Ensure the order constraint for the SAP HANA Topology is configured
-          ansible.builtin.shell:            pcs constraint order SAPHanaTopology_{{ db_sid | upper }}_HDB{{ db_instance_number }}-clone then SAPHana_{{ db_sid | upper }}_HDB{{ db_instance_number }}-clone
-          register:                         order
-          failed_when:                      order.rc > 0
+        - name:                        "5.8 HANA Pacemaker Scale-out - Ensure the order constraint for the SAP HANA Topology is configured"
+          ansible.builtin.shell: >
+                                       pcs constraint order SAPHanaTopology_{{ db_sid | upper }}_HDB{{ db_instance_number }}-clone \
+                                       then SAPHana_{{ db_sid | upper }}_HDB{{ db_instance_number }}-clone
+          register:                    order
+          failed_when:                 order.rc > 0
 
-        - name:                             Ensure the Virtual IP group colocation constraint is configured
-          ansible.builtin.shell:            pcs constraint colocation add g_ip_{{ db_sid | upper }}_{{ db_instance_number }} with master SAPHana_{{ db_sid | upper }}_HDB{{ db_instance_number }}-clone 4000
-          register:                         colocation
-          failed_when:                      colocation.rc > 0
+        - name:                        "5.8 HANA Pacemaker Scale-out - Ensure the Virtual IP group colocation constraint is configured"
+          ansible.builtin.shell: >
+                                       pcs constraint colocation add g_ip_{{ db_sid | upper }}_{{ db_instance_number }} \
+                                       with {{ pcs_sap_hana_role_prim }} SAPHana_{{ db_sid | upper }}_HDB{{ db_instance_number }}-clone score=4000
+          register:                    colocation
+          failed_when:                 colocation.rc > 0
 
         # Ref: https://access.redhat.com/articles/6093611#5123-constraints
-        - name:                             Ensure that SAP HANA resources avoids running on the majority maker node
-          ansible.builtin.shell:            pcs constraint location SAPHana_{{ db_sid | upper }}_HDB{{ db_instance_number }}-clone avoids {{ majority_maker }}
-          when:                             majority_maker | length > 0
-          register:                         msl_mm_location
-          failed_when:                      msl_mm_location.rc > 0
+        - name:                        "5.8 HANA Pacemaker Scale-out - Ensure that SAP HANA resources avoids running on the majority maker node"
+          ansible.builtin.shell: >
+                                       pcs constraint location SAPHana_{{ db_sid | upper }}_HDB{{ db_instance_number }}-clone \
+                                       avoids {{ majority_maker }}
+          when:                        majority_maker | length > 0
+          register:                    msl_mm_location
+          failed_when:                 msl_mm_location.rc > 0
 
-        - name:                             Ensure that HANA Resource topology avoids running on the majority maker node
-          ansible.builtin.shell:            pcs constraint location SAPHanaTopology_{{ db_sid | upper }}_HDB{{ db_instance_number }}-clone avoids {{ majority_maker }}
-          when:                             majority_maker | length > 0
-          register:                         hana_mm_location
-          failed_when:                      hana_mm_location.rc > 0
+        - name:                        "5.8 HANA Pacemaker Scale-out - Ensure that HANA Resource topology avoids running on the majority maker node"
+          ansible.builtin.shell: >
+                                       pcs constraint location SAPHanaTopology_{{ db_sid | upper }}_HDB{{ db_instance_number }}-clone \
+                                       avoids {{ majority_maker }}
+          when:                        majority_maker | length > 0
+          register:                    hana_mm_location
+          failed_when:                 hana_mm_location.rc > 0
 
-        - name:                             Ensure that IP Resource avoids running on the majority maker node
-          ansible.builtin.shell:            pcs constraint location g_ip_{{ db_sid | upper }}_{{ db_instance_number }} avoids {{ majority_maker }}
-          when:                             majority_maker | length > 0
-          register:                         vip_mm_location
-          failed_when:                      vip_mm_location.rc > 0
-
-
-        - name:                             Ensure the HANA resources and NFS filesystem constraint is configured
-          ansible.builtin.shell:            pcs constraint location SAPHanaTopology_{{ db_sid | upper }}_HDB{{ db_instance_number }}-clone rule resource-discovery=never score=-INFINITY hana_nfs_s1_active ne true and hana_nfs_s2_active ne true
-          register:                         nfs_constraint
-          failed_when:                      nfs_constraint.rc > 0
+        - name:                        "5.8 HANA Pacemaker Scale-out - Ensure that IP Resource avoids running on the majority maker node"
+          ansible.builtin.shell: >
+                                       pcs constraint location g_ip_{{ db_sid | upper }}_{{ db_instance_number }} \
+                                       avoids {{ majority_maker }}
+          when:                        majority_maker | length > 0
+          register:                    vip_mm_location
+          failed_when:                 vip_mm_location.rc > 0
 
 
-    - name:                                 "5.8 HANA Pacemaker Scale-out - Disable Maintenance mode for the cluster"
-      ansible.builtin.shell:                pcs property set maintenance-mode=false
+        - name:                        "5.8 HANA Pacemaker Scale-out - Ensure the HANA resources and NFS filesystem constraint is configured"
+          ansible.builtin.shell: >
+                                       pcs constraint location SAPHanaTopology_{{ db_sid | upper }}_HDB{{ db_instance_number }}-clone \
+                                       rule resource-discovery=never score=-INFINITY hana_nfs_s1_active ne true and hana_nfs_s2_active ne true
+          register:                    nfs_constraint
+          failed_when:                 nfs_constraint.rc > 0
 
-    - name:                                 "5.8 HANA Pacemaker Scale-out - Wait until cluster has stabilized on RHEL 7"
-      ansible.builtin.shell:                set -o pipefail && pcs status | grep '^Online:'
-      register:                             cluster_stable_check
-      retries:                              12
-      delay:                                10
-      until:                                "(primary_instance_name + ' ' + secondary_instance_name) in cluster_stable_check.stdout or (secondary_instance_name + ' ' + primary_instance_name) in cluster_stable_check.stdout"
-      when:                                 ansible_distribution_major_version != "8" and ansible_distribution_major_version != "9" and ansible_distribution_major_version != "10"
+
+    - name:                            "5.8 HANA Pacemaker Scale-out - Disable Maintenance mode for the cluster"
+      ansible.builtin.shell:           pcs property set maintenance-mode=false
+
+    - name:                            "5.8 HANA Pacemaker Scale-out - Wait until cluster has stabilized on RHEL 7"
+      ansible.builtin.shell:           set -o pipefail && pcs status | grep '^Online:'
+      register:                        cluster_stable_check
+      retries:                         12
+      delay:                           10
+      until:                           "(primary_instance_name + ' ' + secondary_instance_name) in cluster_stable_check.stdout or (secondary_instance_name + ' ' + primary_instance_name) in cluster_stable_check.stdout"
+      when:                            ansible_distribution_major_version != "8" and ansible_distribution_major_version != "9" and ansible_distribution_major_version != "10"
     # '*' is a special character in regexp and needs to be escaped for literal matching
     # if we are worried about character spacing across distros we can match for '\* Online:'
-    - name:                                 "5.8 HANA Pacemaker Scale-out - Wait until cluster has stabilized on RHEL 8 and newer"
-      ansible.builtin.shell:                set -o pipefail && pcs status | grep '^  \* Online:'
-      register:                             cluster_stable_check
-      retries:                              12
-      delay:                                10
-      until:                                "(primary_instance_name + ' ' + secondary_instance_name) in cluster_stable_check.stdout or (secondary_instance_name + ' ' + primary_instance_name) in cluster_stable_check.stdout"
-      when:                                 ansible_distribution_major_version in ["8", "9", "10"]
+    - name:                            "5.8 HANA Pacemaker Scale-out - Wait until cluster has stabilized on RHEL 8 and newer"
+      ansible.builtin.shell:           set -o pipefail && pcs status | grep '^  \* Online:'
+      register:                        cluster_stable_check
+      retries:                         12
+      delay:                           10
+      until:                           "(primary_instance_name + ' ' + secondary_instance_name) in cluster_stable_check.stdout or (secondary_instance_name + ' ' + primary_instance_name) in cluster_stable_check.stdout"
+      when:                            ansible_distribution_major_version in ["8", "9", "10"]
 
-    - name:                                 "5.8 HANA Pacemaker Scale-out - Cleanup any stale cluster resource StartSystem"
-      ansible.builtin.shell:                pcs resource cleanup
+    - name:                            "5.8 HANA Pacemaker Scale-out - Cleanup any stale cluster resource StartSystem"
+      ansible.builtin.shell:           pcs resource cleanup
 
     # the leading spaces are irrelevant here as we are looking for *<space>Started:
-    - name:                               "5.8 HANA Pacemaker Scale-out - Ensure Cluster resources are started on RHEL 7"
-      ansible.builtin.shell:              set -o pipefail && pcs resource show | grep '    Started:'
-      register:                           hana_cluster_resource_check
-      retries:                            12
-      delay:                              10
-      until:                              "(primary_instance_name + ' ' + secondary_instance_name) in hana_cluster_resource_check.stdout or (secondary_instance_name + ' ' + primary_instance_name) in hana_cluster_resource_check.stdout"
-      when:                               ansible_distribution_major_version != "8" and ansible_distribution_major_version != "9" and ansible_distribution_major_version != "10"
+    - name:                            "5.8 HANA Pacemaker Scale-out - Ensure Cluster resources are started on RHEL 7"
+      ansible.builtin.shell:           set -o pipefail && pcs resource show | grep '    Started:'
+      register:                        hana_cluster_resource_check
+      retries:                         12
+      delay:                           10
+      until:                           "(primary_instance_name + ' ' + secondary_instance_name) in hana_cluster_resource_check.stdout or (secondary_instance_name + ' ' + primary_instance_name) in hana_cluster_resource_check.stdout"
+      when:                            ansible_distribution_major_version != "8" and ansible_distribution_major_version != "9" and ansible_distribution_major_version != "10"
 
-    - name:                               "5.8 HANA Pacemaker Scale-out - Ensure Cluster resources are started on RHEL 8 and newer"
-      ansible.builtin.shell:              set -o pipefail && pcs resource status | grep '\* Started:'
-      register:                           hana_cluster_resource_check
-      retries:                            12
-      delay:                              10
-      until:                              "(primary_instance_name + ' ' + secondary_instance_name) in hana_cluster_resource_check.stdout or (secondary_instance_name + ' ' + primary_instance_name) in hana_cluster_resource_check.stdout"
-      when:                               ansible_distribution_major_version in ["8", "9", "10"]
+    - name:                            "5.8 HANA Pacemaker Scale-out - Ensure Cluster resources are started on RHEL 8 and newer"
+      ansible.builtin.shell:           set -o pipefail && pcs resource status | grep '\* Started:'
+      register:                        hana_cluster_resource_check
+      retries:                         12
+      delay:                           10
+      until:                           "(primary_instance_name + ' ' + secondary_instance_name) in hana_cluster_resource_check.stdout or (secondary_instance_name + ' ' + primary_instance_name) in hana_cluster_resource_check.stdout"
+      when:                            ansible_distribution_major_version in ["8", "9", "10"]
   when: ansible_hostname == primary_instance_name
 
 # End of HANA clustering resources

--- a/deploy/ansible/roles-sap/5.8-hanadb-scaleout-pacemaker/vars/main.yml
+++ b/deploy/ansible/roles-sap/5.8-hanadb-scaleout-pacemaker/vars/main.yml
@@ -4,33 +4,33 @@
 ---
 
 cluster_totem:
-  token: 30000
-  retransmits: 10
-  join: 60
-  consensus: 36000
-  max_messages: 20
+  token:                               30000
+  retransmits:                         10
+  join:                                60
+  consensus:                           36000
+  max_messages:                        20
 
 cluster_quorum:
-  expected_votes: 2
-  two_node: 1
+  expected_votes:                      2
+  two_node:                            1
 
 # These are the default timeouts used for the SAP HANA OS clustering. Depending on the
 # SAP HANA System, these may need to be adjusted if the operation takes longer than expected.
 cluster_sap_hana_timeouts:
-  start: 3600
-  stop: 3600
-  monitor_master: 700
-  monitor_slave: 700
-  promote: 3600
-  demote: 3600
+  start:                               3600
+  stop:                                3600
+  monitor_master:                      700
+  monitor_slave:                       700
+  promote:                             3600
+  demote:                              3600
 
 cluster_status_cmd:
-  RedHat: "pcs status --full"
-  Suse: "crm status full"
+  RedHat:                              "pcs status --full"
+  Suse:                                "crm status full"
 
 cluster_cleanup_cmd:
-  RedHat: "pcs resource cleanup"
-  Suse: "crm resource cleanup"
+  RedHat:                              "pcs resource cleanup"
+  Suse:                                "crm resource cleanup"
 
 
 cluster_status_report_wait_in_s:       60
@@ -46,10 +46,32 @@ cluster_name:                          db{{ sid | lower }}
 
 # HANA utility commands
 sapcontrol_command:                    "/usr/sap/{{ db_sid | upper }}/HDB{{ db_instance_number }}/exe/sapcontrol -nr {{ db_instance_number }}"
-storage_object: sbd{{ cluster_name }}
-target: "{{ iscsi_object }}.{{ cluster_name }}.local:{{ cluster_name }}"
+storage_object:                        sbd{{ cluster_name }}
+target:                                "{{ iscsi_object }}.{{ cluster_name }}.local:{{ cluster_name }}"
 
 
 hana_stop_start_timeout_in_seconds:    600
 hana_stop_start_delay_in_seconds:      10
+
+# RHEL: Check maintenance mode command based on OS version
+pcs_check_maintenance_mode: >-
+                                       {% if ansible_distribution_major_version is version ('10','<') %}
+                                       pcs property show maintenance-mode
+                                       {% else %}
+                                       pcs property config maintenance-mode
+                                       {% endif %}
+
+pcs_sap_hana_role_prim: >-
+                                       {% if ansible_distribution_major_version is version ('10','<') %}
+                                       Master
+                                       {% else %}
+                                       Promoted
+                                       {% endif %}
+
+pcs_sap_hana_role_sec: >-
+                                       {% if ansible_distribution_major_version is version ('10','<') %}
+                                       Slave
+                                       {% else %}
+                                       Unpromoted
+                                       {% endif %}
 ...

--- a/deploy/ansible/vars/ansible-input-api.yaml
+++ b/deploy/ansible/vars/ansible-input-api.yaml
@@ -244,6 +244,8 @@ sapbits_sas_token_secret:               "sapbits-sas-token"                     
 NFS_provider:                           "NONE"
 NFS_version:                            "NFSv4.1"
 use_simple_mount:                       false
+# Indicate if Encryption in Transit is to be used for AFS shares
+use_eit_for_afs:                        false
 
 # Cluster - Defaults
 # database_high_availability:            false

--- a/deploy/terraform/run/sap_landscape/module.tf
+++ b/deploy/terraform/run/sap_landscape/module.tf
@@ -25,8 +25,6 @@ module "sap_landscape" {
   deployer_tfstate                             = try(data.terraform_remote_state.deployer[0].outputs, [])
   diagnostics_storage_account                  = local.diagnostics_storage_account
   enable_firewall_for_keyvaults_and_storage    = var.enable_firewall_for_keyvaults_and_storage
-  enable_purge_control_for_keyvaults           = var.enable_purge_control_for_keyvaults
-  enable_rbac_authorization_for_keyvault       = var.enable_rbac_authorization_for_keyvault
   infrastructure                               = local.infrastructure
   install_always_create_fileshares             = var.install_always_create_fileshares
   install_create_smb_shares                    = var.install_create_smb_shares
@@ -44,7 +42,6 @@ module "sap_landscape" {
   peer_with_control_plane_vnet                 = var.use_deployer ? var.peer_with_control_plane_vnet : false
   place_delete_lock_on_resources               = var.place_delete_lock_on_resources
   public_network_access_enabled                = var.public_network_access_enabled
-  soft_delete_retention_days                   = var.soft_delete_retention_days
   storage_account_replication_type             = var.storage_account_replication_type
   tags                                         = var.tags
   terraform_template_version                   = local.version_label

--- a/deploy/terraform/run/sap_landscape/module.tf
+++ b/deploy/terraform/run/sap_landscape/module.tf
@@ -49,6 +49,7 @@ module "sap_landscape" {
   transport_storage_account_id                 = var.transport_storage_account_id
   transport_volume_size                        = var.transport_volume_size
   use_AFS_for_shared_storage                   = var.use_AFS_for_shared_storage
+  AFS_enable_encryption_in_transit             = var.AFS_enable_encryption_in_transit
   use_deployer                                 = length(var.deployer_tfstate_key) > 0
   use_private_endpoint                         = var.use_private_endpoint
   use_service_endpoint                         = var.use_service_endpoint

--- a/deploy/terraform/run/sap_landscape/module.tf
+++ b/deploy/terraform/run/sap_landscape/module.tf
@@ -25,6 +25,8 @@ module "sap_landscape" {
   deployer_tfstate                             = try(data.terraform_remote_state.deployer[0].outputs, [])
   diagnostics_storage_account                  = local.diagnostics_storage_account
   enable_firewall_for_keyvaults_and_storage    = var.enable_firewall_for_keyvaults_and_storage
+  enable_purge_control_for_keyvaults           = var.enable_purge_control_for_keyvaults
+  enable_rbac_authorization_for_keyvault       = var.enable_rbac_authorization_for_keyvault
   infrastructure                               = local.infrastructure
   install_always_create_fileshares             = var.install_always_create_fileshares
   install_create_smb_shares                    = var.install_create_smb_shares
@@ -42,6 +44,7 @@ module "sap_landscape" {
   peer_with_control_plane_vnet                 = var.use_deployer ? var.peer_with_control_plane_vnet : false
   place_delete_lock_on_resources               = var.place_delete_lock_on_resources
   public_network_access_enabled                = var.public_network_access_enabled
+  soft_delete_retention_days                   = var.soft_delete_retention_days
   storage_account_replication_type             = var.storage_account_replication_type
   tags                                         = var.tags
   terraform_template_version                   = local.version_label

--- a/deploy/terraform/run/sap_landscape/tfvar_variables.tf
+++ b/deploy/terraform/run/sap_landscape/tfvar_variables.tf
@@ -940,7 +940,14 @@ variable "ANF_install_volume_zone"                 {
 
 variable "use_AFS_for_shared_storage"              {
                                                      description = "If true, will use AFS for all shared storage."
-                                                     default = false
+                                                     type        = bool
+                                                     default     = false
+                                                   }
+
+variable AFS_enable_encryption_in_transit          {
+                                                     description = "Enable encryption in transit for Azure Files"
+                                                     type        = bool
+                                                     default     = false
                                                    }
 
 #########################################################################################

--- a/deploy/terraform/run/sap_system/module.tf
+++ b/deploy/terraform/run/sap_system/module.tf
@@ -95,6 +95,7 @@ module "common_infrastructure" {
   use_scalesets_for_deployment                  = var.use_scalesets_for_deployment
   dns_settings                                  = local.dns_settings
   enable_firewall_for_keyvaults_and_storage     = var.enable_firewall_for_keyvaults_and_storage
+  AFS_enable_encryption_in_transit              = var.AFS_enable_encryption_in_transit
 
 }
 

--- a/deploy/terraform/run/sap_system/module.tf
+++ b/deploy/terraform/run/sap_system/module.tf
@@ -448,6 +448,7 @@ module "output_files" {
   hana_log                                      = module.hdb_node.hana_log_ANF_volumes
   hana_shared                                   = var.NFS_provider == "ANF" ? module.hdb_node.hana_shared : module.hdb_node.hana_shared_afs_path
   usr_sap                                       = module.common_infrastructure.usrsap_path
+  use_AFS_encryption_in_transit                 = module.common_infrastructure.use_AFS_encryption_in_transit
 
   #########################################################################################
   #  DNS information                                                                      #

--- a/deploy/terraform/run/sap_system/tfvar_variables.tf
+++ b/deploy/terraform/run/sap_system/tfvar_variables.tf
@@ -1320,6 +1320,18 @@ variable "sapmnt_private_endpoint_id"           {
                                                   default     = ""
                                                 }
 
+variable "use_AFS_for_shared_storage"              {
+                                                     description = "If true, will use AFS for all shared storage."
+                                                     type        = bool
+                                                     default     = false
+                                                   }
+
+variable AFS_enable_encryption_in_transit       {
+                                                  description = "Enable encryption in transit for Azure Files"
+                                                  type        = bool
+                                                  default     = false
+                                                }
+
 #########################################################################################
 #                                                                                       #
 #  ANF settings                                                                         #

--- a/deploy/terraform/run/sap_system/variables_global.tf
+++ b/deploy/terraform/run/sap_system/variables_global.tf
@@ -1,40 +1,40 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-variable "application_tier"             {
-                                          description = "Details of the Application layer"
-                                                                                  default = {
-                                                          enable_deployment        = true
-                                                          use_DHCP                 = false
-                                                          application_server_count = 0
-                                                          dual_nics                = false
-                                                        }
+variable "application_tier"            {
+                                         description = "Details of the Application layer"
+                                         default = {
+                                                      enable_deployment        = true
+                                                      use_DHCP                 = false
+                                                      application_server_count = 0
+                                                      dual_nics                = false
+                                                   }
 
-                                        }
+                                       }
 
-variable "databases" {
-                                          description = "Details of the database node"
-                                          default = [
-                                            {
-                                              use_DHCP = false
+variable "databases"                   {
+                                         description = "Details of the database node"
+                                         default = [
+                                           {
+                                             use_DHCP = false
 
-                                            }
-                                          ]
-                                        }
+                                           }
+                                         ]
+                                       }
 
-variable "infrastructure"               {
-                                          description = "Details of the Azure infrastructure to deploy the SAP landscape into"
-                                          default = {}
-                                        }
+variable "infrastructure"              {
+                                         description = "Details of the Azure infrastructure to deploy the SAP landscape into"
+                                         default = {}
+                                       }
 
-variable "options"                      {
-                                          description = "Configuration options"
-                                          default     = {
-                                                          resource_offset   = 0
-                                                          nsg_asg_with_vnet = false
-                                                          legacy_nic_order  = false
-                                                        }
-}
+variable "options"                     {
+                                         description = "Configuration options"
+                                         default     = {
+                                                        resource_offset   = 0
+                                                        nsg_asg_with_vnet = false
+                                                        legacy_nic_order  = false
+                                                      }
+                                       }
 
 variable "ssh-timeout"                 {
                                           description = "Timeout for connection that is used by provisioner"
@@ -75,35 +75,36 @@ variable "tfstate_resource_id"         {
 
                                        }
 
-variable "deployer_tfstate_key"       {
-                                          description = "The key of deployer's remote tfstate file"
-                                          default      =  ""
-                                      }
+variable "deployer_tfstate_key"        {
+                                           description = "The key of deployer's remote tfstate file"
+                                           default      =  ""
+                                       }
 
-variable "landscape_tfstate_key"      {
+variable "landscape_tfstate_key"       {
                                           description = "The key of sap landscape's remote tfstate file"
                                           validation {
                                                        condition = (length(trimspace(try(var.landscape_tfstate_key, ""))) != 0)
                                                        error_message = "The Landscape state file name must be specified."
                                                      }
-                                      }
+                                       }
 
-variable "deployment" {
+variable "deployment"                  {
                                           description = "The type of deployment"
                                           default     = "update"
-                                      }
+                                       }
 
-variable "terraform_template_version" {
+variable "terraform_template_version"  {
                                           description = "The version of Terraform templates that were identified in the state file"
                                           default     = ""
-                                      }
+                                       }
 
-variable "license_type"               {
+variable "license_type"                {
                                           description = "Specifies the license type for the OS"
                                           default     = ""
-                                      }
+                                       }
 
-variable "use_zonal_markers"          {
-                                         type         = bool
-                                         default      = true
-                                      }
+variable "use_zonal_markers"           {
+                                          description = "If true, will use zonal markers for all resources that support them."
+                                          type         = bool
+                                          default      = true
+                                       }

--- a/deploy/terraform/terraform-units/modules/sap_landscape/anf.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/anf.tf
@@ -164,7 +164,9 @@ resource "azurerm_netapp_volume" "transport" {
   tags                                 = var.tags
 
   export_policy_rule {
-                       allowed_clients     = ["0.0.0.0/0"]
+                       allowed_clients     = length(var.ANF_settings.export_policy_client_access_list) > 0 ? (
+                                                    var.ANF_settings.export_policy_client_access_list ) : (
+                                                      azurerm_virtual_network.vnet_sap.address_space )
                        protocol            = ["NFSv4.1"]
                        rule_index          = 1
                        unix_read_only      = false
@@ -278,7 +280,9 @@ resource "azurerm_netapp_volume" "install" {
   tags                                 = var.tags
 
   export_policy_rule {
-                       allowed_clients     = ["0.0.0.0/0"]
+                       allowed_clients     = length(var.ANF_settings.export_policy_client_access_list) > 0 ? (
+                                                    var.ANF_settings.export_policy_client_access_list ) : (
+                                                      azurerm_virtual_network.vnet_sap.address_space )
                        protocol            = ["NFSv4.1"]
                        rule_index          = 1
                        unix_read_only      = false

--- a/deploy/terraform/terraform-units/modules/sap_landscape/storage_accounts.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/storage_accounts.tf
@@ -163,7 +163,7 @@ resource "azurerm_storage_account" "witness_storage" {
 
   account_replication_type             = "LRS"
   account_tier                         = "Standard"
-  https_traffic_only_enabled            = true
+  https_traffic_only_enabled           = true
   min_tls_version                      = "TLS1_2"
   allow_nested_items_to_be_public      = false
   cross_tenant_replication_enabled     = false
@@ -301,7 +301,7 @@ resource "azurerm_storage_account" "transport" {
   account_tier                         = "Premium"
   account_replication_type             = "ZRS"
   account_kind                         = "FileStorage"
-  https_traffic_only_enabled            = false
+  https_traffic_only_enabled           = local.use_AFS_encryption_in_transit
   min_tls_version                      = "TLS1_2"
   allow_nested_items_to_be_public      = false
 
@@ -503,7 +503,7 @@ resource "azurerm_storage_account" "install" {
   account_replication_type             = var.storage_account_replication_type
   account_tier                         = "Premium"
   allow_nested_items_to_be_public      = false
-  https_traffic_only_enabled            = false
+  https_traffic_only_enabled           = local.use_AFS_encryption_in_transit
   min_tls_version                      = "TLS1_2"
   cross_tenant_replication_enabled     = false
   public_network_access_enabled        = var.public_network_access_enabled

--- a/deploy/terraform/terraform-units/modules/sap_landscape/variables_global.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/variables_global.tf
@@ -201,7 +201,7 @@ variable "ANF_settings"                                 {
                                                                       transport_volume_name         = ""
                                                                       transport_volume_size         = 32
                                                                       transport_volume_throughput   = 32
-
+                                                                      export_policy_client_access_list = []
                                                                       use_existing_install_volume   = false
                                                                       install_volume_name           = ""
                                                                       install_volume_size           = 128

--- a/deploy/terraform/terraform-units/modules/sap_landscape/variables_global.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/variables_global.tf
@@ -265,7 +265,14 @@ variable "public_network_access_enabled"                 { description = "Define
 
 variable "use_AFS_for_shared_storage"                    {
                                                            description = "If true, will use AFS for installation media."
-                                                           default = false
+                                                           type        = bool
+                                                           default     = false
+                                                         }
+
+variable "AFS_enable_encryption_in_transit"              {
+                                                           description = "Enable encryption in transit for Azure Files"
+                                                           type        = bool
+                                                           default     = false
                                                          }
 
 variable "tags"                                          { description = "List of tags to associate to all resources" }

--- a/deploy/terraform/terraform-units/modules/sap_landscape/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/variables_local.tf
@@ -661,6 +661,7 @@ locals {
 
   use_AFS_for_shared                             = (var.NFS_provider == "ANF" && var.use_AFS_for_shared_storage) || var.NFS_provider == "AFS"
 
+  use_AFS_encryption_in_transit                  = var.NFS_provider == "AFS" && var.AFS_enable_encryption_in_transit
 
   deploy_monitoring_extension                    = var.infrastructure.deploy_monitoring_extension && length(try(var.infrastructure.user_assigned_identity_id,"")) > 0
 

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/anf.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/anf.tf
@@ -41,7 +41,7 @@ resource "azurerm_netapp_volume" "sapmnt" {
   protocols                            = ["NFSv4.1"]
 
   export_policy_rule {
-                       allowed_clients     = ["0.0.0.0/0"]
+                       allowed_clients     = var.infrastructure.virtual_networks.sap.address_space
                        protocol            = ["NFSv4.1"]
                        rule_index          = 1
                        unix_read_only      = false
@@ -89,7 +89,7 @@ resource "azurerm_netapp_volume" "sapmnt_secondary" {
 
   tags                                 = var.tags
   export_policy_rule {
-                       allowed_clients     = ["0.0.0.0/0"]
+                       allowed_clients     = var.infrastructure.virtual_networks.sap.address_space
                        protocol            = ["NFSv4.1"]
                        rule_index          = 1
                        unix_read_only      = false
@@ -169,7 +169,7 @@ resource "azurerm_netapp_volume" "usrsap" {
   tags                                 = var.tags
 
   export_policy_rule {
-                       allowed_clients     = ["0.0.0.0/0"]
+                       allowed_clients     = var.infrastructure.virtual_networks.sap.address_space
                        protocol            = ["NFSv4.1"]
                        rule_index          = 1
                        unix_read_only      = false

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/anf.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/anf.tf
@@ -9,7 +9,7 @@
 
 resource "azurerm_netapp_volume" "sapmnt" {
   provider                             = azurerm.main
-  count                                = var.NFS_provider == "ANF" ? (
+  count                                = var.NFS_provider == "ANF" && !local.use_AFS_for_shared ? (
                                            var.hana_ANF_volumes.use_existing_sapmnt_volume ? (
                                              0
                                              ) : (
@@ -60,7 +60,7 @@ resource "azurerm_netapp_volume" "sapmnt" {
 
 resource "azurerm_netapp_volume" "sapmnt_secondary" {
   provider                             = azurerm.main
-  count                                = var.NFS_provider == "ANF" ? (
+  count                                = var.NFS_provider == "ANF" && !local.use_AFS_for_shared ? (
                                            var.hana_ANF_volumes.sapmnt_use_clone_in_secondary_zone ? (
                                              1
                                              ) : (
@@ -112,7 +112,7 @@ resource "azurerm_netapp_volume" "sapmnt_secondary" {
 
 data "azurerm_netapp_volume" "sapmnt" {
   provider                             = azurerm.main
-  count                                = var.NFS_provider == "ANF" ? (
+  count                                = var.NFS_provider == "ANF" && !local.use_AFS_for_shared ? (
                                            var.hana_ANF_volumes.use_existing_sapmnt_volume ? (
                                              1
                                              ) : (

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/anf.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/anf.tf
@@ -41,7 +41,7 @@ resource "azurerm_netapp_volume" "sapmnt" {
   protocols                            = ["NFSv4.1"]
 
   export_policy_rule {
-                       allowed_clients     = var.infrastructure.virtual_networks.sap.address_space
+                       allowed_clients     = data.azurerm_virtual_network.vnet_sap.address_space
                        protocol            = ["NFSv4.1"]
                        rule_index          = 1
                        unix_read_only      = false

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/outputs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/outputs.tf
@@ -300,6 +300,11 @@ output "usrsap_path"                             {
 
                                                  }
 
+output "use_AFS_encryption_in_transit"           {
+                                                   description = "Indicates if Encryption in transit is enabled for AFS shares"
+                                                   value       = local.use_AFS_encryption_in_transit
+                                                 }
+
 ###############################################################################
 #                                                                             #
 #                       Anchor VM                                             #

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_global.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_global.tf
@@ -216,6 +216,18 @@ variable "enable_firewall_for_keyvaults_and_storage" {
                                                        type        = bool
                                                      }
 
+variable "use_AFS_for_shared_storage"            {
+                                                    description = "If true, will use AFS for installation media."
+                                                    type        = bool
+                                                    default     = false
+                                                 }
+
+variable "AFS_enable_encryption_in_transit"      {
+                                                    description = "Enable encryption in transit for Azure Files"
+                                                    type        = bool
+                                                    default     = false
+                                                 }
+
 #########################################################################################
 #                                                                                       #
 #  DNS settings                                                                         #
@@ -223,9 +235,9 @@ variable "enable_firewall_for_keyvaults_and_storage" {
 #########################################################################################
 
 
-variable "dns_settings"                                 {
-                                                          description = "DNS Settings"
-                                                        }
+variable "dns_settings"                          {
+                                                    description = "DNS Settings"
+                                                 }
 variable "sapmnt_private_endpoint_id"            {
                                                     description = "Azure Resource Identifier for an private endpoint connection"
                                                     type        = string

--- a/deploy/terraform/terraform-units/modules/sap_system/output_files/inventory.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/output_files/inventory.tf
@@ -266,9 +266,6 @@ resource "local_file" "sap-parameters_yml" {
               ams_resource_id             = var.ams_resource_id
               enable_os_monitoring        = var.enable_os_monitoring
               enable_ha_monitoring        = var.enable_ha_monitoring
-              enable_sap_cal              = var.enable_sap_cal
-              calapi_kv                   = var.calapi_kv
-              sap_cal_product_name        = var.sap_cal_product_name
               use_eit_for_afs             = var.use_AFS_encryption_in_transit
               single_server               = length(var.webdispatcher_server_ips) + length(var.application_server_ips) + length(var.scs_server_ips) + length(var.database_server_ips) == 1 ? (
                                             true) : (

--- a/deploy/terraform/terraform-units/modules/sap_system/output_files/inventory.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/output_files/inventory.tf
@@ -266,6 +266,10 @@ resource "local_file" "sap-parameters_yml" {
               ams_resource_id             = var.ams_resource_id
               enable_os_monitoring        = var.enable_os_monitoring
               enable_ha_monitoring        = var.enable_ha_monitoring
+              enable_sap_cal              = var.enable_sap_cal
+              calapi_kv                   = var.calapi_kv
+              sap_cal_product_name        = var.sap_cal_product_name
+              use_eit_for_afs             = var.use_AFS_encryption_in_transit
               single_server               = length(var.webdispatcher_server_ips) + length(var.application_server_ips) + length(var.scs_server_ips) + length(var.database_server_ips) == 1 ? (
                                             true) : (
                                             false

--- a/deploy/terraform/terraform-units/modules/sap_system/output_files/sap-parameters.tmpl
+++ b/deploy/terraform/terraform-units/modules/sap_system/output_files/sap-parameters.tmpl
@@ -161,6 +161,9 @@ ${hana_log}
 ${hana_shared}
 ${usr_sap}
 
+# Indicate if Encryption in Transit is to be used for AFS shares
+use_eit_for_afs:               ${use_eit_for_afs}
+
 #############################################################################
 #                                                                           #
 #                           Miscellaneous                                   #

--- a/deploy/terraform/terraform-units/modules/sap_system/output_files/variables_global.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/output_files/variables_global.tf
@@ -190,9 +190,10 @@ variable "scs_server_vm_resource_ids"           { description = "List of Virtual
 variable "scs_vm_names"                         { description = "List of VM names for the SCS Servers" }
 variable "shared_home"                          { description = "If defined provides shared-home support" }
 variable "sid_keyvault_user_id"                 { description = "Defines the names for the resources" }
-variable "subnet_cidr_storage"                { description = "address prefix for the storage subnet" }
+variable "subnet_cidr_storage"                  { description = "address prefix for the storage subnet" }
 variable "tfstate_resource_id"                  { description = "Resource ID for tf state file" }
 variable "upgrade_packages"                     { description = "Upgrade packages" }
+variable "use_AFS_encryption_in_transit"        { description = "Indicates if Encryption in transit is enabled for AFS shares" }
 variable "use_custom_dns_a_registration"        {
                                                   description = "Boolean value indicating if a custom dns a record should be created when using private endpoints"
                                                   default     = false

--- a/deploy/terraform/terraform-units/modules/sap_system/output_files/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/output_files/variables_local.tf
@@ -33,7 +33,7 @@ locals {
 
   app_tier                             = (local.app_server_count + local.scs_server_count) > 0
 
-  single_server                          = length(var.webdispatcher_server_ips) + length(var.application_server_ips) + length(var.scs_server_ips) + length(var.database_server_ips) == 1 ? (
+  single_server                        = length(var.webdispatcher_server_ips) + length(var.application_server_ips) + length(var.scs_server_ips) + length(var.database_server_ips) == 1 ? (
                                                        true) : (
                                                        false
                                                      )
@@ -71,5 +71,6 @@ locals {
                                           [])
 
   use_local_credentials                = length(var.authentication) > 0
+  use_eit_for_afs                      = var.use_AFS_encryption_in_transit
 
 }


### PR DESCRIPTION
This pull request introduces support for Azure Files NFS Encryption in Transit (EiT) for both RHEL and SUSE systems, adds a helper script and automation for configuring NVMe disks for swap, and enhances configuration options for Azure Files encryption. It also ensures the correct versioning of Ansible collections and updates package lists to include the `aznfs` package where required.

**Azure Files NFS Encryption in Transit (EiT) Support:**

* Added Ansible tasks to automate the installation and validation of EiT prerequisites for RHEL (8.8, 8.10, 9.x+) and SLES (15 SP4+) systems, including repository setup and `aznfs` package installation. 
* Updated OS package variable files to include the `aznfs` package for supported RedHat and SLES versions. 

**NVMe Disk Swap Automation:**

* Added a Bash script (`88-azure-nvme-swap-conf`) to automate filesystem setup for Azure NVMe temp disks, including reinitialization logic and initramfs/dracut updates.
* Integrated the script into the Ansible swap role, ensuring it runs when NVMe disks are used and swap size is zero.

**Azure Files Encryption Configuration:**

* Introduced a new configuration option `AFS_enable_encryption_in_transit` in the landscape model, parameter details, and template, allowing users to specify if encryption in transit should be enabled for Azure Files. 

**Other Improvements:**

* Updated the Ansible workflow to pin the `community.general` collection to version `11.4.1` for reproducibility and stability.