### PR TITLE
Add check for existing waagent swap configuration in create-swap-perboot.sh

### DIFF
--- a/deploy/ansible/roles-os/1.1-swap/templates/create-swap-perboot.sh.j2
+++ b/deploy/ansible/roles-os/1.1-swap/templates/create-swap-perboot.sh.j2
@@ -7,8 +7,14 @@
 # Deployed by Ansible role 1.1-swap as a cloud-init per-boot script.
 
 SWAP_FILE="/mnt/resource/swapfile"
+WAAGENT_SWAP_FILE="/mnt/swapfile"
 SWAP_SIZE_MB="{{ swap_size_mb }}"
 MOUNT_POINT="/mnt/resource"
+
+if swapon --show | grep -q "$WAAGENT_SWAP_FILE"; then
+  echo "Swap already configured by waagent" | systemd-cat -t create-swap
+  exit 0
+fi
 
 # Wait for the temp disk to be mounted (RAID0 from initramfs)
 for _ in $(seq 1 30); do


### PR DESCRIPTION
## Problem
On NVMe-capable VMs, cloud-init per-boot execution could fail during boot and leave the system in degraded state because the NVMe swap recreation script proceeded into /mnt/resource checks even when swap was already configured by waagent at /mnt/swapfile. This causes cloud-final.service failures in some scenarios.

## Solution
Updated the NVMe per-boot swap script in create-swap-perboot.sh.j2 to add an explicit early-exit condition for waagent-managed swap:
- Added WAAGENT_SWAP_FILE=/mnt/swapfile.
- Added early guard:
  - If /mnt/swapfile is active in swapon output, log and exit 0.
- Keep NVMe-specific logic intact:
  - Wait for /mnt/resource mount.
  - If /mnt/resource/swapfile is already active, exit 0.
  - Otherwise create and enable /mnt/resource/swapfile.

This prevents unnecessary per-boot failures when waagent already provides swap, while preserving NVMe swap recreation behavior when needed.

## Tests
1. Apply the updated role on an affected VM SKU.
2. Reboot the VM (or re-run role path that deploys the per-boot script and then reboot).
3. Verify cloud-init/systemd health:
   - systemctl --failed
   - journalctl -b 0 -u cloud-final.service --no-pager
   Expected: no cloud-final.service failure due to scripts-per-boot.
4. Verify swap behavior when waagent swap is active:
   - swapon --show
   - Confirm /mnt/swapfile active and per-boot script exits cleanly (check logs for create-swap tag).
5. Verify NVMe path still works when waagent swap is not active:
   - Ensure /mnt/resource is mounted.
   - Confirm /mnt/resource/swapfile can be created/activated by script and appears in swapon --show.

## Notes
- Change is limited to the per-boot template script only.
- Scope is behavior-safe for mixed environments where waagent and NVMe swap paths differ.