### PR TITLE
Fix: update Python version requirement

### DIFF
--- a/deploy/scripts/installer_v2.sh
+++ b/deploy/scripts/installer_v2.sh
@@ -678,7 +678,7 @@ function sdaf_installer() {
     echo "State file:                          ${key}.terraform.tfstate"
     echo "Target subscription:                 ${ARM_SUBSCRIPTION_ID}"
     echo "Deployer state file:                 ${TF_VAR_deployer_tfstate_key}"
-    echo "Workload zone state file:            ${TF_VAR_landscape_tfstate_key}"
+    echo "Workload zone state file:            ${TF_VAR_landscape_tfstate_key:-}"
     echo "Control plane keyvault:              ${keyvault}"
     echo ""
     echo "Current directory:                   $(pwd)"

--- a/deploy/scripts/py_scripts/SDAF-GitHub-Actions/README.md
+++ b/deploy/scripts/py_scripts/SDAF-GitHub-Actions/README.md
@@ -28,7 +28,7 @@ This script helps to automate the setup of a GitHub App, repository secrets, env
 2. Change directory
     `cd deploy/scripts/py_scripts/SDAF-GitHub-Actions`
 
-3. **Create a Virtual Environment**: Create and activate a virtual environment using Python 3.10+. On macOS, if `python3` still points to the system Python 3.9, use the versioned binary (e.g. `python3.12`) instead.
+3. **Create a Virtual Environment**: Create and activate a virtual environment using Python 3.10+. On macOS, if `python3` still points to the system/default Python (< 3.10), use the versioned binary (e.g. `python3.12`) instead.
 
     `python3 -m venv venv`
 

--- a/deploy/scripts/py_scripts/SDAF-GitHub-Actions/README.md
+++ b/deploy/scripts/py_scripts/SDAF-GitHub-Actions/README.md
@@ -15,7 +15,7 @@ This script helps to automate the setup of a GitHub App, repository secrets, env
 
 ### Prerequisites
 
-1. **Python**: Ensure Python 3.x is installed on your machine. You can download it from [Python official website](https://www.python.org/downloads/).
+1. **Python**: Ensure Python 3.10 or higher is installed on your machine. You can download it from [Python official website](https://www.python.org/downloads/). Note: macOS ships with Python 3.9 by default,  you will need to install a newer version (e.g. via [Homebrew](https://brew.sh): `brew install python@3.12`).
 2. **Azure CLI**: Ensure the Azure CLI is installed. You can download it from [Azure CLI installation guide](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli).
 3. **Azure Login**: Run `az login` in your terminal to authenticate with Azure before running the script.
 
@@ -28,9 +28,11 @@ This script helps to automate the setup of a GitHub App, repository secrets, env
 2. Change directory
     `cd deploy/scripts/py_scripts/SDAF-GitHub-Actions`
 
-3. **Create a Virtual Environment**: Create and activate a virtual environment.
+3. **Create a Virtual Environment**: Create and activate a virtual environment using Python 3.10+. On macOS, if `python3` still points to the system Python 3.9, use the versioned binary (e.g. `python3.12`) instead.
 
     `python3 -m venv venv`
+
+    > **macOS note**: If `python3 --version` reports < 3.10, run `python3.12 -m venv venv` (or whichever 3.10+ version you installed via Homebrew).
 
     On Unix/Linux/macOS (bash/zsh):
 

--- a/deploy/scripts/py_scripts/SDAF-GitHub-Actions/README.md
+++ b/deploy/scripts/py_scripts/SDAF-GitHub-Actions/README.md
@@ -15,7 +15,7 @@ This script helps to automate the setup of a GitHub App, repository secrets, env
 
 ### Prerequisites
 
-1. **Python**: Ensure Python 3.10 or higher is installed on your machine. You can download it from [Python official website](https://www.python.org/downloads/). Note: macOS ships with Python 3.9 by default,  you will need to install a newer version (e.g. via [Homebrew](https://brew.sh): `brew install python@3.12`).
+1. **Python**: Ensure Python 3.10 or higher is installed on your machine. You can download it from [Python official website](https://www.python.org/downloads/). Note: on macOS, the preinstalled Python (if any) is often older than 3.10 (or may be missing); check `python3 --version` and install a newer version if needed (e.g. via [Homebrew](https://brew.sh): `brew install python@3.12`).
 2. **Azure CLI**: Ensure the Azure CLI is installed. You can download it from [Azure CLI installation guide](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli).
 3. **Azure Login**: Run `az login` in your terminal to authenticate with Azure before running the script.
 

--- a/deploy/scripts/py_scripts/SDAF-GitHub-Actions/requirements.txt
+++ b/deploy/scripts/py_scripts/SDAF-GitHub-Actions/requirements.txt
@@ -1,3 +1,3 @@
 PyGithub==2.5.0
-requests==2.32.5
+requests>=2.33.0
 urllib3>=2.6.0


### PR DESCRIPTION
This pull request updates the setup instructions and dependencies for the `SDAF-GitHub-Actions` deployment scripts to ensure compatibility with newer Python versions and package requirements. The most important changes are:

**Documentation improvements:**

* Updated the prerequisite instructions in `README.md` to require Python 3.10 or higher, and added guidance for macOS users on installing and selecting the appropriate Python version.
* Clarified the virtual environment creation steps in `README.md` to ensure users use Python 3.10+ and provided a specific note for macOS users about versioned Python binaries.

**Dependency updates:**

* Updated `requirements.txt` to require `requests` version 2.33.0 or higher (previously pinned to 2.32.5).