### PR TITLE
Bugfix Custom naming Error The true and false result expressions must have consistent types 

### DIFF
--- a/deploy/terraform/run/sap_system/module.tf
+++ b/deploy/terraform/run/sap_system/module.tf
@@ -82,7 +82,7 @@ module "common_infrastructure" {
   key_vault                                     = local.key_vault
   landscape_tfstate                             = data.terraform_remote_state.landscape.outputs
   license_type                                  = var.license_type
-  naming                                        = length(var.name_override_file) > 0 ? local.custom_names : module.sap_namegenerator.naming
+  naming                                        = length(var.name_override_file) > 0 ? local.custom_names : local.generator_as_lists
   NFS_provider                                  = var.NFS_provider
   options                                       = local.options
   sapmnt_private_endpoint_id                    = var.sapmnt_private_endpoint_id
@@ -148,7 +148,7 @@ module "hdb_node" {
   infrastructure                                = local.infrastructure
   landscape_tfstate                             = data.terraform_remote_state.landscape.outputs
   license_type                                  = var.license_type
-  naming                                        = length(var.name_override_file) > 0 ? local.custom_names : module.sap_namegenerator.naming
+  naming                                        = length(var.name_override_file) > 0 ? local.custom_names : local.generator_as_lists
   NFS_provider                                  = var.NFS_provider
   observer_vm_size                              = var.observer_vm_size
   observer_vm_tags                              = var.observer_vm_tags
@@ -207,7 +207,7 @@ module "app_tier" {
   infrastructure                                = local.infrastructure
   landscape_tfstate                             = data.terraform_remote_state.landscape.outputs
   license_type                                  = var.license_type
-  naming                                        = length(var.name_override_file) > 0 ? local.custom_names : module.sap_namegenerator.naming
+  naming                                        = length(var.name_override_file) > 0 ? local.custom_names : local.generator_as_lists
   network_location                              = module.common_infrastructure.network_location
   network_resource_group                        = module.common_infrastructure.network_resource_group
   options                                       = local.options
@@ -271,7 +271,7 @@ module "anydb_node" {
   infrastructure                                = local.infrastructure
   landscape_tfstate                             = data.terraform_remote_state.landscape.outputs
   license_type                                  = var.license_type
-  naming                                        = length(var.name_override_file) > 0 ? local.custom_names : module.sap_namegenerator.naming
+  naming                                        = length(var.name_override_file) > 0 ? local.custom_names : local.generator_as_lists
   observer_vm_size                              = var.observer_vm_size
   observer_vm_tags                              = var.observer_vm_tags
   observer_vm_zones                             = var.observer_vm_zones

--- a/deploy/terraform/run/sap_system/module.tf
+++ b/deploy/terraform/run/sap_system/module.tf
@@ -331,7 +331,7 @@ module "output_files" {
   landscape_tfstate                             = data.terraform_remote_state.landscape.outputs
   naming                                        = length(var.name_override_file) > 0 ? (
                                                     local.custom_names) : (
-                                                    module.sap_namegenerator.naming
+                                                    local.generator_as_lists
                                                   )
   random_id                                     = module.common_infrastructure.random_id
   save_naming_information                       = var.save_naming_information

--- a/deploy/terraform/run/sap_system/output.tf
+++ b/deploy/terraform/run/sap_system/output.tf
@@ -247,3 +247,29 @@ output "subscription_id_used"          {
                                          value       = length(var.subscription_id) > 0 ? var.subscription_id : data.azurerm_key_vault_secret.subscription_id[0].value
                                          sensitive   = true
                                        }
+
+###############################################################################
+#                                                                             #
+#                    DEBUG: sap_namegenerator output                          #
+#                    (Temporary output to debug type mismatch)                #
+#                                                                             #
+###############################################################################
+
+output "debug_namegenerator_raw"       {
+                                         description = "DEBUG: Raw output from sap_namegenerator module"
+                                         value       = module.sap_namegenerator.naming
+                                       }
+
+output "debug_vm_names_values"         {
+                                         description = "DEBUG: VM names values and lengths"
+                                         value       = {
+                                           for k, v in module.sap_namegenerator.naming.virtualmachine_names :
+                                           k => {
+                                             value  = v
+                                             length = try(length(v), 0)
+                                             # Type will be inferred from structure:
+                                             # - tuple: shown as (item1, item2) or parens in JSON
+                                             # - list: shown as [item1, item2] or brackets in JSON
+                                           }
+                                         }
+                                       }

--- a/deploy/terraform/run/sap_system/output.tf
+++ b/deploy/terraform/run/sap_system/output.tf
@@ -247,29 +247,3 @@ output "subscription_id_used"          {
                                          value       = length(var.subscription_id) > 0 ? var.subscription_id : data.azurerm_key_vault_secret.subscription_id[0].value
                                          sensitive   = true
                                        }
-
-###############################################################################
-#                                                                             #
-#                    DEBUG: sap_namegenerator output                          #
-#                    (Temporary output to debug type mismatch)                #
-#                                                                             #
-###############################################################################
-
-output "debug_namegenerator_raw"       {
-                                         description = "DEBUG: Raw output from sap_namegenerator module"
-                                         value       = module.sap_namegenerator.naming
-                                       }
-
-output "debug_vm_names_values"         {
-                                         description = "DEBUG: VM names values and lengths"
-                                         value       = {
-                                           for k, v in module.sap_namegenerator.naming.virtualmachine_names :
-                                           k => {
-                                             value  = v
-                                             length = try(length(v), 0)
-                                             # Type will be inferred from structure:
-                                             # - tuple: shown as (item1, item2) or parens in JSON
-                                             # - list: shown as [item1, item2] or brackets in JSON
-                                           }
-                                         }
-                                       }

--- a/deploy/terraform/run/sap_system/variables_local.tf
+++ b/deploy/terraform/run/sap_system/variables_local.tf
@@ -68,18 +68,21 @@ locals {
                                       )
 
   // Merge custom naming with generator (fill missing keys with generator values)
-  // Strategy: Start with generator (all 9 keys), override with custom JSON keys,
-  //           then convert virtualmachine_names arrays to lists
+  // Strategy: Start with generator (all 9 top-level keys, all 23 VM keys)
+  //           Override with custom JSON keys (merge VM keys, don't replace)
   // This allows custom JSON to override ANY key (storageaccount_names, ppg_names, etc.)
   // while keeping generator defaults for missing keys
   custom_names                       = local.custom_names_raw == null ? null : merge(
-                                        local.generator_as_lists,  # Base: all 9 keys from generator
-                                        local.custom_names_raw,    # Override: any keys from JSON file
+                                        local.generator_as_lists,  # Base: all 9 top-level keys from generator
+                                        local.custom_names_raw,    # Override: any top-level keys from JSON file
                                         {
-                                          virtualmachine_names = {
-                                            for vm_key, vm_val in local.custom_names_raw.virtualmachine_names :
-                                            vm_key => tolist(vm_val)  # Convert arrays to lists
-                                          }
+                                          virtualmachine_names = merge(
+                                            local.generator_as_lists.virtualmachine_names,  # All 23 VM keys from generator (as lists)
+                                            {
+                                              for vm_key, vm_val in local.custom_names_raw.virtualmachine_names :
+                                              vm_key => tolist(vm_val)  # Override specific VM keys from JSON (convert to lists)
+                                            }
+                                          )
                                         }
                                       )
 

--- a/deploy/terraform/run/sap_system/variables_local.tf
+++ b/deploy/terraform/run/sap_system/variables_local.tf
@@ -53,9 +53,7 @@ locals {
   custom_names_raw                   = length(var.name_override_file) > 0 ? (
                                         jsondecode(file(format("%s/%s", path.cwd, var.name_override_file)))) : (
                                         null
-                                      )
-
-  
+                                      ) 
   // Convert ALL generator virtualmachine_names attributes to lists
   generator_as_lists                = merge(
                                         module.sap_namegenerator.naming,
@@ -79,7 +77,7 @@ locals {
                                           virtualmachine_names = merge(
                                             local.generator_as_lists.virtualmachine_names,  # All 23 VM keys from generator (as lists)
                                             {
-                                              for vm_key, vm_val in local.custom_names_raw.virtualmachine_names :
+                                              for vm_key, vm_val in try(local.custom_names_raw.virtualmachine_names, {}) :
                                               vm_key => tolist(vm_val)  # Override specific VM keys from JSON (convert to lists)
                                             }
                                           )


### PR DESCRIPTION
## Problem
[Azure/sap-automation git issue #1033](https://github.com/Azure/sap-automation/issues/1033) - Error The true and false result expressions must have consistent types when overriding custom naming

## Solution

1.  Standardizing virtualmachine_names values to list of strings, both in the jsondecode side and in naming generator output
2.  Merge the original naming generator output with the data structure from override JSON

## Tests
Not yet

## Notes
Terraform is very strict on the type of the true and false values of conditional expressions. Some users already raised this as an issue in terraform : ["Inconsistent conditional result types" is overly restrictive https://github.com/hashicorp/terraform/issues/34757](https://github.com/hashicorp/terraform/issues/34757) ; but it were closed and reading the discussion it seems that their position is 'won't fix'.