### PR TITLE
Fix: use full workload zone name for Key Vault secret lookup in sap_system

### DIFF
--- a/deploy/terraform/run/sap_system/imports.tf
+++ b/deploy/terraform/run/sap_system/imports.tf
@@ -38,9 +38,8 @@ data "terraform_remote_state" "landscape" {
 #
 
 locals {
-  # Determine effective naming based on configuration
-  use_workload_zone_naming = length(trimspace(var.workload_zone_name)) > 0
-  environment_name         = local.use_workload_zone_naming ? var.workload_zone_name : local.environment
+  # Workload zone name used for KV secret lookups - always the full name (e.g. TEST-SWNO-SAP01)
+  environment_name = local.workload_zone_name
 
   # Control plane naming resolution
   control_plane_name_resolved = coalesce(

--- a/deploy/terraform/run/sap_system/imports.tf
+++ b/deploy/terraform/run/sap_system/imports.tf
@@ -38,7 +38,8 @@ data "terraform_remote_state" "landscape" {
 #
 
 locals {
-  # Workload zone name used for KV secret lookups - always the full name (e.g. TEST-SWNO-SAP01)
+  # Workload zone name used for KV secret lookups; defaults to the resolved/full workload zone name
+  # when var.workload_zone_name is not provided or empty (for example, TEST-SWNO-SAP01).
   environment_name = local.workload_zone_name
 
   # Control plane naming resolution


### PR DESCRIPTION
## Problem

In `deploy/terraform/run/sap_system/imports.tf`, Key Vault secret names for workload zone
credentials were built using `local.environment_name`, which fell back to `local.environment`
(e.g. `TEST`) when `var.workload_zone_name` was not explicitly provided in the tfvars.

This caused Terraform to look up secrets named:

- `TEST-client-id`
- `TEST-client-secret`
- `TEST-tenant-id`
- `TEST-subscription-id`

which do not exist. Ansible stores them using the **full workload zone name**, e.g.:

- `TEST-NOEU-SAP01-client-id`
- `TEST-NOEU-SAP01-client-secret`

Resulting in deployment failures:

Error: KeyVault Secret "TEST-client-id" (KeyVault URI "https://<vault>.vault.azure.net/") does not exist
Error: secret TEST-client-secret does not exist in Key Vault
Error: KeyVault Secret "TEST-tenant-id" does not exist


## Root Cause

```hcl
# Before — falls back to just the environment short name
use_workload_zone_naming = length(trimspace(var.workload_zone_name)) > 0
environment_name         = local.use_workload_zone_naming ? var.workload_zone_name : local.environment

When var.workload_zone_name is empty, local.environment resolves to
upper(local.infrastructure.environment) = "TEST" — only the environment segment,
not the full workload zone name.
```

## Fix
Replace the two-step logic with a direct reference to local.workload_zone_name,
which is already defined in [variables_local.tf](vscode-file://vscode-app/Users/nadeen/Downloads/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) with a reliable coalesce fallback:

```hcl
workload_zone_name = coalesce(
  var.workload_zone_name,
  upper(format("%s-%s-%s", var.environment, module.sap_namegenerator.naming_new.location_short, var.network_logical_name))
)
```

This always resolves to the full workload zone name (e.g. TEST-NOEU-SAP01)
regardless of whether var.workload_zone_name is explicitly passed.
