### PR TITLE
Add JAVA installation support for SCS, PAS, and Application Servers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,5 @@ __pycache__
 *.scc
 .ansible/.lock
 
+.idea/
+

--- a/deploy/ansible/playbook_05_00_00_sap_scs_install.yaml
+++ b/deploy/ansible/playbook_05_00_00_sap_scs_install.yaml
@@ -304,7 +304,7 @@
                     path:              'INSTALL/DISTRIBUTED/{{ scs_bom_instance_type }}/{{ instance_type }}'
                     tier:              'scs'
                     this_sid:          "{{ sid_to_be_deployed.sid | upper }}"
-                    work_log_component_name: "ASCS{{ scs_instance_number }}"
+                    work_log_component_name: "{{ instance_type }}{{ scs_instance_number }}"
 
                   loop:                "{{ all_sids }}"
                   loop_control:
@@ -569,7 +569,7 @@
                 path:                  'INSTALL/HA/{{ scs_bom_instance_type }}/{{ instance_type }}'
                 tier:                  'scs'
                 this_sid:              "{{ sap_sid | upper }}"
-                work_log_component_name: "ASCS{{ scs_instance_number }}"
+                work_log_component_name: "{{ instance_type }}{{ scs_instance_number }}"
               when:
                 - scs_bom_id is defined
                 - node_tier == 'scs'

--- a/deploy/ansible/playbook_05_00_00_sap_scs_install.yaml
+++ b/deploy/ansible/playbook_05_00_00_sap_scs_install.yaml
@@ -300,7 +300,7 @@
                     name:              roles-sap/7.0.0-post-install
                   vars:
                     suffix:            "_SCS"
-                    prefix:            "{{ bom.product_ids.scs.replace('.', '/').replace('/ABAP', '').replace('/JAVA', '').split(':')[1] }}"
+                    prefix:            "{{ bom.product_ids.scs.replace('.', '/').replace('/ABAP', '').replace('/PD', '').replace('/JAVA', '').split(':')[1] }}"
                     path:              'INSTALL/DISTRIBUTED/{{ scs_bom_instance_type }}/{{ instance_type }}'
                     tier:              'scs'
                     this_sid:          "{{ sid_to_be_deployed.sid | upper }}"

--- a/deploy/ansible/playbook_05_02_sap_pas_install.yaml
+++ b/deploy/ansible/playbook_05_02_sap_pas_install.yaml
@@ -277,7 +277,7 @@
                 path:                  'INSTALL/DISTRIBUTED/{{ pas_bom_instance_type }}/APP1'
                 tier:                  'pas'
                 this_sid:              "{{ sid_to_be_deployed.sid | upper }}"
-                work_log_component_name: "D{{ pas_instance_number }}"
+                work_log_component_name: "{{ 'J' if pas_bom_instance_type == 'JAVA' else 'D' }}{{ pas_instance_number }}"
               loop:                    "{{ all_sids }}"
               loop_control:
                 loop_var:              sid_to_be_deployed

--- a/deploy/ansible/playbook_05_03_sap_app_install.yaml
+++ b/deploy/ansible/playbook_05_03_sap_app_install.yaml
@@ -251,7 +251,7 @@
             path:                      "{{ app_file_path }}"
             tier:                      'app'
             this_sid:                  "{{ sid_to_be_deployed.sid | upper }}"
-            work_log_component_name:   "D{{ app_instance_number }}"
+            work_log_component_name:   "{{ 'J' if app_bom_instance_type == 'JAVA' else 'D' }}{{ app_instance_number }}"
           loop:                        "{{ all_sids }}"
           loop_control:
             loop_var:                  sid_to_be_deployed

--- a/deploy/ansible/roles-misc/0.9-sap-on-azure-quality-checks/tasks/setup.yaml
+++ b/deploy/ansible/roles-misc/0.9-sap-on-azure-quality-checks/tasks/setup.yaml
@@ -77,11 +77,13 @@
   ansible.builtin.shell: >-
                                    Update-AzConfig -EnableLoginByWam $false
 
-                                   $modules = @("Az", "Az.NetAppFiles", "Posh-SSH")
+                                   $modules = @("Az", "Az.NetAppFiles", "Posh-SSH", "Az.Compute")
 
                                    foreach ($module in $modules) {
                                      if (-not (Get-Module -ListAvailable -Name $module)) {
                                        Install-Module $module -Force -Scope AllUsers -Confirm:$false
+                                     } else { 
+                                       Update-Module -Name $module -Force -Scope AllUsers -Confirm:$false
                                      }
                                    }
   register:                        qc_modules_result

--- a/deploy/ansible/roles-misc/0.9-sap-on-azure-quality-checks/vars/main.yaml
+++ b/deploy/ansible/roles-misc/0.9-sap-on-azure-quality-checks/vars/main.yaml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 azure_utility_repo: https://raw.githubusercontent.com/Azure/SAP-on-Azure-Scripts-and-Utilities
-powershell_version: 7.3.12
+powershell_version: 7.5.2
 
 # https://github.com/Azure/SAP-on-Azure-Scripts-and-Utilities/blob/main/QualityCheck/QualityCheck.ps1
 vm_operating_system_map:

--- a/deploy/ansible/roles-os/1.1-swap/tasks/main.yaml
+++ b/deploy/ansible/roles-os/1.1-swap/tasks/main.yaml
@@ -166,7 +166,7 @@
   vars:
     swap_size_mb:                      "{{ (sap_swap | selectattr('tier', 'search', node_tier) | list | first).swap_size_mb }}"
   when:
-    - swap_size == '0'
+    - swap_size | int == 0
 
 - name:                                "1.1 Swap - Reboot"
   when:

--- a/deploy/ansible/roles-os/1.9-kernelparameters/vars/parameters.yaml
+++ b/deploy/ansible/roles-os/1.9-kernelparameters/vars/parameters.yaml
@@ -63,6 +63,7 @@ parameters:
     - { tier: 'os',    node_tier: 'all',     name: 'net.ipv6.conf.default.accept_redirects',     value: '0',                    state: 'present' }
     - { tier: 'os',    node_tier: 'all',     name: 'net.ipv6.conf.default.accept_source_route',  value: '0',                    state: 'present' }
     - { tier: 'os',    node_tier: 'all',     name: 'kernel.sem',                                 value: '250 32000 100 4096',   state: 'present' }
+    - { tier: 'os',    node_tier: 'all',     name: 'net.ipv4.tcp_retries2',                      value: '15',                   state: 'present' }
     - { tier: 'os',    node_tier: 'all',     name: 'net.ipv4.tcp_keepalive_intvl',               value: '75',                   state: 'present' }
     - { tier: 'os',    node_tier: 'all',     name: 'net.ipv4.tcp_keepalive_probes',              value: '9',                    state: 'present' }
     - { tier: 'os',    node_tier: 'all',     name: 'net.ipv4.tcp_slow_start_after_idle',         value: '0',                    state: 'present' }

--- a/deploy/ansible/roles-sap/5.0.0-scs-install/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.0.0-scs-install/tasks/main.yaml
@@ -233,7 +233,7 @@
 
     - name:                            "5.0.0 SAP Central Services Installation - Find the installationSuccesfullyFinished.dat (SAPINST)"
       ansible.builtin.find:
-        paths:                         "{{ tmp_directory }}/{{ sid_to_be_deployed.sid | upper }}/sapinst_instdir/{{ bom.product_ids.scs.replace('.', '/').replace('/ABAP', '').split(':')[1] }}/INSTALL/DISTRIBUTED/{{ instance_type }}/{{ application_type }}"
+        paths:                         "{{ tmp_directory }}/{{ sid_to_be_deployed.sid | upper }}/sapinst_instdir/{{ bom.product_ids.scs.replace('.', '/').replace('/ABAP', '').replace('/JAVA', '').split(':')[1] }}/INSTALL/DISTRIBUTED/{{ scs_bom_instance_type }}/{{ instance_type }}"
         file_type:                     file
         patterns:                      'installationSuccesfullyFinished.dat'
         recurse:                       true

--- a/deploy/ansible/roles-sap/5.0.0-scs-install/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.0.0-scs-install/tasks/main.yaml
@@ -233,7 +233,7 @@
 
     - name:                            "5.0.0 SAP Central Services Installation - Find the installationSuccesfullyFinished.dat (SAPINST)"
       ansible.builtin.find:
-        paths:                         "{{ tmp_directory }}/{{ sid_to_be_deployed.sid | upper }}/sapinst_instdir/{{ bom.product_ids.scs.replace('.', '/').replace('/ABAP', '').replace('/JAVA', '').split(':')[1] }}/INSTALL/DISTRIBUTED/{{ scs_bom_instance_type }}/{{ instance_type }}"
+        paths:                         "{{ tmp_directory }}/{{ sid_to_be_deployed.sid | upper }}/sapinst_instdir/{{ bom.product_ids.scs.replace('.', '/').replace('/ABAP', '').replace('/PD', '').replace('/JAVA', '').split(':')[1] }}/INSTALL/DISTRIBUTED/{{ scs_bom_instance_type }}/{{ instance_type }}"
         file_type:                     file
         patterns:                      'installationSuccesfullyFinished.dat'
         recurse:                       true

--- a/deploy/ansible/roles-sap/5.0.0-scs-install/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.0.0-scs-install/tasks/main.yaml
@@ -77,9 +77,18 @@
   ansible.builtin.set_fact:
     application_type:                  "{% if instance_type == 'SCS' %}JAVA{% else %}ABAP{% endif %}"
 
+- name:                                "5.0.0 SAP Central Services Installation - Register variables"
+  ansible.builtin.set_fact:
+    scs_bom_id:                        "{{ bom.product_ids.scs }}"
+    scs_bom_instance_type:             "{% if bom.InstanceType is defined %}{{ bom.InstanceType | upper }}{% else %}ABAP{% endif %}"
+
+- name:                                "5.0.0 SAP Central Services Installation - Register additional variables"
+  ansible.builtin.set_fact:
+    installGateway:                    "{% if scs_bom_instance_type == 'ABAP' %}true{% else %}false{% endif %}"
+
 - name:                                "5.0.0 SAP Central Services Installation - Find the installationSuccesfullyFinished.dat (SAPINST)"
   ansible.builtin.find:
-    paths:                             "{{ tmp_directory }}/{{ sid_to_be_deployed.sid | upper }}/sapinst_instdir/{{ bom.product_ids.scs.replace('.', '/').replace('/ABAP', '').split(':')[1] }}/INSTALL/DISTRIBUTED/{{ instance_type }}/{{ application_type }}"
+    paths:                             "{{ tmp_directory }}/{{ sid_to_be_deployed.sid | upper }}/sapinst_instdir/{{ bom.product_ids.scs.replace('.', '/').replace('/ABAP', '').replace('/PD', '').replace('/JAVA', '').split(':')[1] }}/INSTALL/DISTRIBUTED/{{ scs_bom_instance_type }}/{{ instance_type }}"
     file_type:                         file
     patterns:                          'installationSuccesfullyFinished.dat'
     recurse:                           false
@@ -107,15 +116,6 @@
     path:                              "/etc/sap_deployment_automation/{{ sid_to_be_deployed.sid | upper }}/sap_deployment_scs.txt"
   register:                            scs_installed
   when:                                "'scs' in supported_tiers"
-
-- name:                                "5.0.0 SAP Central Services Installation - Register variables"
-  ansible.builtin.set_fact:
-    scs_bom_id:                        "{{ bom.product_ids.scs }}"
-    scs_bom_instance_type:             "{% if bom.InstanceType is defined %}{{ bom.InstanceType | upper }}{% else %}ABAP{% endif %}"
-
-- name:                                "5.0.0 SAP Central Services Installation - Register additional variables"
-  ansible.builtin.set_fact:
-    installGateway:                    "{% if scs_bom_instance_type == 'ABAP' %}true{% else %}false{% endif %}"
 
 - name:                                "5.0.0 SAP Central Services Installation"
   block:

--- a/deploy/ansible/roles-sap/5.1-dbload/templates/dbload-inifile-param.j2
+++ b/deploy/ansible/roles-sap/5.1-dbload/templates/dbload-inifile-param.j2
@@ -26,7 +26,7 @@ HDB_Schema_Check_Dialogs.dropSchema                                   = true
 NW_ABAP_Import_Dialog.migmonJobNum                                    = 12
 hanadb.landscape.reorg.useParameterFile                               = DONOTUSEFILE
 
-{% if platform | upper == 'HANA' %}
+{% if platform | upper == 'HANA' and hana_schema == 'SAPHANADB' %}
 
 SAPINST.CD.PACKAGE.HDBCLIENT                                          = {{ target_media_location }}/CD_HDBCLIENT/SAP_HANA_CLIENT
 SAPINST.CD.PACKAGE.CD1                                                = {{ target_media_location }}/CD_EXPORT/DATA_UNITS/EXP1
@@ -60,6 +60,26 @@ NW_Recovery_Install_HDB.extractParallelJobs                           = 24
 NW_Recovery_Install_HDB.sidAdmName                                    = {{ db_sid | lower }}adm
 NW_Recovery_Install_HDB.sidAdmPassword                                = {{ main_password }}
 
+
+{% endif %}
+
+{% if platform | upper == 'HANA' and hana_schema == 'SAPJAVA1' %}
+
+SAPINST.CD.PACKAGE.HDBCLIENT                                          = {{ target_media_location }}/CD_HDBCLIENT/SAP_HANA_CLIENT
+SAPINST.CD.PACKAGE.CD1                                                = {{ target_media_location }}/CD_EXPORT
+
+HDB_Schema_Check_Dialogs.schemaName                                   = {{ hana_schema }}
+HDB_Schema_Check_Dialogs.schemaPassword                               = {{ main_password }}
+
+NW_HDB_DB.javaSchemaName                                              = {{ hana_schema }}
+NW_HDB_DB.javaSchemaPassword                                          = {{ main_password }}
+NW_HDB_getDBInfo.dbhost                                               = {{ sap_db_hostname }}
+NW_HDB_getDBInfo.dbsid                                                = {{ db_sid | upper }}
+NW_HDB_getDBInfo.instanceNumber                                       = {{ db_instance_number }}
+NW_HDB_getDBInfo.systemPassword                                       = {{ main_password }}
+NW_HDB_getDBInfo.systemid                                             = {{ db_sid | upper }}
+NW_HDB_getDBInfo.usingSSL                                             = true
+NW_JAVA_Export.keyPhrase                                              = {{ main_password }}
 
 {% endif %}
 

--- a/deploy/ansible/roles-sap/5.2-pas-install/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.2-pas-install/tasks/main.yaml
@@ -145,7 +145,7 @@
       ansible.builtin.set_fact:
         scs_server:                    "{% if scs_high_availability %}{{ sid_to_be_deployed.sid | lower }}scs{{ scs_instance_number }}cl1{% else %}{{ hostvars[scs_server_temp | first]['virtual_host'] }}{% endif %}"
         db_virtual_hostname:           "{{ hostvars[db_server_temp | first]['virtual_host'] }}"
-        file_path:                     "{% if scs_high_availability %}INSTALL/HA/ABAP/APP1{% else %}INSTALL/DISTRIBUTED/ABAP/APP1{% endif %}"
+        file_path:                     "{% if scs_high_availability %}INSTALL/HA/{{ 'JAVA' if pas_bom_instance_type == 'JAVA' else 'ABAP' }}/APP1{% else %}INSTALL/DISTRIBUTED/{{ 'JAVA' if pas_bom_instance_type == 'JAVA' else 'ABAP' }}/APP1{% endif %}"
         DB:                            "{% if MULTI_SIDS is defined %}{{ sid_to_be_deployed.sid | upper }}/HDB{{ db_instance_number }}{% else %}{{ db_sid | upper }}/HDB{{ db_instance_number }}{% endif %}"
         pas_virtual_hostname:          "{{ custom_pas_virtual_hostname | default(virtual_host, true) }}"
         pas_bom_id:                    "{{ bom.product_ids.pas }}"
@@ -340,7 +340,7 @@
 
     - name:                            "5.2 Primary Application Server Installation - Find the installationSuccesfullyFinished.dat (SAPINST)"
       ansible.builtin.find:
-        paths:                         "{{ tmp_directory }}/{{ sid_to_be_deployed.sid | upper }}/sapinst_instdir/{{ bom.product_ids.pas.replace('.', '/').replace('/ABAP', '').split(':')[1] }}/{{ file_path }}"
+        paths:                         "{{ tmp_directory }}/{{ sid_to_be_deployed.sid | upper }}/sapinst_instdir/{{ bom.product_ids.pas.replace('.', '/').replace('/ABAP', '').replace('/PD', '').split(':')[1] }}/{{ file_path }}"
         file_type:                     file
         patterns:                      'installationSuccesfullyFinished.dat'
         recurse:                       true

--- a/deploy/ansible/roles-sap/5.3-app-install/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.3-app-install/tasks/main.yaml
@@ -234,7 +234,7 @@
 
     - name:                            "5.3 Additional Application Server Installation - Find the installationSuccesfullyFinished.dat (SAPINST)"
       ansible.builtin.find:
-        paths:                         "{{ tmp_directory }}/{{ sid_to_be_deployed.sid | upper }}/sapinst_instdir/{{ bom.product_ids.app.replace('.', '/').replace('/ABAP', '').replace('/PD', '').split(':')[1] }}/{{ file_path }}"
+        paths:                         "{{ tmp_directory }}/{{ sid_to_be_deployed.sid | upper }}/sapinst_instdir/{{ app_bom_id.replace('.', '/').replace('/ABAP', '').replace('/PD', '').split(':')[1] }}/{{ file_path }}"
         file_type:                     file
         patterns:                      'installationSuccesfullyFinished.dat'
         recurse:                       true

--- a/deploy/ansible/roles-sap/5.3-app-install/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.3-app-install/tasks/main.yaml
@@ -78,6 +78,7 @@
 - name:                                "5.3 Additional Application Server Installation - Register installation variables"
   ansible.builtin.set_fact:
     app_bom_id:                        "{% if database_high_availability %}{{ bom.product_ids.app_ha | default(bom.product_ids.app) }}{% else %}{{ bom.product_ids.app }}{% endif %}"
+    app_bom_instance_type:             "{% if bom.InstanceType is defined %}{{ bom.InstanceType }}{% else %}ABAP{% endif %}"
 
 - name:                                "5.3 Additional Application Server Installation - Check if the DB load balancer port is available and listening"
   ansible.builtin.wait_for:
@@ -135,7 +136,7 @@
       ansible.builtin.set_fact:
         scs_server:                    "{% if scs_high_availability %}{{ sid_to_be_deployed.sid | lower }}scs{{ scs_instance_number }}cl1{% else %}{{ hostvars[scs_server_temp | first]['virtual_host'] }}{% endif %}"
         db_virtual_hostname:           "{{ hostvars[db_server_temp | first]['virtual_host'] }}"
-        file_path:                     "{% if scs_high_availability %}INSTALL/HA/ABAP/APPX{% else %}INSTALL/DISTRIBUTED/ABAP/APPS{% endif %}"
+        file_path:                     "{% if scs_high_availability %}{{ 'INSTALL/HA/ABAP/APPX' if app_bom_instance_type == 'JAVA' else 'INSTALL/HA/JAVA/APPX' }}{% else %}{{ 'INSTALL/AS/APPS' if app_bom_instance_type == 'JAVA' else 'INSTALL/DISTRIBUTED/ABAP/APPS' }}{% endif %}"
 
     - name:                            "5.3 Additional Application Server Installation - Check that installation media exists"
       ansible.builtin.stat:
@@ -233,7 +234,7 @@
 
     - name:                            "5.3 Additional Application Server Installation - Find the installationSuccesfullyFinished.dat (SAPINST)"
       ansible.builtin.find:
-        paths:                         "{{ tmp_directory }}/{{ sid_to_be_deployed.sid | upper }}/sapinst_instdir/{{ bom.product_ids.app.replace('.', '/').replace('/ABAP', '').split(':')[1] }}/{{ file_path }}"
+        paths:                         "{{ tmp_directory }}/{{ sid_to_be_deployed.sid | upper }}/sapinst_instdir/{{ bom.product_ids.app.replace('.', '/').replace('/ABAP', '').replace('/PD', '').split(':')[1] }}/{{ file_path }}"
         file_type:                     file
         patterns:                      'installationSuccesfullyFinished.dat'
         recurse:                       true

--- a/deploy/ansible/roles-sap/5.3-app-install/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.3-app-install/tasks/main.yaml
@@ -136,7 +136,7 @@
       ansible.builtin.set_fact:
         scs_server:                    "{% if scs_high_availability %}{{ sid_to_be_deployed.sid | lower }}scs{{ scs_instance_number }}cl1{% else %}{{ hostvars[scs_server_temp | first]['virtual_host'] }}{% endif %}"
         db_virtual_hostname:           "{{ hostvars[db_server_temp | first]['virtual_host'] }}"
-        file_path:                     "{% if scs_high_availability %}{{ 'INSTALL/HA/ABAP/APPX' if app_bom_instance_type == 'JAVA' else 'INSTALL/HA/JAVA/APPX' }}{% else %}{{ 'INSTALL/AS/APPS' if app_bom_instance_type == 'JAVA' else 'INSTALL/DISTRIBUTED/ABAP/APPS' }}{% endif %}"
+        file_path:                     "{% if scs_high_availability %}{{ 'INSTALL/HA/JAVA/APPX' if app_bom_instance_type == 'JAVA' else 'INSTALL/HA/ABAP/APPX' }}{% else %}{{ 'INSTALL/AS/APPS' if app_bom_instance_type == 'JAVA' else 'INSTALL/DISTRIBUTED/ABAP/APPS' }}{% endif %}"
 
     - name:                            "5.3 Additional Application Server Installation - Check that installation media exists"
       ansible.builtin.stat:


### PR DESCRIPTION
## Problem
SAP JAVA installations are not properly supported across the SCS, PAS, and Application Server Ansible playbooks and tasks. Specifically:
- The DB Load parameter template lacks conditional handling for SAPJAVA1 schema types alongside SAPHANADB
- SCS installation tasks do not correctly differentiate between JAVA and ABAP installation types
- PAS and Application Server playbooks are missing conditions to account for JAVA installations
- The PowerShell version in the setup task is outdated (pre-7.5.2), and the module installation logic does not handle upgrades properly
- The swap size configuration task has an incorrect condition
- The TCP kernel parameter `net.ipv4.tcp_retries2` is not included in the default kernel parameters configuration

## Solution
- Add conditional sections for SAPHANADB and SAPJAVA1 schema types in the DB Load parameter template (`dbload-inifile-param.j2`)
- Fix SCS installation tasks to support both JAVA and ABAP installation types
- Add replacement function for PD path to ensure correct path resolution
- Add JAVA installation conditions to the PAS and Application Server playbooks and task files
- Upgrade PowerShell to 7.5.2 and improve module installation/upgrade logic in setup tasks
- Fix swap size configuration condition to correctly evaluate sizing
- Add `net.ipv4.tcp_retries2` to the kernel parameters configuration

## Tests
- Performed end-to-end JAVA installation on SAP systems covering SCS, PAS, and Application Server tiers
- Verified DB Load completes successfully with SAPJAVA1 schema type
- Validated swap configuration and kernel parameter settings on deployed VMs

## Notes
None.