### PR TITLE
Hotfix for Sybase disk sizing

### DIFF
--- a/deploy/ansible/roles-sap/5.1-dbload/templates/dbload-inifile-param.j2
+++ b/deploy/ansible/roles-sap/5.1-dbload/templates/dbload-inifile-param.j2
@@ -125,7 +125,7 @@ SAPINST.CD.PACKAGE.CD3                                                = {{ targe
 
 
 
-{% if platform | upper == 'ASE' %}
+{% if platform | upper == 'SYBASE' %}
 
 # Sort order configuration of the database server
 SYB.NW_DB.aseSortOrder                                                  = binaryalt

--- a/deploy/configs/sybase_sizes.json
+++ b/deploy/configs/sybase_sizes.json
@@ -203,7 +203,7 @@
           "fullname"                   : "",
           "count"                      : 1,
           "disk_type"                  : "Premium_LRS",
-          "size_gb"                    : 128,
+          "size_gb"                    : 256,
           "caching"                    : "ReadWrite",
           "write_accelerator"          : false
         },
@@ -260,7 +260,7 @@
         {
           "name"                       : "sapdata_1",
           "fullname"                   : "",
-          "count"                      : 2,
+          "count"                      : 3,
           "disk_type"                  : "Premium_LRS",
           "size_gb"                    : 512,
           "caching"                    : "ReadOnly",
@@ -272,7 +272,7 @@
           "fullname"                   : "",
           "count"                      : 1,
           "disk_type"                  : "Premium_LRS",
-          "size_gb"                    : 128,
+          "size_gb"                    : 256,
           "caching"                    : "None",
           "write_accelerator"          : false,
           "lun_start"                  : 11
@@ -282,7 +282,7 @@
           "fullname"                   : "",
           "count"                      : 2,
           "disk_type"                  : "Premium_LRS",
-          "size_gb"                    : 128,
+          "size_gb"                    : 256,
           "caching"                    : "None",
           "write_accelerator"          : false,
           "lun_start"                  : 14
@@ -292,7 +292,7 @@
           "fullname"                   : "",
           "count"                      : 1,
           "disk_type"                  : "Premium_LRS",
-          "size_gb"                    : 64,
+          "size_gb"                    : 128,
           "caching"                    : "ReadOnly",
           "write_accelerator"          : false,
           "lun_start"                  : 16

--- a/deploy/configs/sybase_sizes.json
+++ b/deploy/configs/sybase_sizes.json
@@ -260,7 +260,7 @@
         {
           "name"                       : "sapdata_1",
           "fullname"                   : "",
-          "count"                      : 3,
+          "count"                      : 2,
           "disk_type"                  : "Premium_LRS",
           "size_gb"                    : 512,
           "caching"                    : "ReadOnly",
@@ -282,7 +282,7 @@
           "fullname"                   : "",
           "count"                      : 2,
           "disk_type"                  : "Premium_LRS",
-          "size_gb"                    : 256,
+          "size_gb"                    : 128,
           "caching"                    : "None",
           "write_accelerator"          : false,
           "lun_start"                  : 14

--- a/deploy/configs/sybase_sizes.json
+++ b/deploy/configs/sybase_sizes.json
@@ -10,7 +10,7 @@
           "fullname"                   : "",
           "count"                      : 1,
           "disk_type"                  : "Premium_LRS",
-          "size_gb"                    : 128,
+          "size_gb"                    : 256,
           "caching"                    : "ReadWrite"
         },
         {
@@ -106,7 +106,7 @@
           "fullname"                   : "",
           "count"                      : 1,
           "disk_type"                  : "Premium_LRS",
-          "size_gb"                    : 128,
+          "size_gb"                    : 256,
           "caching"                    : "ReadWrite",
           "write_accelerator"          : false
         },
@@ -310,7 +310,7 @@
           "fullname"                   : "",
           "count"                      : 1,
           "disk_type"                  : "Premium_LRS",
-          "size_gb"                    : 128,
+          "size_gb"                    : 256,
           "caching"                    : "ReadWrite",
           "write_accelerator"          : false
         },


### PR DESCRIPTION
This pull request updates Sybase disk configuration by increases disk sizes and counts for improved storage capacity and performance.

**Sybase Disk Configuration Changes:**

* Increased disk size for several devices (e.g., from 128GB to 256GB, 64GB to 128GB) and increased the count for `sapdata_1` from 2 to 3 in `deploy/configs/sybase_sizes.json` to provide greater storage and scalability. [[1]](diffhunk://#diff-3db1657812a86657a9510f6f6660af02bce1393c5655df035a8a1f2f66ac4279L206-R206) [[2]](diffhunk://#diff-3db1657812a86657a9510f6f6660af02bce1393c5655df035a8a1f2f66ac4279L263-R263) [[3]](diffhunk://#diff-3db1657812a86657a9510f6f6660af02bce1393c5655df035a8a1f2f66ac4279L275-R275) [[4]](diffhunk://#diff-3db1657812a86657a9510f6f6660af02bce1393c5655df035a8a1f2f66ac4279L285-R285) [[5]](diffhunk://#diff-3db1657812a86657a9510f6f6660af02bce1393c5655df035a8a1f2f66ac4279L295-R295)## Problem
<Please describe what problem this PR is trying to resolve>

## Solution
<Please elaborate the solution for the problem>

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>