### PR TITLE
Fix: update condition for suse_subscription_id handling in SUSE

### DIFF
--- a/deploy/ansible/roles-os/1.3-repository/tasks/1.3.0-preparation-Suse.yaml
+++ b/deploy/ansible/roles-os/1.3-repository/tasks/1.3.0-preparation-Suse.yaml
@@ -25,7 +25,7 @@
 
     # -------------------- BYOS / BYOL Registration Path --------------------8
     - name:                            "1.3.0 Repository - SUSE - Re-register SLE instance (BYOS - using registration code)"
-      when:                            suse_subscription_id | default('') | length > 0
+      when:                            suse_subscription_id | default('', true) | length > 0
       block:
         - name:                        "1.3.0 Repository - SUSE - BYOS - Cleanup existing registration"
           ansible.builtin.shell:      |
@@ -60,7 +60,7 @@
 
     # -------------------- PAYG Registration Path ---------------------------8
     - name:                            "1.3.0 Repository - SUSE - Re-register SLE instance (PAYG - using registercloudguest)"
-      when:                            suse_subscription_id | default('') | length == 0
+      when:                            suse_subscription_id | default('', true) | length == 0
       block:
         - name:                        "1.3.0 Repository - SUSE - PAYG - Cleanup existing registration"
           ansible.builtin.shell:      |


### PR DESCRIPTION
This pull request makes a small but important update to the SUSE repository preparation tasks in the Ansible playbooks. The changes improve the handling of undefined variables to prevent possible errors during playbook execution.

Variable handling improvements:

* Updated the `when` conditions in `1.3.0-preparation-Suse.yaml` to use `default('', true)`, ensuring that `suse_subscription_id` is treated as an empty string if it is undefined, which prevents errors and makes the playbook more robust. [[1]](diffhunk://#diff-421c1f8760081f47970b37e3834b022511ce0234b24ac522321cc343f88f61a3L28-R28) [[2]](diffhunk://#diff-421c1f8760081f47970b37e3834b022511ce0234b24ac522321cc343f88f61a3L63-R63)