### PR TITLE
Fix for release march2026

### DIFF
--- a/deploy/scripts/pipeline_scripts/v2/00-store-secrets-in-keyvault.sh
+++ b/deploy/scripts/pipeline_scripts/v2/00-store-secrets-in-keyvault.sh
@@ -183,7 +183,6 @@ allParameters+=(--subscription "$ARM_SUBSCRIPTION_ID")
 if [ "$PLATFORM" == "devops" ]; then
 	allParameters+=(--ado)
 elif [ "$PLATFORM" == "github" ]; then
-	allParameters+=(--github)
 	allParameters+=(--gh_pat "$GH_PAT")
 fi
 if [ "${USE_MSI:-false}" == "true" ]; then

--- a/deploy/terraform/terraform-units/modules/sap_deployer/role_assignments.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/role_assignments.tf
@@ -247,17 +247,6 @@ resource "azurerm_role_assignment" "appconfig_data_owner_spn" {
 
 }
 
-resource "azurerm_role_assignment" "appconfig_data_owner_current" {
-  provider                             = azurerm.main
-  count                                = var.options.assign_resource_permissions && var.app_config_service.deploy ? 1 : 0
-  scope                                = length(var.app_config_service.id) == 0 ? azurerm_app_configuration.app_config[0].id : data.azurerm_app_configuration.app_config[0].id
-  role_definition_name                 = "App Configuration Data Owner"
-  principal_type                       = "ServicePrincipal"
-  principal_id                         = data.azurerm_client_config.current.object_id
-
-}
-
-
 locals {
   run_as_msi                           = length(var.deployer.user_assigned_identity_id) == 0 ? (
                                            var.bootstrap || var.options.use_spn ? false : azurerm_user_assigned_identity.deployer[0].principal_id == data.azurerm_client_config.current.object_id ) : (


### PR DESCRIPTION
## Summary

Fixes issues observed during the testing release march2026 using GitHub Actions

## Changes

#### 1. Remove duplicate `App Configuration Data Owner` role assignment

**File:** `deploy/terraform/terraform-units/modules/sap_deployer/role_assignments.tf`

`azurerm_role_assignment.appconfig_data_owner_current` was always a duplicate of an existing resource. This caused a `409 RoleAssignmentExists` conflict on every deployer deployment:

``` Error: unexpected status 409 (409 Conflict) with error: RoleAssignmentExists:
The role assignment already exists.
address: module.sap_deployer.azurerm_role_assignment.appconfig_data_owner_spn[0]
```
The resource has been removed. All required role assignments are fully covered by `appconfig_data_owner_spn` (SPN path) and `appconfig_data_owner_msi` (MSI path).

----
#### 2. Remove invalid `--github` parameter from `set_secrets_v2.sh` invocation

**File:** `deploy/scripts/pipeline_scripts/v2/00-store-secrets-in-keyvault.sh`

`00-store-secrets-in-keyvault.sh` was passing `--github` to `set_secrets_v2.sh`, which does not define that option in its `getopt` spec, causing an immediate parse failure:

```
set_secrets_v2: unrecognized option '--github'
Error: Process completed with exit code 1.
```

The platform is already detected internally via the `GITHUB_ACTIONS` environment variable (through `detect_platform`). The invalid argument has been removed. `--gh_pat` continues to be passed correctly.
