### PR TITLE
Add the Ability to provide BoM component names

### DIFF
--- a/deploy/ansible/roles-sap/0.1-bom-validator/tasks/aggregate_bom.yaml
+++ b/deploy/ansible/roles-sap/0.1-bom-validator/tasks/aggregate_bom.yaml
@@ -8,17 +8,15 @@
     verbosity:                         1
 
 - name:                                 "aggregate_bom: - One time block"
-  when:
-    - first_pass is not defined # Causes to only be run on first pass when called in a loop
   block:
     - name:                            "aggregate_bom: - new bom name"
-      when:                            new_bom_name is not defined
+      when:                            this_bom_name is not defined
       ansible.builtin.set_fact:
-        new_bom_name:                  "{{ bom_base_name }}{{ bom_suffix }}"
+        this_bom_name:                  "{{ bom_base_name }}{{ bom_suffix }}"
 
     - name:                            "Informational"
       ansible.builtin.debug:
-        var:                           new_bom_name
+        var:                           this_bom_name
         verbosity:                     1
 
     # Create download directory structure
@@ -27,7 +25,7 @@
       become:                          "{{ bom_processing_become }}"
       become_user:                     "{{ orchestration_ansible_user }}"
       ansible.builtin.file:
-        path:                          "{{ download_directory }}/bom/{{ new_bom_name }}"
+        path:                          "{{ download_directory }}/bom/{{ this_bom_name }}"
         state:                         directory
         mode:                          0755
 
@@ -38,7 +36,7 @@
       become_user:                     "{{ orchestration_ansible_user }}"
       ansible.builtin.copy:
         content:                       "{{ new_bom | default('NOT DEFINED') }}"
-        dest:                          "{{ download_directory }}/bom/{{ new_bom_name }}/{{ new_bom_name }}.yaml"
+        dest:                          "{{ download_directory }}/bom/{{ this_bom_name }}/{{ this_bom_name }}.yaml"
         mode:                          0644
         force:                         true
       register:                        first_pass

--- a/deploy/ansible/roles-sap/0.1-bom-validator/tasks/aggregate_bom_files.yaml
+++ b/deploy/ansible/roles-sap/0.1-bom-validator/tasks/aggregate_bom_files.yaml
@@ -37,6 +37,12 @@
         mode:                           0755
 
 # Preserve original BOM block
+
+- name:                                 "{{ task_prefix }}: - Check if directory for new BoM exists"
+  ansible.builtin.stat:
+    path:                               "{{ download_directory }}/bom/{{ new_bom_name }}"
+  register:                             original_bom_stats
+
 - name:                                 "{{ task_prefix }}: - Original BOM block"
   vars:
     destination:                        "{{ download_directory }}/bom/{{ new_bom_name }}"
@@ -45,6 +51,7 @@
     file_name:                          "{{ sub_path | basename }}"
     new_file_name:                      "{{ sub_path | basename }}.original"
   when:
+    - original_bom_stats.stat.exists
     - object_stats.stat.mimetype  == "text/plain"
     - file_name                   == this_bom_name + ".yaml"
   block:
@@ -78,6 +85,7 @@
     file_name:                          "{{ sub_path | basename }}"
     new_file_name:                      "{{ sub_path | basename | regex_replace(this_bom_name, new_bom_name) }}"
   when:
+    - original_bom_stats.stat.exists
     - object_stats.stat.mimetype  == "text/plain"         or
       object_stats.stat.mimetype  == "application/pdf"    or
       object_stats.stat.mimetype  == "text/xml"

--- a/deploy/ansible/roles-sap/0.1-bom-validator/tasks/bom_download.yaml
+++ b/deploy/ansible/roles-sap/0.1-bom-validator/tasks/bom_download.yaml
@@ -420,7 +420,11 @@
 
         - name:                            "BOM: {{ bom_name }} Upload File {{ bom_media_entry.archive }} failed"
           ansible.builtin.fail:
-            msg:                           "Authentication error, please check the SAS token"
+            msg: >-
+                                      {{ "Upload failed using SAS token authentication. Please verify the SAS token, storage account, container, and network connectivity. "
+                                         if allowSharedKeyAccess else
+                                         "Upload failed using Azure AD authentication (--auth-mode login). Please ensure you are logged in with 'az login' and have sufficient permissions. " }}
+                                      az storage blob upload stderr: {{ blobUpload.stderr | default("n/a") }}
           when:
             - blobUpload.rc != 0
             - blobUpload.stderr is defined

--- a/deploy/ansible/roles-sap/0.1-bom-validator/tasks/bom_download.yaml
+++ b/deploy/ansible/roles-sap/0.1-bom-validator/tasks/bom_download.yaml
@@ -6,7 +6,7 @@
 # Step: 01
 # Description:  Initialize facts
 #
-- name:                                 "{{ task_prefix }} - BOM: {{ bom_name }} Download {{ bom_media_entry.archive }}"
+- name:                                 "0.1 Bom Validator - Download {{ bom_media_entry.archive }}"
   ansible.builtin.set_fact:
     task_prefix:                        bom_download                            # set the fact so it is globally availabe
     proceed:                            true
@@ -20,16 +20,13 @@
 # Step: 02
 # Description:  Informational
 #
-- name:                                 "{{ task_prefix }} - Informational"
+- name:                                "0.1 Bom Validator - Informational"
   ansible.builtin.debug:
-    var:                                bom_media_entry
-    verbosity:                          1
+    msg:
+      - "Entry : {{ bom_media_entry }}"
+      - "check_storage_account:    {{ check_storage_account }}"
+    verbosity:                         1
 
-- name:                                 "{{ task_prefix }} - Informational"
-  ansible.builtin.debug:
-    msg: |-
-                                        check_storage_account:    {{ check_storage_account }}
-    verbosity:                          1
 # Step: 02 - END
 # -------------------------------------+---------------------------------------8
 
@@ -37,7 +34,7 @@
 # Step: 03
 # Description:
 #
-- name:                                 "{{ task_prefix }} - BOM: {{ bom_name }} Check Storage Account for {{ bom_media_entry.archive }}"
+- name:                                 "0.1 Bom Validator - Check Storage Account for file"
   when:
     - check_storage_account | bool
     - sa_enabled
@@ -48,14 +45,14 @@
   # Step: 03-01
   # Description:
   #
-    - name:                             "{{ task_prefix }} - BOM: {{ bom_name }} Check is file {{ bom_media_entry.archive }} is already downloaded"
+    - name:                             "0.1 Bom Validator - Check if file is already downloaded using SAS token"
       ansible.builtin.uri:
         url:                            "{{ sapbits_location_base_path }}/{{ sapbits_bom_files }}/archives/{{ bom_media_entry.archive }}{% if sapbits_sas_token is not undefined %}?{{ sapbits_sas_token }}{% endif %}"
         status_code:                    [200, 403, 404, 409]
         method:                         HEAD
       register:                         blob_exists
 
-    - name:                             "{{ task_prefix }} - Informational"
+    - name:                             "0.1 Bom Validator - Show if File is downloaded"
       ansible.builtin.debug:
         var:                            blob_exists
         verbosity:                      1
@@ -66,7 +63,7 @@
       # Step: 03-02
       # Description:  Validate the url status. Fail if authentication fails
       #
-    - name:                            "{{ task_prefix }} - BOM: {{ bom_name }} Authentication error {{ bom_media_entry.archive }}"
+    - name:                            "0.1 Bom Validator - Authentication error"
       ansible.builtin.fail:
         msg:                           "Authentication error, please check the SAS token"
       when:                            blob_exists.status == 403
@@ -77,7 +74,7 @@
       # Step: 03-03
       # Description:
       #
-    - name:                            "{{ task_prefix }} - BOM: {{ bom_name }} Set Fact  {{ bom_media_entry.archive }}"
+    - name:                            "0.1 Bom Validator - Set Fact"
       ansible.builtin.set_fact:
         proceed:                       false
       when:                            blob_exists.status != 404
@@ -85,7 +82,7 @@
 # -------------------------------------+---------------------------------------8
 
 
-- name:                                 "{{ task_prefix }} - BOM: {{ bom_name }} Check Storage Account for {{ bom_media_entry.archive }}"
+- name:                                 "0.1 Bom Validator - Check Storage Account for file using Entra authentication"
   when:
     - check_storage_account | bool
     - sa_enabled
@@ -96,7 +93,7 @@
   # Step: 03-01
   # Description:
   #
-    - name:                            "{{ task_prefix }} - BOM: {{ bom_name }} Check is file {{ bom_media_entry.archive }} is already downloaded"
+    - name:                            "0.1 Bom Validator - Check if file is already downloaded using Entra authentication"
       ansible.builtin.command: >-
                                           az storage blob list
                                             --account-name {{ account }}
@@ -106,9 +103,9 @@
       delegate_to:                     localhost
       register:                        blobExists
 
-    - name:                            "{{ task_prefix }} - Informational"
+    - name:                            "0.1 Bom Validator - Informational"
       ansible.builtin.debug:
-        var:                           blobExists
+        msg:                           "blobExists: {{ blobExists }}"
         verbosity:                     2
       # Step: 03-01 - END
       # -------------------------------+---------------------------------------------8
@@ -121,7 +118,7 @@
       # Step: 03-03
       # Description:
       #
-    - name:                            "{{ task_prefix }} - BOM: {{ bom_name }} Set Fact  {{ bom_media_entry.archive }}"
+    - name:                            "0.1 Bom Validator - Set Fact to not proceed"
       ansible.builtin.set_fact:
         proceed:                       false
       when:                            blobExists.stdout | trim | length > 0
@@ -135,7 +132,7 @@
 # Step: 04
 # Description:  Informational check of the proceed parameter.
 #
-- name:                                 "{{ task_prefix }} - Informational check of the proceed parameter"
+- name:                                 "0.1 Bom Validator - Informational check of the proceed parameter"
   ansible.builtin.assert:
     that:
       - "proceed"
@@ -158,6 +155,9 @@
 # Description:
 #
 - name:                                "BOM: Download File {{ bom_media_entry.archive }}"
+  when:
+    - proceed
+    - bom_media_entry.platform is undefined or bom_media_entry.platform | upper == platform
   block:
   # -----------------------------------+-----------------------------------------8
   # Step: 05-01
@@ -191,7 +191,7 @@
       # Step: 05-01-01-on-failure-01
       # Description:
       #
-        - name:                        "BOM: Ensure URL is correct"
+        - name:                        "BOM: Check URL formatting"
           ansible.builtin.set_fact:
             file_url:                  "{{ bom_media_entry.url | lower | urlsplit('scheme') }}://{{ bom_media_entry.url | lower | urlsplit('hostname') }}/{{ bom_media_entry.url | lower | urlsplit('path') | replace('\"', '') }}"
           # Step: 05-01-01-on-failure-01 - END
@@ -201,10 +201,11 @@
           # Step: 05-01-01-on-failure-02
           # Description:
           #
-        - name:                        "BOM: Ensure URL is correct"
+        - name:                        "BOM: Show file URL"
           ansible.builtin.debug:
             msg:
               - "file_url: '{{ file_url }}"
+            verbosity:                 1
           # Step: 05-01-01-on-failure-02 - END
           # ---------------------------+-------------------------------------------------8
 
@@ -235,6 +236,7 @@
           # Step: 05-01-01 - END
           # ---------------------------+-------------------------------------------------8
 
+
   # Step: 05-01 - END
   # -----------------------------------+-----------------------------------------8
 
@@ -242,9 +244,9 @@
   # Step: 05-02
   # Description:
   #
-    - name:                            "BOM: {{ bom_name }} Download File {{ bom_media_entry.archive }}"
+    - name:                            "BOM: Show result from Download File"
       ansible.builtin.debug:
-        var:                           result
+        msg:                           "Download result: {{ result }}"
         verbosity:                     1
   # Step: 05-02 - END
   # -----------------------------------+-----------------------------------------8
@@ -254,26 +256,26 @@
   # Description:  Checksum block
   #
     - name:                            "BOM: Create checksums"
+      when:
+        - bom_media_entry.checksum is not defined
       block:
       # -------------------------------+---------------------------------------------8
       # Step: 05-03-01
       # Description:
       #
-        - name:                        "BOM: Verify Files"
+        - name:                        "BOM: Calculate checksum"
           ansible.builtin.stat:
             path:                      "{{ result.dest }}"
             checksum_algorithm:        sha256
           register:                    fs_check
 
-        - name:                        "BOM: Show"
+        - name:                        "BOM: Show Checksum"
           ansible.builtin.debug:
-            var:                       fs_check
+            msg:
+              - "fs_check:         {{ fs_check }}"
+              - "create_checksums: {{ create_checksums | default(false) }}"
             verbosity:                 1
 
-        - name:                        "BOM: Show"
-          ansible.builtin.debug:
-            var:                       create_checksums
-            verbosity:                 1
       # Step: 05-03-01 - END
       # -------------------------------+---------------------------------------------8
 
@@ -282,40 +284,26 @@
       # Step: 05-03-02
       # Description:
       #
-        - name:                         "block"
-          block:
+        # - name:                         "block"
+        #   when:
+        #     - bom_media_entry.checksum is defined
+        #     - bom_media_entry.checksum | bool is not true
+        #   block:
           # ---------------------------+-------------------------------------------------8
           # Step: 05-03-02-01
           # Description:
           #
 
-            # # MKD - Interesting change to task, but ultimately leaves room for error.
-            # #       It can identify an incorrectly indentented line and insert a line
-            # #       after with a fixed indentation that breakes the yaml structure.
-            # #       This was noticed in a merge conflict during resolution prior to a
-            # #       pull request for the dynamic bom
-            # - name:                        "BOM: Line"
-            #   ansible.builtin.blockinfile:
-            #     path:                      "{{ bom_file }}"
-            #     # regexp:                    '      archive:      {{ item.archive }}'
-            #     insertafter:               '^\s*archive:\s*{{ item.archive }}'
-            #     block:                     "      checksum: {{ fs_check.stat.checksum }}"
-            #     marker:                    "# {mark} ANSIBLE MANAGED BLOCK {{ item.archive }}"
+            # - name:                        "BOM: Add checksum length"
             #   when:
             #     - fs_check is defined
             #     - create_checksums is defined
             #     - bom_file is defined
-
-            - name:                        "BOM: Line"
-              ansible.builtin.blockinfile:
-                path:                      "{{ bom_file }}"
-                insertafter:               '      archive:      {{ bom_media_entry.archive }}'
-                block:                     "      checksum:     {{ fs_check.stat.checksum }}"
-                marker:                    "# {mark} ANSIBLE MANAGED BLOCK {{ bom_media_entry.archive }}"
-              when:
-                - fs_check is defined
-                - create_checksums is defined
-                - bom_file is defined
+            #   ansible.builtin.blockinfile:
+            #     path:                      "{{ bom_file }}"
+            #     insertafter:               '      archive:      {{ bom_media_entry.archive }}'
+            #     block:                     "      checksum:     {{ fs_check.stat.checksum }}"
+            #     marker:                    "# {mark} ANSIBLE MANAGED BLOCK {{ bom_media_entry.archive }}"
           # Step: 05-03-02-01 - END
           # ---------------------------+-------------------------------------------------8
 
@@ -323,23 +311,20 @@
           # Step: 05-03-02-02
           # Description:
           #
-            - name:                        "BOM: Remove marker"
-              ansible.builtin.lineinfile:
-                path:                      "{{ bom_file }}"
-                regexp:                    '# BEGIN ANSIBLE MANAGED BLOCK {{ bom_media_entry.archive }}'
-                state:                      absent
+            # - name:                        "BOM: Remove begin marker"
+            #   ansible.builtin.lineinfile:
+            #     path:                      "{{ bom_file }}"
+            #     regexp:                    '# BEGIN ANSIBLE MANAGED BLOCK {{ bom_media_entry.archive }}'
+            #     state:                      absent
 
-            - name:                        "BOM: Remove marker"
-              ansible.builtin.lineinfile:
-                path:                      "{{ bom_file }}"
-                regexp:                    '# END ANSIBLE MANAGED BLOCK {{ bom_media_entry.archive }}'
-                state:                     absent
+            # - name:                        "BOM: Remove end marker"
+            #   ansible.builtin.lineinfile:
+            #     path:                      "{{ bom_file }}"
+            #     regexp:                    '# END ANSIBLE MANAGED BLOCK {{ bom_media_entry.archive }}'
+            #     state:                     absent
           # Step: 05-03-02-02 - END
           # ---------------------------+-------------------------------------------------8
 
-          when:
-            - bom_media_entry.checksum is defined
-            - bom_media_entry.checksum | bool is not true
       # Step: 05-03-02 - END
       # -------------------------------+---------------------------------------------8
 
@@ -348,6 +333,8 @@
       # Description:  Update in memory BOM
       #
         - name:                         "block"
+          when:
+            - create_checksums is defined
           block:
 
           # ---------------------------+-------------------------------------------------8
@@ -356,9 +343,9 @@
           #
             - name:                                 "Update BOM"
               ansible.builtin.set_fact:
-                bom:                                "{{ bom_update }}"
+                root_media_list:                    "{{ root_media_list_update }}"
               vars:
-                bom_update:                         "{#- -#}{% set _ = bom.materials.media[bom_media_index].update({'checksum': fs_check.stat.checksum}) -%} {{ bom }}"
+                root_media_list_update:             "{#- -#}{% set _ = root_media_list[bom_media_index].update({'checksum': fs_check.stat.checksum}) -%} {{ root_media_list }}"
           # Step: 05-03-03-01 - END
           # ---------------------------+-------------------------------------------------8
 
@@ -366,20 +353,16 @@
           # Step: 05-03-03-02
           # Description:
           #
-            - name:                        "BOM: Show"
+            - name:                        "BOM: Show Entry"
               ansible.builtin.debug:
-                var:                       bom.materials.media[bom_media_index]
+                var:                       root_media_list[bom_media_index]
                 verbosity:                 1
           # Step: 05-03-03-02 - END
           # ---------------------------+-------------------------------------------------8
 
-          when:
-            - create_checksums is defined
       # Step: 05-03-03 - END
       # -------------------------------+---------------------------------------------8
 
-      when:
-        - bom_media_entry.checksum is not defined
   # Step: 05-03 - END
   # -----------------------------------+-----------------------------------------8
 
@@ -414,10 +397,7 @@
           delegate_to:                     localhost
           register:                        blobUpload
           ignore_errors:                   true
-          failed_when:
-            - blobUpload.rc != 0
-            - blobUpload.stderr is defined
-            - blobUpload.stderr.find("BlobAlreadyExists") == -1
+          failed_when:                     false
 
         - name:                            "BOM: {{ bom_name }} Upload File {{ bom_media_entry.archive }}"
           when:
@@ -435,11 +415,15 @@
           delegate_to:                     localhost
           register:                        blobUpload
           ignore_errors:                   true
-          failed_when:
+          failed_when:                     false
+
+        - name:                            "BOM: {{ bom_name }} Upload File {{ bom_media_entry.archive }} failed"
+          ansible.builtin.fail:
+            msg:                           "Authentication error, please check the SAS token"
+          when:
             - blobUpload.rc != 0
             - blobUpload.stderr is defined
             - blobUpload.stderr.find("BlobAlreadyExists") == -1
-
       # Step: 05-04-01 - END
       # -------------------------------+---------------------------------------------8
 
@@ -460,7 +444,6 @@
   # Step: 05-04 - END
   # -----------------------------------+-----------------------------------------8
 
-  when: proceed
 # Step: 05 - END
 # -------------------------------------+---------------------------------------8
 

--- a/deploy/ansible/roles-sap/0.1-bom-validator/tasks/bom_download.yaml
+++ b/deploy/ansible/roles-sap/0.1-bom-validator/tasks/bom_download.yaml
@@ -204,7 +204,7 @@
         - name:                        "BOM: Show file URL"
           ansible.builtin.debug:
             msg:
-              - "file_url: '{{ file_url }}"
+              - "file_url: '{{ file_url }}'"
             verbosity:                 1
           # Step: 05-01-01-on-failure-02 - END
           # ---------------------------+-------------------------------------------------8

--- a/deploy/ansible/roles-sap/0.1-bom-validator/tasks/bom_download.yaml
+++ b/deploy/ansible/roles-sap/0.1-bom-validator/tasks/bom_download.yaml
@@ -257,6 +257,7 @@
   #
     - name:                            "BOM: Create checksums"
       when:
+        - create_checksums | default(false) | bool
         - bom_media_entry.checksum is not defined
       block:
       # -------------------------------+---------------------------------------------8

--- a/deploy/ansible/roles-sap/0.1-bom-validator/tasks/bom_validator.yaml
+++ b/deploy/ansible/roles-sap/0.1-bom-validator/tasks/bom_validator.yaml
@@ -162,7 +162,7 @@
 #
 - name:                                "0.1 BoM Validator - BOM {{ bom_name }} Check and Download Files"
   ansible.builtin.include_tasks:       bom_download.yaml
-  loop:                                "{{ bom.materials.media | flatten(levels=1) }}"
+  loop:                                "{{ root_media_list | flatten(levels=1) }}"
   loop_control:
     loop_var:                           bom_media_entry
     index_var:                          bom_media_index

--- a/deploy/ansible/roles-sap/0.1-bom-validator/tasks/bom_validator.yaml
+++ b/deploy/ansible/roles-sap/0.1-bom-validator/tasks/bom_validator.yaml
@@ -43,7 +43,7 @@
 #
 - name:                             "Informational"
   ansible.builtin.debug:
-    var:                            bom_name
+    msg:                            "Processing BoM: {{ current_bom_name }}"
     verbosity:                      1
 # Step: 01 - END
 # -------------------------------------+---------------------------------------8
@@ -94,6 +94,9 @@
 # Description:  Generate SAS token block
 #
 - name:                                 "Generate SAS token block"
+  when:
+    - sa_enabled
+    - allowSharedKeyAccess
   block:
 
   # -----------------------------------+---------------------------------------8
@@ -149,9 +152,6 @@
 
   vars:
     task_prefix:                        Generate SAS token block
-  when:
-    - sa_enabled
-    - allowSharedKeyAccess
 # Step: 04 - END
 # -------------------------------------+---------------------------------------8
 
@@ -160,13 +160,16 @@
 # Step: 05
 # Description:  Check and download files
 #
-- name:                                "0.1 BoM Validator: - BOM: {{ bom_name }} Check and Download Files"
+- name:                                "0.1 BoM Validator - BOM {{ bom_name }} Check and Download Files"
   ansible.builtin.include_tasks:       bom_download.yaml
   loop:                                "{{ bom.materials.media | flatten(levels=1) }}"
   loop_control:
     loop_var:                           bom_media_entry
     index_var:                          bom_media_index
   no_log:                              false
+  when:
+    - bom_media_entry.archive is defined
+    - bom_media_entry.archive != ''
 # Step: 05 - END
 # -------------------------------------+---------------------------------------8
 
@@ -181,32 +184,21 @@
   # Step: 06-01
   # Description:
   #
-    - name:                             "{{ task_prefix }} - Combine dependent BoMs"
-      ansible.builtin.set_fact:
-        root_media_list:                "{{ root_media_list + bom.materials.media | flatten(levels=1) }}"
-  # Step: 06-01 - END
-  # -------------------------------------+---------------------------------------8
-
-  # -------------------------------------+---------------------------------------8
-  # Step: 06-02
-  # Description:
-  #
-    - name:                             "{{ task_prefix }} - Informational"
+    - name:                             "{{ task_prefix }} - List of files"
       ansible.builtin.debug:
         msg: |-
                                         {{ root_media_list }}
         verbosity:                      1
-  # Step: 06-02 - END
-  # -------------------------------------+---------------------------------------8
+  # Step: 06-01 - END
+  # -----------------------------------+-----------------------------------------8
 
   vars:
     task_prefix:                        Combine dependent BoMs block
-  when: root_media_list is defined
 # Step: 06 - END
-# -------------------------------------+---------------------------------------8
+# -----------------------------------+-----------------------------------------8
 
 
-# -------------------------------------+---------------------------------------8
+# -----------------------------------+-----------------------------------------8
 # Step: 07
 # Description:
 #
@@ -216,66 +208,7 @@
 # Step: 07 - END
 # -------------------------------------+---------------------------------------8
 
-
-# # -------------------------------------+---------------------------------------8
-# # Step: 08
-# # Description:
-# #
-# - name: "Upload"
-#   block:
-
-# # -------------------------------------+---------------------------------------8
-# # Step: 08-01
-# # Description:
-# #
-#     - name:                                "0.1 BoM Validator: - delete old versions of templates"
-#       ansible.builtin.command: >-
-#                                           az storage blob delete-batch
-#                                             --account-name {{ sapbits_location_base_path.rpartition('//')[2].split('.')[0] }}
-#                                             --sas-token {{ sapbits_sas_token }}
-#                                             --source {{ sapbits_location_base_path.rpartition('//')[2].split('/')[1] }}
-#                                             --pattern "{{ sapbits_bom_files }}/boms/{{ bom_base_name }}/templates/*"
-#       delegate_to:                         localhost
-#       ignore_errors:                       false
-#       changed_when:                        false
-# # Step: 08-01 - END
-# # -------------------------------------+---------------------------------------8
-
-# # -------------------------------------+---------------------------------------8
-# # Step: 08-02
-# # Description:
-# #
-#     - name:                                "0.1 BoM Validator: - BOM: {{ bom_name }} Upload Folder"
-#       vars:
-#         bom_container_name:               "{{ sapbits_location_base_path.rpartition('//')[2].split('/')[1] }}/{{ sapbits_bom_files }}/boms"
-#       ansible.builtin.command: >-
-#                                           az storage blob upload-batch
-#                                             --account-name {{ account }}
-#                                             --account-key {{ sapbits_access_key }}
-#                                             --destination "{{ bom_container_name }}/{{ bom_name }}/templates"
-#                                             --source "{{ bom_file.rpartition('/')[0] }}/templates"
-#                                             --overwrite true
-#                                             --if-none-match "*"
-#                                             --no-progress
-#       delegate_to:                         localhost
-#       register:                            bom_upload_azresult
-#       changed_when:                        false
-#       ignore_errors:                       false
-#       failed_when:
-#         - bom_upload_azresult.rc != 0
-#         - bom_upload_azresult.stderr is defined
-#         - bom_upload_azresult.stderr.find("BlobAlreadyExists") == -1
-# # Step: 08-02 - END
-# # -------------------------------------+---------------------------------------8
-
-#   when:
-#     - upload is defined
-#     - upload
-#     - sa_enabled                                              # and Storage Account is enabled
-# # Step: 08 - END
-# # -------------------------------------+---------------------------------------8
-
-...
 # /*---------------------------------------------------------------------------8
 # |                                   END                                      |
 # +------------------------------------4--------------------------------------*/
+...

--- a/deploy/ansible/roles-sap/0.1-bom-validator/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/0.1-bom-validator/tasks/main.yaml
@@ -261,6 +261,9 @@
 - name:                                "0.1 BoM Validator - Save Kernel BOM as Dictionary"
   ansible.builtin.set_fact:
     kernel_bom:                        "{{ bom }}"
+  when:
+    - kernel_bom_name != ""
+    - bom is defined
 
 - name:                                "0.1 BoM Validator - Process dependent BoMs in a loop"
   ansible.builtin.include_tasks:       bom_validator.yaml

--- a/deploy/ansible/roles-sap/0.1-bom-validator/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/0.1-bom-validator/tasks/main.yaml
@@ -176,7 +176,7 @@
 - name:                                "0.1 BoM Validator - Save BOM {{ root_bom_name }} as Dictionary"
   ansible.builtin.set_fact:
     root_bom:                          "{{ bom }}"
-    platform:                          "{% if platform is undefined %}{{ bom.platform | default('HANA') | upper }}{% endif %}"
+    platform:                          "{{ platform | default(bom.platform | default('HANA') | upper) }}"
 # Step: 05 - END
 # -------------------------------------+---------------------------------------8
 

--- a/deploy/ansible/roles-sap/0.1-bom-validator/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/0.1-bom-validator/tasks/main.yaml
@@ -34,7 +34,7 @@
 # Test Cases:
 #
 # +----------------+--------------+
-# |                | Dependancies |
+# |                | Dependencies |
 # |                |      +-------+---------+
 # |                |      | Storage Account |
 # |                |      |   +-------------+
@@ -61,7 +61,7 @@
 ---
 
 # When Fact: pause = true
-- name:                                 "TROUBLESHOOTING: "
+- name:                                 "0.1 BoM Validator - TROUBLESHOOTING: "
   ansible.builtin.pause:
     prompt:                             "Press enter to continue..."
     echo:                               true
@@ -109,7 +109,7 @@
 # Description:  Initialize Facts - Start out with KeyVault and Storage Account
 #               access disabled.
 #
-- name:                                 "Initialize facts"
+- name:                                 "0.1 BoM Validator - Initialize facts"
   ansible.builtin.set_fact:
     kv_enabled:                         false
     sa_enabled:                         false
@@ -129,7 +129,7 @@
 # Step: 02
 # Description:  Call validation for Prerequisites
 #
-- name:                                 "Execute Pre-checks Task"
+- name:                                 "0.1 BoM Validator - Execute Pre-checks Task"
   ansible.builtin.import_tasks:         pre_checks.yaml
 # Step: 02 - END
 # -------------------------------------+---------------------------------------8
@@ -149,12 +149,21 @@
 # Description:  Call BOM processor, passing BOM name.
 #               account and container vars are never used if sa_enabled is False
 #
-- name:                                "0.1 BoM Validator: - Process main BOM"
+
+- name:                                "0.1 BoM Validator - Initialize names"
+  ansible.builtin.set_fact:
+    root_bom_name:                     "{{ bom_base_name.split('-')[0] }}"
+    database_bom_name:                 "{{ bom_base_name.split('-')[1] | default('')}}"
+    kernel_bom_name:                   "{{ bom_base_name.split('-')[2] | default('')}}"
+    new_bom_name:                      "{{ bom_base_name.split('-')[3] | default(bom_base_name.split('-')[0]) }}{{ bom_suffix }}"
+    new_bom_file_name:                 "{{ bom_base_name.split('-')[3] | default(bom_base_name.split('-')[0]) }}{{ bom_suffix }}.yaml"
+
+- name:                                "0.1 BoM Validator - Process main BOM"
   ansible.builtin.include_tasks:       bom_validator.yaml
   vars:
     account:                           "{{ sapbits_location_base_path.rpartition('//')[2].split('.')[0] }}"
     container:                         "{{ sapbits_location_base_path.rpartition('//')[2].split('/')[1] }}/{{ sapbits_bom_files }}/archives"
-    bom_name:                          "{{ bom_base_name }}"
+    current_bom_name:                  "{{ root_bom_name }}"
     upload:                            true
 # Step: 04 - END
 # -------------------------------------+---------------------------------------8
@@ -164,25 +173,33 @@
 # Step: 05
 # Description:  Save BOM and Media list for consolidation
 #
-- name:                                "0.1 BoM Validator: - Save BOM {{ bom_base_name }} as Dictionary"
+- name:                                "0.1 BoM Validator - Save BOM {{ root_bom_name }} as Dictionary"
   ansible.builtin.set_fact:
     root_bom:                          "{{ bom }}"
-    root_media_list:                   "{{ bom.materials.media | flatten(levels=1) }}"
+    platform:                          "{% if platform is undefined %}{{ bom.platform | default('HANA') | upper }}{% endif %}"
 # Step: 05 - END
 # -------------------------------------+---------------------------------------8
 
+- name:                                "0.1 BoM Validator - Informational"
+  ansible.builtin.debug:
+    msg:
+      - "BOM Base Name:          {{ bom_base_name }}"
+      - "Application BOM Name:   {{ root_bom_name }}"
+      - "Database BOM Name:      {{ database_bom_name }}"
+      - "Kernel BOM Name:        {{ kernel_bom_name }}"
+      - "New BOM Name:           {{ new_bom_name }}"
 
-# -------------------------------------+---------------------------------------8
-# Step: 06
-# Description:  Call BOM processor, passing dependent BOM names.
-#               account and container vars are never used if sa_enabled is False
-#
-- name:                                "0.1 BoM Validator: - Process dependent BoMs in a loop"
+
+# # -------------------------------------+---------------------------------------8
+# # Step: 08
+# # Description: Dependencies processing
+
+- name:                                "0.1 BoM Validator - Process dependent BoMs in a loop"
   ansible.builtin.include_tasks:       bom_validator.yaml
   vars:
     account:                           "{{ sapbits_location_base_path.rpartition('//')[2].split('.')[0] }}"
     container:                         "{{ sapbits_location_base_path.rpartition('//')[2].split('/')[1] }}/{{ sapbits_bom_files }}/archives"
-    bom_name:                          "{{ bom_dependency.name }}"
+    current_bom_name:                  "{{ bom_dependency.name }}"
     upload:                            false
   register:                            dependent_bom_collection
   loop:                                "{{ bom.materials.dependencies | flatten(levels=1) }}"
@@ -190,16 +207,107 @@
     loop_var:                          bom_dependency
   when:
     - bom.materials.dependencies is defined
-    - bom.materials.dependencies | length>0
-# Step: 06 - END
-# -------------------------------------+---------------------------------------8
+    - bom.materials.dependencies | length > 0
+
+- name:                                "0.1 BoM Validator - Process database BOM"
+  when:
+    - database_bom_name != ""
+  ansible.builtin.include_tasks:       bom_validator.yaml
+  vars:
+    account:                           "{{ sapbits_location_base_path.rpartition('//')[2].split('.')[0] }}"
+    container:                         "{{ sapbits_location_base_path.rpartition('//')[2].split('/')[1] }}/{{ sapbits_bom_files }}/archives"
+    current_bom_name:                  "{{ database_bom_name }}"
+    upload:                            false
+
+- name:                                "0.1 BoM Validator - Save BOM {{ database_bom_name }} as Dictionary"
+  ansible.builtin.set_fact:
+    database_bom:                      "{{ bom }}"
+
+- name:                                "0.1 BoM Validator - Save minimumDistroVersions"
+  ansible.builtin.set_fact:
+    minimumRedHatVersion:              "{% if bom.minimumRedHatVersion is defined %}{{ bom.minimumRedHatVersion }}{% endif %}"
+    minimumSLESVersion:                "{% if bom.minimumSLESVersion is defined %}{{ bom.minimumSLESVersion }}{% endif %}"
 
 
+- name:                                "0.1 BoM Validator - Process dependent BoMs in a loop"
+  ansible.builtin.include_tasks:       bom_validator.yaml
+  vars:
+    account:                           "{{ sapbits_location_base_path.rpartition('//')[2].split('.')[0] }}"
+    container:                         "{{ sapbits_location_base_path.rpartition('//')[2].split('/')[1] }}/{{ sapbits_bom_files }}/archives"
+    current_bom_name:                  "{{ bom_dependency.name }}"
+    upload:                            false
+  register:                            dependent_bom_collection
+  loop:                                "{{ bom.materials.dependencies | flatten(levels=1) }}"
+  loop_control:
+    loop_var:                          bom_dependency
+  when:
+    - bom.materials.dependencies is defined
+    - bom.materials.dependencies | length > 0
+
+- name:                                "0.1 BoM Validator - Process kernel BOM"
+  when:
+    - kernel_bom_name != ""
+  ansible.builtin.include_tasks:       bom_validator.yaml
+  vars:
+    account:                           "{{ sapbits_location_base_path.rpartition('//')[2].split('.')[0] }}"
+    container:                         "{{ sapbits_location_base_path.rpartition('//')[2].split('/')[1] }}/{{ sapbits_bom_files }}/archives"
+    current_bom_name:                  "{{ kernel_bom_name }}"
+    upload:                            false
+
+- name:                                "0.1 BoM Validator - Save Kernel BOM as Dictionary"
+  ansible.builtin.set_fact:
+    kernel_bom:                        "{{ bom }}"
+
+- name:                                "0.1 BoM Validator - Process dependent BoMs in a loop"
+  ansible.builtin.include_tasks:       bom_validator.yaml
+  vars:
+    account:                           "{{ sapbits_location_base_path.rpartition('//')[2].split('.')[0] }}"
+    container:                         "{{ sapbits_location_base_path.rpartition('//')[2].split('/')[1] }}/{{ sapbits_bom_files }}/archives"
+    current_bom_name:                  "{{ bom_dependency.name }}"
+    upload:                            false
+  register:                            dependent_bom_collection
+  loop:                                "{{ bom.materials.dependencies | flatten(levels=1) }}"
+  loop_control:
+    loop_var:                          bom_dependency
+  when:
+    - bom.materials.dependencies is defined
+    - bom.materials.dependencies | length > 0
+
+- name:                                "0.1 BoM Validator -  - Show Application, Database, and Kernel BOMs"
+  ansible.builtin.debug:
+    msg:
+      - "Application Platform                {{ root_bom.platform | default('Not defined') }}"
+      - "Application supported Databases:    {{ root_bom.supportedPlatforms | default('Not defined') }}"
+      - "Application supported DB Versions:  {{ root_bom.supportedDBVersions | default('Not defined') }}"
+      - "Application supported Kernels:      {{ root_bom.supportedKernels | default('Not defined') }}"
+      - "Database Platform:                  {{ database_bom.platform | default('Not defined') }}"
+      - "Database Version:                   {{ database_bom.version | default('Not defined') }}"
+      - "Kernel Version:                     {{ kernel_bom.kernel | default('Not defined') }}"
+
+- name:                                "0.1 BoM Validator - Incompatible Application and Database BOM"
+  ansible.builtin.fail:
+    msg:
+      - "Incompatible combination of Application BOM (platform: {{ root_bom.supportedPlatforms }}) and Database BOM (platform: {{ database_bom.platform }}, version: {{ database_bom.version }})."
+  when:
+    - database_bom is defined
+    - root_bom.supportedPlatforms is defined
+    - root_bom.supportedDBVersions is defined
+    - (database_bom.platform is not in root_bom.supportedPlatforms) or (database_bom.version is not in root_bom.supportedDBVersions)
+
+- name:                                "0.1 BoM Validator - Incompatible Application and Kernel BOM"
+  ansible.builtin.fail:
+    msg:
+      - "Incompatible combination of Application BOM (Supported Kernels: {{ root_bom.supportedKernels }}) and Kernel BOM (kernel: {{ kernel_bom.kernel }})."
+  when:
+    - kernel_bom is defined
+    - root_bom.supportedKernels is defined
+    - kernel_bom.kernel is not in root_bom.supportedKernels
+
 # -------------------------------------+---------------------------------------8
-# Step: 07
+# Step: 06
 # Description:  Deduplicate entries in consolidated BOM Media list
 #
-- name:                                "0.1 BOM Validator: - Filter combined BoM"
+- name:                                "0.1 BoM Validator - Filter combined BoM"
   ansible.builtin.set_fact:
     root_media_list:                   "{{ root_media_list | unique(attribute='archive') | list }}"
 # Step: 07 - END
@@ -214,7 +322,7 @@
   ansible.builtin.set_fact:
     new_bom:                           "{{ lookup('template', 'bom.j2') }}"
 
-- name:                               "Informational"
+- name:                               "0.1 BoM Validator - Show new BoM"
   ansible.builtin.debug:
     var:                              new_bom
     verbosity:                        1
@@ -227,34 +335,35 @@
 # Description:  Aggregate BOM files - Loop through all BOM directories used and
 #               build consolidated BOM directory.
 #
-- name:                                 "main: - Informational"
+- name:                                 "0.1 BoM Validator - Informational"
   ansible.builtin.debug:
     var:                                aggregated_bom_directories
     verbosity:                          1
 
-- name:                                 "main: - Aggregate BOM files"
+- name:                                 "0.1 BoM Validator - Aggregate BOM files"
   ansible.builtin.include_tasks:        aggregate_bom.yaml
   loop:                                "{{ aggregated_bom_directories }}"
   loop_control:
     loop_var:                          bom_dir
 
-# - name:                                "0.1 BOM Validator: - remove BoM"
-#   # become:                              true
-#   # become_user:                         root
-#   delegate_to:                         localhost
-#   ansible.builtin.file:
-#     path:                              "{{ download_directory }}/bom/{{ bom_base_name }}.yaml"
-#     state:                             absent
+- name:                                "0.1 BOM Validator: - Create BoM Directory"
+  become:                              true
+  become_user:                         "{{ orchestration_ansible_user }}"
+  delegate_to:                         localhost
+  ansible.builtin.file:
+    path:                              "{{ download_directory }}/bom/{{ new_bom_name }}"
+    state:                             directory
+    mode:                              0755
 
-# - name:                                "0.1 BOM Validator: - write combined BoM"
-#   # become:                              true
-#   # become_user:                         root
-#   delegate_to:                         localhost
-#   ansible.builtin.copy:
-#     content:                           "{{ new_bom }}"
-#     dest:                              "{{ download_directory }}/bom/{{ bom_base_name }}{{ bom_suffix }}.yaml"
-#     mode:                              0644
-#     force:                             true
+- name:                                "0.1 BOM Validator: - write combined BoM"
+  become:                              true
+  become_user:                         "{{ orchestration_ansible_user }}"
+  delegate_to:                         localhost
+  ansible.builtin.copy:
+    content:                           "{{ new_bom }}"
+    dest:                              "{{ download_directory }}/bom/{{ new_bom_name }}/{{ new_bom_name }}{{ bom_suffix }}.yaml"
+    mode:                              0644
+    force:                             true
 
 # Step: 09 - END
 # -------------------------------------+---------------------------------------8
@@ -264,22 +373,23 @@
 # Step: 10
 # Description:  Upload New Customer BOM to Storage Account
 #
-- name: "BOM Upload"
+- name: "BOM Upload using SAS token"
   when:
     - sa_enabled
+    - allowSharedKeyAccess
   block:
 
 # -------------------------------------+---------------------------------------8
 # Step: 10-01
 # Description:
 #
-    - name:                               "0.1 BoM Validator: - delete combined BoM using SAS Token"
+    - name:                               "0.1 BoM Validator - delete combined BoM using SAS Token"
       ansible.builtin.command: >-
                                           az storage blob delete
                                             --account-name {{ sapbits_location_base_path.rpartition('//')[2].split('.')[0] }}
                                             --sas-token {{ sapbits_sas_token }}
                                             --container-name {{ sapbits_location_base_path.rpartition('//')[2].split('/')[1] }}/{{ sapbits_bom_files }}/boms/{{ new_bom_name }}
-                                            --name {{ bom_base_name }}.yaml
+                                            --name {{ new_bom_name }}.yaml
       delegate_to:                         localhost
       register:                            azresult
       changed_when:                        false
@@ -287,23 +397,6 @@
         - azresult.rc != 0
         - azresult.stderr is defined
         - azresult.stderr.find("BlobNotFound") == -1
-      when:                                allowSharedKeyAccess
-
-    - name:                               "0.1 BoM Validator: - delete combined BoM"
-      ansible.builtin.command: >-
-                                          az storage blob delete
-                                            --account-name {{ sapbits_location_base_path.rpartition('//')[2].split('.')[0] }}
-                                            --auth-mode login
-                                            --container-name {{ sapbits_location_base_path.rpartition('//')[2].split('/')[1] }}/{{ sapbits_bom_files }}/boms/{{ new_bom_name }}
-                                            --name {{ bom_base_name }}.yaml
-      delegate_to:                         localhost
-      register:                            azresult
-      changed_when:                        false
-      failed_when:
-        - azresult.rc != 0
-        - azresult.stderr is defined
-        - azresult.stderr.find("BlobNotFound") == -1
-      when:                                not allowSharedKeyAccess
 
 # Step: 10-01 - END
 # -------------------------------------+---------------------------------------8
@@ -313,7 +406,7 @@
 # Step: 10-02
 # Description:
 #
-    - name:                                "0.1 BoM Validator: - Upload combined BoM using SAS Token"
+    - name:                                "0.1 BoM Validator - Upload combined BoM using SAS Token"
       ansible.builtin.command: >-
                                           az storage blob upload-batch
                                             --account-name  {{ sapbits_location_base_path.rpartition('//')[2].split('.')[0] }}
@@ -330,9 +423,69 @@
         - azresult.rc != 0
         - azresult.stderr is defined
         - azresult.stderr.find("BlobAlreadyExists") == -1
-      when:                                allowSharedKeyAccess
 
-    - name:                                "0.1 BoM Validator: - Upload combined BoM"
+# Step: 10-02 - END
+# -------------------------------------+---------------------------------------8
+
+
+# -------------------------------------+---------------------------------------8
+# Step: 10-03
+# Description:
+#
+    - name:                             "0.1 BoM Validator - Remove temporary directory"
+      ansible.builtin.file:
+        path:                           "{{ download_directory }}/bom/{{ new_bom_name }}"
+        state:                          absent
+# Step: 10-03 - END
+# -------------------------------------+---------------------------------------8
+
+
+# -------------------------------------+---------------------------------------8
+# Step: 10-04
+# Description:
+#
+    - name:                                "0.1 BoM Validator - Show Storage Account BOM folder path"
+      ansible.builtin.debug:
+        msg:
+          - "Bill of Materials ({{ new_bom_name }}) created."
+          - "Software download location: {{ sapbits_location_base_path }}/{{ sapbits_bom_files }}/boms/{{ new_bom_name }}"
+# Step: 10-04 - END
+# -------------------------------------+---------------------------------------8
+
+- name: "BOM Upload"
+  when:
+    - sa_enabled
+    - not allowSharedKeyAccess
+  block:
+
+# -------------------------------------+---------------------------------------8
+# Step: 10-01
+# Description:
+#
+    - name:                               "0.1 BoM Validator - delete combined BoM"
+      ansible.builtin.command: >-
+                                          az storage blob delete
+                                            --account-name {{ sapbits_location_base_path.rpartition('//')[2].split('.')[0] }}
+                                            --auth-mode login
+                                            --container-name {{ sapbits_location_base_path.rpartition('//')[2].split('/')[1] }}/{{ sapbits_bom_files }}/boms/{{ new_bom_name }}
+                                            --name {{ root_bom_name }}.yaml
+      delegate_to:                         localhost
+      register:                            azresult
+      changed_when:                        false
+      failed_when:
+        - azresult.rc != 0
+        - azresult.stderr is defined
+        - azresult.stderr.find("BlobNotFound") == -1
+
+# Step: 10-01 - END
+# -------------------------------------+---------------------------------------8
+
+
+# -------------------------------------+---------------------------------------8
+# Step: 10-02
+# Description:
+#
+    - name:                                "0.1 BoM Validator - Upload combined BoM"
       ansible.builtin.command: >-
                                           az storage blob upload-batch
                                             --account-name  {{ sapbits_location_base_path.rpartition('//')[2].split('.')[0] }}
@@ -349,7 +502,6 @@
         - azresult.rc != 0
         - azresult.stderr is defined
         - azresult.stderr.find("BlobAlreadyExists") == -1
-      when:                                not allowSharedKeyAccess
 
 # Step: 10-02 - END
 # -------------------------------------+---------------------------------------8
@@ -359,7 +511,7 @@
 # Step: 10-03
 # Description:
 #
-    - name:                             "Remove temporary directory"
+    - name:                             "0.1 BoM Validator - Remove temporary directory"
       ansible.builtin.file:
         path:                           "{{ download_directory }}/bom/{{ new_bom_name }}"
         state:                          absent
@@ -371,11 +523,14 @@
 # Step: 10-04
 # Description:
 #
-    - name:                                "Show Storage Account BOM folder path"
+    - name:                                "0.1 BoM Validator - Show Storage Account BOM folder path"
       ansible.builtin.debug:
-        msg:                               "{{ sapbits_location_base_path }}/{{ sapbits_bom_files }}/boms/{{ new_bom_name }}"
+        msg:
+          - "Bill of Materials ({{ new_bom_name }}) created."
+          - "Software download location: {{ sapbits_location_base_path }}/{{ sapbits_bom_files }}/boms/{{ new_bom_name }}"
 # Step: 10-04 - END
 # -------------------------------------+---------------------------------------8
+
 
 # Step: 10 - END
 # -------------------------------------+---------------------------------------8
@@ -384,9 +539,11 @@
 # Step: 11
 # Description:  When Storage Account access is disabled, show local path.
 #
-- name:                                "Show local BOM folder path"
+- name:                                "0.1 BoM Validator - Show local BOM folder path"
   ansible.builtin.debug:
-    msg:                               "{{ download_directory }}/bom/{{ new_bom_name }}"
+    msg:
+          - "Bill of Materials ({{ new_bom_name }}) created."
+          - "Software download location: {{ download_directory }}/bom/{{ new_bom_name }}"
   when:
     - not sa_enabled
 # Step: 11 - END

--- a/deploy/ansible/roles-sap/0.1-bom-validator/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/0.1-bom-validator/tasks/main.yaml
@@ -361,7 +361,7 @@
   delegate_to:                         localhost
   ansible.builtin.copy:
     content:                           "{{ new_bom }}"
-    dest:                              "{{ download_directory }}/bom/{{ new_bom_name }}/{{ new_bom_name }}{{ bom_suffix }}.yaml"
+    dest:                              "{{ download_directory }}/bom/{{ new_bom_name }}/{{ new_bom_file_name }}"
     mode:                              0644
     force:                             true
 

--- a/deploy/ansible/roles-sap/0.1-bom-validator/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/0.1-bom-validator/tasks/main.yaml
@@ -292,7 +292,7 @@
     - database_bom is defined
     - root_bom.supportedPlatforms is defined
     - root_bom.supportedDBVersions is defined
-    - (database_bom.platform is not in root_bom.supportedPlatforms) or (database_bom.version is not in root_bom.supportedDBVersions)
+    - (database_bom.platform not in root_bom.supportedPlatforms) or (database_bom.version not in root_bom.supportedDBVersions)
 
 - name:                                "0.1 BoM Validator - Incompatible Application and Kernel BOM"
   ansible.builtin.fail:
@@ -301,7 +301,7 @@
   when:
     - kernel_bom is defined
     - root_bom.supportedKernels is defined
-    - kernel_bom.kernel is not in root_bom.supportedKernels
+    - kernel_bom.kernel not in root_bom.supportedKernels
 
 # -------------------------------------+---------------------------------------8
 # Step: 06

--- a/deploy/ansible/roles-sap/0.1-bom-validator/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/0.1-bom-validator/tasks/main.yaml
@@ -152,12 +152,12 @@
 
 - name:                                "0.1 BoM Validator - Initialize names"
   ansible.builtin.set_fact:
-    root_bom_name:                     "{{ bom_base_name.split('-')[0] }}"
-    database_bom_name:                 "{{ bom_base_name.split('-')[1] | default('')}}"
-    kernel_bom_name:                   "{{ bom_base_name.split('-')[2] | default('')}}"
-    new_bom_name:                      "{{ bom_base_name.split('-')[3] | default(bom_base_name.split('-')[0]) }}{{ bom_suffix }}"
-    new_bom_file_name:                 "{{ bom_base_name.split('-')[3] | default(bom_base_name.split('-')[0]) }}{{ bom_suffix }}.yaml"
-
+    bom_parts:                          "{{ bom_base_name.split('-') }}"
+    root_bom_name:                     "{{ bom_parts[0] }}"
+    database_bom_name:                 "{{ bom_parts[1] if bom_parts|length > 1 else '' }}"
+    kernel_bom_name:                   "{{ bom_parts[2] if bom_parts|length > 2 else '' }}"
+    new_bom_name:                      "{{ bom_parts[3] if bom_parts|length > 3 else bom_parts[0] }}{{ bom_suffix }}"
+    new_bom_file_name:                 "{{ bom_parts[3] if bom_parts|length > 3 else bom_parts[0] }}{{ bom_suffix }}.yaml"
 - name:                                "0.1 BoM Validator - Process main BOM"
   ansible.builtin.include_tasks:       bom_validator.yaml
   vars:

--- a/deploy/ansible/roles-sap/0.1-bom-validator/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/0.1-bom-validator/tasks/main.yaml
@@ -220,10 +220,14 @@
     upload:                            false
 
 - name:                                "0.1 BoM Validator - Save BOM {{ database_bom_name }} as Dictionary"
+  when:
+    - database_bom_name != ""
   ansible.builtin.set_fact:
     database_bom:                      "{{ bom }}"
 
 - name:                                "0.1 BoM Validator - Save minimumDistroVersions"
+  when:
+    - database_bom_name != ""
   ansible.builtin.set_fact:
     minimumRedHatVersion:              "{% if bom.minimumRedHatVersion is defined %}{{ bom.minimumRedHatVersion }}{% endif %}"
     minimumSLESVersion:                "{% if bom.minimumSLESVersion is defined %}{{ bom.minimumSLESVersion }}{% endif %}"

--- a/deploy/ansible/roles-sap/0.1-bom-validator/tasks/pre_checks.yaml
+++ b/deploy/ansible/roles-sap/0.1-bom-validator/tasks/pre_checks.yaml
@@ -30,7 +30,7 @@
 #         - text        = AnsibleUnicode
 #         - boolean     = bool
 #
-- name:                                 "(pre_checks.yaml) - Validate required variable is present and not empty (bom_base_name)"
+- name:                                 "0.1 BoM Validator - Pre Check - Validate required variable is present and not empty (bom_base_name)"
   ansible.builtin.assert:
     that:
       - "bom_base_name is defined"                                              # Has the variable been defined
@@ -54,10 +54,10 @@
 #                 - s_password
 #               from KeyVault when they are not already defined.
 #
-- name:                                 "(pre_checks.yaml) - KeyVault validation block..."
+- name:                                 "0.1 BoM Validator - Pre Check - KeyVault validation block..."
   block:
 
-    - name:                             "(pre_checks.yaml) - {{ task_prefix }} - Informational"
+    - name:                             "0.1 BoM Validator - Pre Check - {{ task_prefix }} - Informational"
       ansible.builtin.debug:
         msg: |-
                                         Entering KV Block...
@@ -67,7 +67,7 @@
 # Step: 02-01
 # Description:
 #
-    - name:                             "(pre_checks.yaml) - {{ task_prefix }} - Set deployer keyvault name"
+    - name:                             "0.1 BoM Validator - Pre Check - {{ task_prefix }} - Set deployer keyvault name"
       ansible.builtin.set_fact:
         kv_name:                        "{{ deployer_kv_name }}"
       when:                             deployer_kv_name is defined
@@ -78,7 +78,7 @@
 # Step: 02-02
 # Description:
 #
-    - name:                             "(pre_checks.yaml) - {{ task_prefix }} - Load the keyvault secrets"
+    - name:                             "0.1 BoM Validator - Pre Check - {{ task_prefix }} - Load the keyvault secrets"
       ansible.builtin.include_role:
         name:                           roles-misc/0.2-kv-secrets
         public:                         true
@@ -93,7 +93,7 @@
 # Step: 02-03
 # Description:
 #
-    - name:                             "(pre_checks.yaml) - {{ task_prefix }} - Set kv_enabled: true"
+    - name:                             "0.1 BoM Validator - Pre Check - Set kv_enabled: true"
       ansible.builtin.set_fact:
         kv_enabled:                     true
       when:
@@ -118,7 +118,7 @@
 # Step: 03
 # Description:  Informational check of the kv_name parameter.
 #
-- name:                                "(pre_checks.yaml) - Informational check of the kv_name parameter"
+- name:                                "0.1 BoM Validator - Pre Check - Informational check of the kv_name parameter"
   ansible.builtin.assert:
     that:
       - "kv_name is defined"                                                    # Has the variable been defined
@@ -142,7 +142,7 @@
 # Step: 04
 # Description:  Validation for s_user
 #
-- name:                                 "(pre_checks.yaml) - Check that the S-User is present and not empty (s_user)"
+- name:                                 "0.1 BoM Validator - Pre Check - Check that the S-User is present and not empty (s_user)"
   ansible.builtin.assert:
     that:
       - "s_user is defined"                                                     # Has the variable been defined
@@ -163,7 +163,7 @@
 # Step: 05
 # Description:  Validate that s_password parameter has been given a value
 #
-- name:                                 "(pre_checks.yaml) - Check that the S-User password is present and not empty (s_password)"
+- name:                                 "0.1 BoM Validator - Pre Check - Check that the S-User password is present and not empty (s_password)"
   ansible.builtin.assert:
     that:
       - "s_password is defined"                                                 # Has the variable been defined
@@ -187,7 +187,7 @@
 #               is an intermediary location to stage files before upload to SA.
 #               Default: ~/tmp/downloads
 #
-- name:                                 "(pre_checks.yaml) - Check that the Download Directory is present and not empty (download_directory)"
+- name:                                 "0.1 BoM Validator - Pre Check - Check that the Download Directory is present and not empty (download_directory)"
   ansible.builtin.assert:
     that:
       - "download_directory is defined"                                              # Has the variable been defined
@@ -206,9 +206,11 @@
 # Step: 07
 # Description:  Create BOM download directories".
 #
-# TODO: allow for concurrancy by using unique tmp directory dtructure.
+# TODO: allow for concurrency by using unique tmp directory structure.
 #
-- name:                                 "(pre_checks.yaml) - Prepare download directory"
+- name:                                 "0.1 BoM Validator - Pre Check - Prepare download directory"
+  when:
+    - download_directory
   block:
 
 # -------------------------------------+---------------------------------------8
@@ -230,7 +232,6 @@
         - "{{ download_directory }}/files"
         - "{{ download_directory }}/bom"
 
-
 # Step: 07-01 - END
 # -------------------------------------+---------------------------------------8
 
@@ -238,7 +239,7 @@
 # Step: 07-02
 # Description:  Create test file
 #
-    - name:                             "(pre_checks.yaml) - {{ task_prefix }} - BoM Initial file"
+    - name:                             "0.1 BoM Validator - Pre Check - {{ task_prefix }} - Create BoM Initial file"
       ansible.builtin.copy:
         dest:                           "{{ download_directory }}/readme.md"
         content:                        "This is the container with the SAP media"
@@ -250,8 +251,6 @@
 
   vars:
     task_prefix:                        Prepare download directory block
-  when:
-    - download_directory
 # Step: 07 - END
 # -------------------------------------+---------------------------------------8
 
@@ -266,10 +265,10 @@
 #                 - sapbits_sas_token
 #               from KeyVault when they are not already defined.
 #
-- name:                                 "(pre_checks.yaml) - Storage Account validation block"
+- name:                                 "0.1 BoM Validator - Pre Check - Storage Account validation block"
   block:
 
-    - name:                             "(pre_checks.yaml) - {{ task_prefix }} - Informational"
+    - name:                             "0.1 BoM Validator - Pre Check - {{ task_prefix }} - Informational"
       ansible.builtin.debug:
         msg: |-
                                         Entering Storage Account Block...
@@ -280,7 +279,7 @@
 # Step: 08-01
 # Description:  Validate sapbits_bom_files
 #
-    - name:                             "(pre_checks.yaml) - {{ task_prefix }} - Validate required variable is present and not empty (sapbits_bom_files)"
+    - name:                             "0.1 BoM Validator - Pre Check - {{ task_prefix }} - Validate required variable is present and not empty (sapbits_bom_files)"
       ansible.builtin.assert:
         that:
           - "sapbits_bom_files is defined"                                          # Has the variable been defined
@@ -297,7 +296,7 @@
 # Step: 08-02
 # Description:
 #
-    - name:                             "(pre_checks.yaml) - {{ task_prefix }} - Load the storage account details"
+    - name:                             "0.1 BoM Validator - Pre Check - {{ task_prefix }} - Load the storage account details"
       ansible.builtin.include_role:
         name:                           roles-misc/0.3.sap-installation-media-storage-details
         public:                         true
@@ -310,7 +309,7 @@
 # Step: 08-03
 # Description:
 #
-    - name:                             "(pre_checks.yaml) - {{ task_prefix }} - Validate required variable is present and not empty (sapbits_location_base_path)"
+    - name:                             "0.1 BoM Validator - Pre Check - {{ task_prefix }} - Validate required variable is present and not empty (sapbits_location_base_path)"
       ansible.builtin.assert:
         that:
           - "sapbits_location_base_path is defined"                                 # Has the variable been defined
@@ -333,7 +332,7 @@
 # Step: 08 - END
 # -------------------------------------+---------------------------------------8
 
-- name:                                 "(pre_checks.yaml) - {{ task_prefix }} - Get account information"
+- name:                                 "0.1 BoM Validator - Pre Check - {{ task_prefix }} - Get account information"
   ansible.builtin.command: >-
                                         az account show --query user --output yaml
   vars:
@@ -343,15 +342,15 @@
   ignore_errors:                        true
   changed_when:                         false
 
-- name:                                 "(pre_checks.yaml) - {{ task_prefix }} - Show account information"
+- name:                                 "0.1 BoM Validator - Pre Check - {{ task_prefix }} - Show account information"
   ansible.builtin.debug:
-    var:                                azresult
+    msg:                                "Running as: {{ azresult.stdout }}"
 
 # -------------------------------------+---------------------------------------8
 # Step: 09
 # Description:
 #
-- name:                                 "(pre_checks.yaml) - Set SAS Token"
+- name:                                 "0.1 BoM Validator - Pre Check - Set SAS Token"
   ansible.builtin.set_fact:
     sapbits_sas_token:                  "{{ sapbits_access_key }}"
   no_log:                               true                                    # censor output of secret
@@ -366,7 +365,7 @@
 # Step: 10
 # Description:
 #
-- name:                                 "(pre_checks.yaml) - Set sa_enabled: true"
+- name:                                 "0.1 BoM Validator - Pre Check - Set sa_enabled: true"
   ansible.builtin.set_fact:
     sa_enabled:                         true
   when:
@@ -386,7 +385,7 @@
 # Step: 11
 # Description:
 #
-- name:                                 "(pre_checks.yaml) - {{ task_prefix }} - Check storage account container when using SAS Token"
+- name:                                 "0.1 BoM Validator - Pre Check - {{ task_prefix }} - Upload readme.md using SAS Token"
   ansible.builtin.command: >-
                                         az storage blob upload
                                           --account-name {{ sapbits_location_base_path.rpartition('//')[2].split('.')[0] }}
@@ -411,7 +410,7 @@
     - sa_enabled
     - allowSharedKeyAccess
 
-- name:                                 "(pre_checks.yaml) - {{ task_prefix }} - Check storage account container"
+- name:                                 "0.1 BoM Validator - Pre Check - {{ task_prefix }} - Upload readme.md"
   ansible.builtin.command: >-
                                         az storage blob upload
                                           --account-name {{ sapbits_location_base_path.rpartition('//')[2].split('.')[0] }}
@@ -447,7 +446,7 @@
 #   - sapbits_location_base_path
 #   - sapbits_access_key
 #   - sapbits_sas_token
-- name:                                "(pre_checks.yaml) - Informational check of Storage Account parameters"
+- name:                                "0.1 BoM Validator - Pre Check - Informational check of Storage Account parameters"
   ansible.builtin.assert:
     that:
       - "sapbits_location_base_path is defined"                                 # Has the variable been defined
@@ -466,7 +465,7 @@
                                        - "Storage account_name:            {{ account_name }}"
                                        - "allowSharedKeyAccess:            {{ allowSharedKeyAccess }}"
 
-- name:                                "(pre_checks.yaml) - Informational check of Storage Account parameters"
+- name:                                "0.1 BoM Validator - Pre Check - Informational check of Storage Account parameters"
   when:                                 allowSharedKeyAccess
   ansible.builtin.assert:
     that:

--- a/deploy/ansible/roles-sap/0.1-bom-validator/templates/bom.j2
+++ b/deploy/ansible/roles-sap/0.1-bom-validator/templates/bom.j2
@@ -2,16 +2,28 @@
 #
 # Downloaded on {{ ansible_date_time.date }} at {{ ansible_date_time.time }}
 
-name:          {{ root_bom.name }}
-filename:      {% if root_bom.filename is defined %}{{ root_bom.filename }}{% endif %}
+name:                 {{ new_bom_name }}
 
-target:        {{ root_bom.target }}
+filename:             {% if new_bom_file_name is defined %}{{ new_bom_file_name }}{% endif %}
 
-version:       {{ root_bom.version }}
+target:               {{ root_bom.target }}
 
-platform:      {% if root_bom.platform is defined %}{{ root_bom.platform }}{% endif %}
+version:              {{ root_bom.version }}
 
-InstanceType:  {% if root_bom.InstanceType is defined %}{{ root_bom.InstanceType }}{% else %}ABAP{% endif %}
+platform:             {% if root_bom.platform is defined %}{{ root_bom.platform }}{% endif %}
+
+InstanceType:         {% if root_bom.InstanceType is defined %}{{ root_bom.InstanceType }}{% else %}ABAP{% endif %}
+
+supportedPlatforms:   {% if root_bom.supportedPlatforms is defined %}{{ root_bom.supportedPlatforms }}{% endif %}
+
+supportedDBVersions:  {% if root_bom.supportedDBVersions is defined %}{{ root_bom.supportedDBVersions }}{% endif %}
+
+supportedKernels:     {% if root_bom.supportedKernels is defined %}{{ root_bom.supportedKernels }}{% endif %}
+
+minimumRedHatVersion: {% if minimumRedHatVersion is defined %}{{ minimumRedHatVersion }}{% endif %}
+
+minimumSLESVersion:   {% if minimumSLESVersion is defined %}{{ minimumSLESVersion }}{% endif %}
+
 
 
 product_ids:
@@ -22,10 +34,10 @@ product_ids:
 {%   endfor %}
 {% endif %}
 
+{% if root_bom.patch_information is defined %}
 
 patch_information:
 
-{% if root_bom.patch_information is defined %}
 {%   for pKey,pValue in root_bom.patch_information.items() %}
 {{'  %-20s' | format(pKey | trim +':') }}{{' \"%s\"' | format(pValue | trim) }}
 {%   endfor %}

--- a/deploy/ansible/roles-sap/3.3-bom-processing/tasks/bom_processor.yaml
+++ b/deploy/ansible/roles-sap/3.3-bom-processing/tasks/bom_processor.yaml
@@ -181,16 +181,13 @@
                                          -xf {{ target_media_location }}/{% if item.path is undefined %}downloads{% else %}{{ item.path }}{% endif %}/\
                                          {% if item.filename is undefined %}{{ item.archive }}{% else %}{{ item.filename }}{% endif %}"
   args:
-    chdir:                             "{{ target_media_location }}/{{ item.extractDir }}"
-    creates:                           "{{ target_media_location }}/{{ item.extractDir }}/ \
+    chdir:                             "{{ target_media_location }}/{{ item.extractDir | default('') }}"
+    creates:                           "{{ target_media_location }}/{{ item.extractDir | default('') }}/ \
                                         {% if item.creates is defined %}{{ item.creates }}{% else %}NOT_DEFINED{% endif %}"
   loop:                                "{{ bom.materials.media | flatten(levels=1) }}"
   when:
-    - item.extract is not undefined
-    - item.extract
-    - ( item.filename is undefined and (item.archive | regex_search('[^.]+(?=\\.*$)') | upper=="SAR") ) or
-      ( item.filename is defined   and (item.filename | regex_search('[^.]+(?=\\.*$)') | upper=="SAR") )
-
+    - item.extract | default(false)
+    - item.archive | regex_search('[^.]+(?=\\.*$)') | upper=="SAR"
 
 #   06) Extract files - UNRAR
 

--- a/deploy/ansible/roles-sap/3.3-bom-processing/tasks/bom_processor.yaml
+++ b/deploy/ansible/roles-sap/3.3-bom-processing/tasks/bom_processor.yaml
@@ -187,7 +187,8 @@
   loop:                                "{{ bom.materials.media | flatten(levels=1) }}"
   when:
     - item.extract | default(false)
-    - item.archive | regex_search('[^.]+(?=\\.*$)') | upper=="SAR"
+    - (item.archive is defined and (item.archive | regex_search('[^.]+(?=\\.*$)') | upper == "SAR")) or
+      (item.filename is defined and (item.filename | regex_search('[^.]+(?=\\.*$)') | upper == "SAR"))
 
 #   06) Extract files - UNRAR
 

--- a/deploy/ansible/roles-sap/3.3.1-bom-utility/tasks/bom-register.yaml
+++ b/deploy/ansible/roles-sap/3.3.1-bom-utility/tasks/bom-register.yaml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 # Inputs:
-#   bom_name              - Name of BOM (ex: S41909SPS03_v0001ms)
+#    current_bom_name              - Name of BOM (ex: S41909SPS03_v0001ms)
 #
 #
 # Outputs:
@@ -47,29 +47,35 @@
 
 - name:                                "3.3.1 BoM Processing - Set the new name"
   ansible.builtin.set_fact:
-    new_bom_name:                      "{{ bom_base_name }}{{ bom_suffix }}"
+    this_bom_name:                      "{{ current_bom_name | default(bom_base_name + bom_suffix) }}"
 
 - name:                                "3.3.1 BoM Processing - Show new name"
   ansible.builtin.debug:
     msg:
-      - "BoM Name:   {{ new_bom_name }}"
+      - "BoM Name:   {{ this_bom_name }}"
 
 # -------------------------------------+---------------------------------------8
 # Step: 03
 # Description:  Check Storage Account for BOM when SA is enabled
 #
 - name:                                 "3.3.1 BoM Processing - Check Storage Account for BOM block"
+  when:
+    - sa_enabled | default(true)                                                 # when true; if not defined, then value is false
+    # - sa_enabled is defined
+    # - sa_enabled
+
+    # - sa_enabled is not defined or sa_enabled | bool
   block:
 
 # -------------------------------------+---------------------------------------8
 # Step: 03-01
 # Description:
 #
-    - name:                             "3.3.1 BoM Processing - Download {{ new_bom_name }} from the storage account"
+    - name:                             "3.3.1 BoM Processing - Download {{ this_bom_name }} from the storage account"
       ansible.builtin.get_url:
-        url:                            "{{ sapbits_location_base_path }}/{{ sapbits_bom_files }}/boms/{{ new_bom_name }}/{{ new_bom_name }}.yaml\
+        url:                            "{{ sapbits_location_base_path }}/{{ sapbits_bom_files }}/boms/{{ this_bom_name }}/{{ this_bom_name }}.yaml\
                                         {% if sapbits_sas_token is defined %}?{{ sapbits_sas_token }}{% endif %}"
-        dest:                           "{{ download_directory }}/bom/{{ new_bom_name }}.yaml"
+        dest:                           "{{ download_directory }}/bom/{{ this_bom_name }}.yaml"
         mode:                           0644
         validate_certs:                 false
       delegate_to:                      localhost
@@ -87,18 +93,12 @@
     - name:                             "3.3.1 BoM Processing - Show BoM download status"
       ansible.builtin.debug:
         msg:
-          - "URL:    {{ sapbits_location_base_path }}/{{ sapbits_bom_files }}/boms/{{ new_bom_name }}/{{ new_bom_name }}.yaml{% if sapbits_sas_token is defined %}?{{ sapbits_sas_token }}{% endif %}"
+          - "URL:    {{ sapbits_location_base_path }}/{{ sapbits_bom_files }}/boms/{{ this_bom_name }}/{{ this_bom_name }}.yaml{% if sapbits_sas_token is defined %}?{{ sapbits_sas_token }}{% endif %}"
           - "Result: {{ result }}"
         verbosity:                      2
 # Step: 03-03 - END
 # -------------------------------------+---------------------------------------8
 
-  when:
-    - sa_enabled | default(true)                                                 # when true; if not defined, then value is false
-    # - sa_enabled is defined
-    # - sa_enabled
-
-    # - sa_enabled is not defined or sa_enabled | bool
 # Step: 03 - END
 # -------------------------------------+---------------------------------------8
 
@@ -107,17 +107,21 @@
 # Step: 04
 # Description:  Register BOM if found in Storage Account
 #
-- name:                                 "3.3.1 BoM Processing - Retrieve BOM ({{ bom_name }}) from Storage Account"
+- name:                                "3.3.1 BoM Processing - Retrieve BOM ({{  this_bom_name }}) from Storage Account"
+  when:
+    - result is succeeded or result is skipped
+    - sa_enabled | default(false)
+    # - sa_enabled is not defined or sa_enabled | bool
   block:
 
 # -------------------------------------+---------------------------------------8
 # Step: 04-01
 # Description:
 #
-    - name:                             "{{ task_prefix }} Register downloaded BOM ({{ bom_name }})"
+    - name:                            "{{ task_prefix }} Register downloaded BOM ({{  this_bom_name }})"
       ansible.builtin.include_vars:
-        file:                           "{{ download_directory }}/bom/{{ new_bom_name }}.yaml"
-        name:                           bom
+        file:                          "{{ download_directory }}/bom/{{ this_bom_name }}.yaml"
+        name:                          bom
 # Step: 04-01 - END
 # -------------------------------------+---------------------------------------8
 
@@ -125,19 +129,16 @@
 # Step: 04-02
 # Description:
 #
-    - name:                             "{{ task_prefix }} Register downloaded BOM ({{ bom_name }}) file name"
+    - name:                             "{{ task_prefix }} Register downloaded BOM ({{  this_bom_name }}) file name"
       ansible.builtin.set_fact:
-        bom_file:                       "{{ download_directory }}/bom/{{ new_bom_name }}.yaml"
-        aggregated_bom_directories:     "{{ aggregated_bom_directories | default([]) + [{'path': path, 'location': 'sa'}] }}"
+        bom_file:                      "{{ download_directory }}/bom/{{ this_bom_name }}.yaml"
+        aggregated_bom_directories:    "{{ aggregated_bom_directories | default([]) + [{'path': path, 'location': 'sa'}] }}"
+        from_storage_account:          true
       vars:
-        path:                           "{{ sapbits_location_base_path }}/{{ sapbits_bom_files }}/boms/{{ new_bom_name }}"
+        path:                          "{{ sapbits_location_base_path }}/{{ sapbits_bom_files }}/boms/{{ this_bom_name }}"
 # Step: 04-02 - END
 # -------------------------------------+---------------------------------------8
 
-  when:
-    - result is succeeded or result is skipped
-    - sa_enabled | default(false)
-    # - sa_enabled is not defined or sa_enabled | bool
 # Step: 04 - END
 # -------------------------------------+---------------------------------------8
 
@@ -146,18 +147,18 @@
 # Step: 05
 # Description:  Check for MS provided BOM if not in SA
 #
-- name:                                 "{{ task_prefix }} Check for Microsoft Supplied BOM ({{ bom_name }})"
+- name:                                "{{ task_prefix }} Check for Microsoft Supplied BOM ({{  this_bom_name }})"
   block:
 
 # -------------------------------------+---------------------------------------8
 # Step: 05-01
 # Description:
 #
-    - name:                             "{{ task_prefix }} Check for Microsoft Supplied BOM ({{ bom_name }})"
+    - name:                            "{{ task_prefix }} Check for Microsoft Supplied BOM ({{  this_bom_name }})"
       ansible.builtin.stat:
-        path:                           "{{ BOM_directory }}/{{ bom_name }}/{{ bom_name }}.yaml"
-      register:                         microsoft_supplied_bom
-      delegate_to:                      localhost
+        path:                          "{{ BOM_directory }}/{{  this_bom_name }}/{{  this_bom_name }}.yaml"
+      register:                        microsoft_supplied_bom
+      delegate_to:                     localhost
       become:                          "{{ bom_processing_become }}"
 
 # Step: 05-01 - END
@@ -170,7 +171,7 @@
     - name:                             "{{ task_prefix }} Show Microsoft Supplied BOM ({{ bom_base_name }}) result"
       ansible.builtin.debug:
         msg: |-
-                                        BOM PATH:   {{ BOM_directory }}/{{ bom_name }}/{{ bom_name }}.yaml
+                                        BOM PATH:   {{ BOM_directory }}/{{  this_bom_name }}/{{  this_bom_name }}.yaml
                                         BOM Exists: {{ microsoft_supplied_bom.stat.exists }}
         verbosity:                      0
 # Step: 05-02 - END
@@ -180,7 +181,7 @@
 # Step: 05-03
 # Description:
 #
-    - name:                             "{{ task_prefix }} Register Microsoft Supplied BOM {{ bom_name }}"
+    - name:                             "{{ task_prefix }} Register Microsoft Supplied BOM {{  this_bom_name }}"
       ansible.builtin.include_vars:
         file:                           "{{ microsoft_supplied_bom.stat.path }}"
         name:                           bom_temp
@@ -192,14 +193,14 @@
 # Step: 05-04
 # Description:
 #
-    - name:                             "{{ task_prefix }} Register Microsoft Supplied BOM ({{ bom_name }}) facts"
+    - name:                            "{{ task_prefix }} Register Microsoft Supplied BOM ({{  this_bom_name }}) facts"
       ansible.builtin.set_fact:
-        bom:                            "{{ bom_temp }}"
-        bom_file:                       "{{ microsoft_supplied_bom.stat.path }}"
-        aggregated_bom_directories:     "{{ aggregated_bom_directories | default([]) + [{'path': path, 'location': 'local'}] }}"
+        bom:                           "{{ bom_temp }}"
+        bom_file:                      "{{ microsoft_supplied_bom.stat.path }}"
+        aggregated_bom_directories:    "{{ aggregated_bom_directories | default([]) + [{'path': path, 'location': 'local'}] }}"
       vars:
-        path:                           "{{ microsoft_supplied_bom.stat.path | dirname }}"
-      when:                             microsoft_supplied_bom.stat.exists
+        path:                          "{{ microsoft_supplied_bom.stat.path | dirname }}"
+      when:                            microsoft_supplied_bom.stat.exists
 # Step: 05-04 - END
 # -------------------------------------+---------------------------------------8
 
@@ -207,16 +208,16 @@
 # Step: 05-05
 # Description:
 #
-    - name:                             "{{ task_prefix }} Check for Microsoft Supplied BOM ({{ bom_name }}) in archives"
+    - name:                             "{{ task_prefix }} Check for Microsoft Supplied BOM ({{  this_bom_name }}) in archives"
       block:
 
 # -------------------------------------+---------------------------------------8
 # Step: 05-05-01
 # Description:
 #
-        - name:                         "{{ task_prefix }} Check for Microsoft Supplied BOM ({{ bom_name }}) in archives"
+        - name:                         "{{ task_prefix }} Check for Microsoft Supplied BOM ({{  this_bom_name }}) in archives"
           ansible.builtin.stat:
-            path:                       "{{ BOM_directory }}/archives/{{ bom_name }}/{{ bom_name }}.yaml"
+            path:                       "{{ BOM_directory }}/archives/{{  this_bom_name }}/{{  this_bom_name }}.yaml"
           register:                     microsoft_supplied_bom_archive
           delegate_to:                  localhost
           become:                       "{{ bom_processing_become }}"
@@ -227,7 +228,7 @@
 # Step: 05-05-02
 # Description:
 #
-        - name:                         "{{ task_prefix }} Register Microsoft Supplied BOM {{ bom_name }} from archives"
+        - name:                         "{{ task_prefix }} Register Microsoft Supplied BOM {{  this_bom_name }} from archives"
           ansible.builtin.include_vars:
             file:                       "{{ microsoft_supplied_bom_archive.stat.path }}"
             name:                       bom_temp
@@ -239,7 +240,7 @@
 # Step: 05-05-03
 # Description:
 #
-        - name:                         "{{ task_prefix }} Register Microsoft Supplied BOM ({{ bom_name }}) facts"
+        - name:                         "{{ task_prefix }} Register Microsoft Supplied BOM ({{  this_bom_name }}) facts"
           ansible.builtin.set_fact:
             bom:                        "{{ bom_temp }}"
             bom_file:                   "{{ microsoft_supplied_bom_archive.stat.path }}"
@@ -265,6 +266,10 @@
 # Description:  Validate that BoM was found
 #
 
+- name:                                "{{ task_prefix }} Append the file list"
+  ansible.builtin.set_fact:
+    root_media_list:                   "{% if root_media_list is defined %}{{ root_media_list + bom.materials.media | flatten(levels=1) }}{% else %}{{ bom.materials.media }}{% endif %}"
+
 - name:                                 "{{ task_prefix }} Show BOM object"
   ansible.builtin.debug:
     var:                                bom
@@ -272,7 +277,7 @@
 
 - name:                                 "{{ task_prefix }} Validate that a BOM object is created"
   ansible.builtin.fail:
-    msg:                                "Unable to find the Bill of materials file for {{ bom_name }}."
+    msg:                                "Unable to find the Bill of materials file for {{  this_bom_name }}."
   when:                                 bom is not defined
 # Step: 06 - END
 # -------------------------------------+---------------------------------------8
@@ -307,7 +312,7 @@
 #     that:
 #       - bom.platform is defined                                                 # Has the variable been defined
 #       - bom.platform | upper == platform | upper
-#     fail_msg:                           "The BoM {{ bom_name }} is not for platform {{ platform }}"
+#     fail_msg:                           "The BoM {{  current_bom_name }} is not for platform {{ platform }}"
 #   when:
 #     - platform is defined
 #     - platform | length > 2

--- a/deploy/ansible/roles-sap/3.3.1-bom-utility/tasks/bom-register.yaml
+++ b/deploy/ansible/roles-sap/3.3.1-bom-utility/tasks/bom-register.yaml
@@ -269,6 +269,10 @@
 - name:                                "{{ task_prefix }} Append the file list"
   ansible.builtin.set_fact:
     root_media_list:                   "{% if root_media_list is defined %}{{ root_media_list + bom.materials.media | flatten(levels=1) }}{% else %}{{ bom.materials.media }}{% endif %}"
+  when:
+    - bom is defined
+    - bom.materials is defined
+    - bom.materials.media is defined
 
 - name:                                 "{{ task_prefix }} Show BOM object"
   ansible.builtin.debug:

--- a/deploy/ansible/roles-sap/3.3.1-bom-utility/tasks/bom-template.yaml
+++ b/deploy/ansible/roles-sap/3.3.1-bom-utility/tasks/bom-template.yaml
@@ -34,7 +34,7 @@
 
 - name:                                "3.3.1 BoM Template Processing: - Set the new name"
   ansible.builtin.set_fact:
-    new_bom_name:                      "{{ bom_base_name }}{{ bom_suffix }}"
+    bom_name:                          "{{ bom_base_name }}{{ bom_suffix }}"
 
 #   0x) Create hidden directory for parameter files
 - name:                                "3.3.1 BoM Template processing: Create hidden directory"

--- a/deploy/scripts/pipeline_scripts/v2/04-sap-software-download.sh
+++ b/deploy/scripts/pipeline_scripts/v2/04-sap-software-download.sh
@@ -128,6 +128,7 @@ fi
 
 sapbits_location_base_path=$(getVariableFromApplicationConfiguration "$APPLICATION_CONFIGURATION_ID" "${CONTROL_PLANE_NAME}_SAPMediaPath" "${CONTROL_PLANE_NAME}")
 
+export ANSIBLE_DISPLAY_SKIPPED_HOSTS=false
 
 command="ansible-playbook -e download_directory=$AGENT_TEMP_DIRECTORY \
 -e BOM_directory=${sample_path} \
@@ -135,6 +136,7 @@ command="ansible-playbook -e download_directory=$AGENT_TEMP_DIRECTORY \
 -e deployer_kv_name=$DEPLOYER_KEYVAULT \
 -e check_storage_account=$CHECK_STORAGE_ACCOUNT \
 -e orchestration_ansible_user=$USER \
+-e create_checksums=true \
 -e sapbits_location_base_path=$sapbits_location_base_path \
  $EXTRA_PARAMETERS $SAP_AUTOMATION_REPO_PATH/deploy/ansible/playbook_bom_downloader.yaml"
 


### PR DESCRIPTION
Add the Ability to provide the names of the application, database and kernel BoMs making it easier to assemble Bill of Materials files

## Problem
Currently we have to maintain all permutations of Application, Kernel and Database BoMs

## Solution
Enhance the playbook to take a list of Bom names during the software acquisition pipeline and dynamically aggregate them.

The code is backwards compliant and will not break the existing process.

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>