### PR TITLE
Enhance utility storage account management and configurations

### DIFF
--- a/deploy/terraform/run/sap_landscape/module.tf
+++ b/deploy/terraform/run/sap_landscape/module.tf
@@ -57,6 +57,7 @@ module "sap_landscape" {
   use_private_endpoint                         = var.use_private_endpoint
   use_service_endpoint                         = var.use_service_endpoint
   vm_settings                                  = local.vm_settings
+  utility_storage_settings                     = local.utility_storage_settings
   witness_storage_account                      = local.witness_storage_account
   dns_settings                                 = local.dns_settings
   data_plane_available                         = var.data_plane_available
@@ -71,5 +72,6 @@ module "sap_namegenerator" {
   random_id                                    = coalesce(var.custom_random_id, module.sap_landscape.random_id)
   sap_vnet_name                                = var.network_logical_name
   utility_vm_count                             = var.utility_vm_count
+  utility_storage_count                        = length(local.utility_storage_settings)
 }
 

--- a/deploy/terraform/run/sap_landscape/output.tf
+++ b/deploy/terraform/run/sap_landscape/output.tf
@@ -288,6 +288,17 @@ output "witness_storage_account_key"             {
                                                    value       = module.sap_landscape.witness_storage_account_key
                                                  }
 
+//Utility Storage
+output "utility_storage_account_ids"             {
+                                                   description = "List of utility storage account IDs"
+                                                   value       = module.sap_landscape.utility_storage_account_ids
+                                                 }
+
+output "utility_storage_account_names"           {
+                                                   description = "List of utility storage account names"
+                                                   value       = module.sap_landscape.utility_storage_account_names
+                                                 }
+
 ###############################################################################
 #                                                                             #
 #                            ANF                                              #

--- a/deploy/terraform/run/sap_landscape/tfvar_variables.tf
+++ b/deploy/terraform/run/sap_landscape/tfvar_variables.tf
@@ -1092,6 +1092,31 @@ variable "utility_vm_nic_ips"                      {
                                                      default     = []
                                                    }
 
+#########################################################################################
+#                                                                                       #
+#  Utility Storage Accounts                                                             #
+#                                                                                       #
+#########################################################################################
+
+variable "utility_storage_accounts"                {
+                                                     description = "List of utility storage account configurations for the workload zone"
+                                                     type = list(object({
+                                                       name                     = optional(string, "")
+                                                       account_kind             = optional(string, "StorageV2")
+                                                       account_tier             = optional(string, "Standard")
+                                                       account_replication_type = optional(string, "LRS")
+                                                       file_shares = optional(list(object({
+                                                         name     = string
+                                                         quota    = optional(number, 128)
+                                                         protocol = optional(string, "SMB")
+                                                       })), [])
+                                                       blob_containers = optional(list(object({
+                                                         name = string
+                                                       })), [])
+                                                     }))
+                                                     default     = []
+                                                   }
+
 variable "patch_mode"                           {
                                                   description = "If defined, define the patch mode for the virtual machines"
                                                   default     = "ImageDefault"

--- a/deploy/terraform/run/sap_landscape/tfvar_variables.tf
+++ b/deploy/terraform/run/sap_landscape/tfvar_variables.tf
@@ -1102,13 +1102,13 @@ variable "utility_storage_accounts"                {
                                                      description = "List of utility storage account configurations for the workload zone"
                                                      type = list(object({
                                                        name                     = optional(string, "")
-                                                       account_kind             = optional(string, "StorageV2")
-                                                       account_tier             = optional(string, "Standard")
+                                                       account_kind             = optional(string, "FileStorage")
+                                                       account_tier             = optional(string, "Premium")
                                                        account_replication_type = optional(string, "LRS")
                                                        file_shares = optional(list(object({
                                                          name     = optional(string, "")
                                                          quota    = optional(number, 128)
-                                                         protocol = optional(string, "SMB")
+                                                         protocol = optional(string, "NFS")
                                                        })), [])
                                                        blob_containers = optional(list(object({
                                                          name = optional(string, "")

--- a/deploy/terraform/run/sap_landscape/tfvar_variables.tf
+++ b/deploy/terraform/run/sap_landscape/tfvar_variables.tf
@@ -1106,12 +1106,12 @@ variable "utility_storage_accounts"                {
                                                        account_tier             = optional(string, "Standard")
                                                        account_replication_type = optional(string, "LRS")
                                                        file_shares = optional(list(object({
-                                                         name     = string
+                                                         name     = optional(string, "")
                                                          quota    = optional(number, 128)
                                                          protocol = optional(string, "SMB")
                                                        })), [])
                                                        blob_containers = optional(list(object({
-                                                         name = string
+                                                         name = optional(string, "")
                                                        })), [])
                                                      }))
                                                      default     = []

--- a/deploy/terraform/run/sap_landscape/transform.tf
+++ b/deploy/terraform/run/sap_landscape/transform.tf
@@ -318,25 +318,29 @@ locals {
                                          }
 
   utility_storage_settings             = [
-                                           for acct in var.utility_storage_accounts : {
+                                           for acct_idx, acct in var.utility_storage_accounts : {
                                              name                     = acct.name
                                              account_kind             = acct.account_kind
                                              account_tier             = acct.account_kind == "FileStorage" ? "Premium" : acct.account_tier
                                              account_replication_type = acct.account_replication_type
                                              file_shares              = acct.account_kind == "StorageV2" ? [
-                                               for share in acct.file_shares : {
-                                                 name     = share.name
+                                               for share_idx, share in acct.file_shares : {
+                                                 name     = length(share.name) > 0 ? share.name : format("share%02d", share_idx)
                                                  quota    = share.quota
                                                  protocol = upper(share.protocol)
                                                } if upper(share.protocol) != "NFS"
                                              ] : [
-                                               for share in acct.file_shares : {
-                                                 name     = share.name
+                                               for share_idx, share in acct.file_shares : {
+                                                 name     = length(share.name) > 0 ? share.name : format("share%02d", share_idx)
                                                  quota    = share.quota
                                                  protocol = upper(share.protocol)
                                                }
                                              ]
-                                             blob_containers          = acct.account_kind == "FileStorage" ? [] : acct.blob_containers
+                                             blob_containers          = acct.account_kind == "FileStorage" ? [] : [
+                                               for ctr_idx, ctr in acct.blob_containers : {
+                                                 name = length(ctr.name) > 0 ? ctr.name : format("container%02d", ctr_idx)
+                                               }
+                                             ]
                                              https_traffic_only_enabled = (
                                                acct.account_kind == "FileStorage" &&
                                                length([for s in acct.file_shares : s if upper(s.protocol) == "NFS"]) > 0

--- a/deploy/terraform/run/sap_landscape/transform.tf
+++ b/deploy/terraform/run/sap_landscape/transform.tf
@@ -323,17 +323,11 @@ locals {
                                              account_kind             = acct.account_kind
                                              account_tier             = acct.account_kind == "FileStorage" ? "Premium" : acct.account_tier
                                              account_replication_type = acct.account_replication_type
-                                             file_shares              = acct.account_kind == "StorageV2" ? [
+                                             file_shares              = [
                                                for share_idx, share in acct.file_shares : {
                                                  name     = length(share.name) > 0 ? share.name : format("share%02d", share_idx)
                                                  quota    = share.quota
-                                                 protocol = upper(share.protocol)
-                                               } if upper(share.protocol) != "NFS"
-                                             ] : [
-                                               for share_idx, share in acct.file_shares : {
-                                                 name     = length(share.name) > 0 ? share.name : format("share%02d", share_idx)
-                                                 quota    = share.quota
-                                                 protocol = upper(share.protocol)
+                                                 protocol = acct.account_kind == "StorageV2" ? "SMB" : upper(share.protocol)
                                                }
                                              ]
                                              blob_containers          = acct.account_kind == "FileStorage" ? [] : [
@@ -347,11 +341,7 @@ locals {
                                              ) ? false : (acct.account_kind == "FileStorage" ? var.AFS_enable_encryption_in_transit : true)
                                            }
                                            if (
-                                             length(
-                                               acct.account_kind == "StorageV2" ? [
-                                                 for s in acct.file_shares : s if upper(s.protocol) != "NFS"
-                                               ] : acct.file_shares
-                                             ) > 0
+                                             length(acct.file_shares) > 0
                                              || length(acct.account_kind == "FileStorage" ? [] : acct.blob_containers) > 0
                                            )
                                          ]

--- a/deploy/terraform/run/sap_landscape/transform.tf
+++ b/deploy/terraform/run/sap_landscape/transform.tf
@@ -317,6 +317,41 @@ locals {
                                            disk_type          = var.utility_vm_os_disk_type
                                          }
 
+  utility_storage_settings             = [
+                                           for acct in var.utility_storage_accounts : {
+                                             name                     = acct.name
+                                             account_kind             = acct.account_kind
+                                             account_tier             = acct.account_kind == "FileStorage" ? "Premium" : acct.account_tier
+                                             account_replication_type = acct.account_replication_type
+                                             file_shares              = acct.account_kind == "StorageV2" ? [
+                                               for share in acct.file_shares : {
+                                                 name     = share.name
+                                                 quota    = share.quota
+                                                 protocol = upper(share.protocol)
+                                               } if upper(share.protocol) != "NFS"
+                                             ] : [
+                                               for share in acct.file_shares : {
+                                                 name     = share.name
+                                                 quota    = share.quota
+                                                 protocol = upper(share.protocol)
+                                               }
+                                             ]
+                                             blob_containers          = acct.account_kind == "FileStorage" ? [] : acct.blob_containers
+                                             https_traffic_only_enabled = (
+                                               acct.account_kind == "FileStorage" &&
+                                               length([for s in acct.file_shares : s if upper(s.protocol) == "NFS"]) > 0
+                                             ) ? false : (acct.account_kind == "FileStorage" ? var.AFS_enable_encryption_in_transit : true)
+                                           }
+                                           if (
+                                             length(
+                                               acct.account_kind == "StorageV2" ? [
+                                                 for s in acct.file_shares : s if upper(s.protocol) != "NFS"
+                                               ] : acct.file_shares
+                                             ) > 0
+                                             || length(acct.account_kind == "FileStorage" ? [] : acct.blob_containers) > 0
+                                           )
+                                         ]
+
   ANF_settings                         = {
                                           use               = var.NFS_provider == "ANF"
                                           name              = var.ANF_account_name

--- a/deploy/terraform/terraform-units/modules/sap_landscape/outputs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/outputs.tf
@@ -306,6 +306,22 @@ output "transport_storage_account_id" {
 
 ###############################################################################
 #                                                                             #
+#                            Utility Storage                                  #
+#                                                                             #
+###############################################################################
+
+output "utility_storage_account_ids"             {
+                                                  description = "List of utility storage account IDs"
+                                                  value       = azurerm_storage_account.utility[*].id
+                                                }
+
+output "utility_storage_account_names"           {
+                                                  description = "List of utility storage account names"
+                                                  value       = azurerm_storage_account.utility[*].name
+                                                }
+
+###############################################################################
+#                                                                             #
 #                            DNS                                              #
 #                                                                             #
 ###############################################################################

--- a/deploy/terraform/terraform-units/modules/sap_landscape/utility_storage.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/utility_storage.tf
@@ -161,7 +161,8 @@ resource "azurerm_storage_account_network_rules" "utility" {
                                              var.infrastructure.virtual_networks.sap.subnet_app.exists ? var.infrastructure.virtual_networks.sap.subnet_app.id : azurerm_subnet.app[0].id) : (
                                              null
                                            ),
-                                           length(local.deployer_subnet_management_id) > 0 ? local.deployer_subnet_management_id : null
+                                           length(local.deployer_subnet_management_id) > 0 ? local.deployer_subnet_management_id : null,
+                                           length(var.infrastructure.additional_subnet_id) > 0 ? var.infrastructure.additional_subnet_id : null
                                          ]) : null
 
   bypass                               = ["Metrics", "Logging", "AzureServices"]

--- a/deploy/terraform/terraform-units/modules/sap_landscape/utility_storage.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/utility_storage.tf
@@ -137,7 +137,7 @@ resource "azurerm_storage_container" "utility" {
 
 resource "azurerm_storage_account_network_rules" "utility" {
   provider                             = azurerm.main
-  count                                = var.enable_firewall_for_keyvaults_and_storage ? length(var.utility_storage_settings) : 0
+  count                                = length(var.utility_storage_settings)
   depends_on                           = [
                                            azurerm_storage_account.utility,
                                            azurerm_storage_share.utility,
@@ -145,7 +145,7 @@ resource "azurerm_storage_account_network_rules" "utility" {
                                          ]
 
   storage_account_id                   = azurerm_storage_account.utility[count.index].id
-  default_action                       = "Deny"
+  default_action                       = var.enable_firewall_for_keyvaults_and_storage ? "Deny" : "Allow"
 
   ip_rules                             = var.public_network_access_enabled ? compact([
                                            length(local.deployer_public_ip_address) > 0 ? local.deployer_public_ip_address : "",

--- a/deploy/terraform/terraform-units/modules/sap_landscape/utility_storage.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/utility_storage.tf
@@ -89,8 +89,32 @@ resource "azurerm_storage_account" "utility" {
                                          )
   default_to_oauth_authentication      = true
 
+  network_rules {
+                  default_action              = var.enable_firewall_for_keyvaults_and_storage ? "Deny" : "Allow"
+                  ip_rules                    = var.public_network_access_enabled && var.utility_storage_settings[count.index].https_traffic_only_enabled ? compact([
+                                                  length(local.deployer_public_ip_address) > 0 ? local.deployer_public_ip_address : "",
+                                                  length(var.Agent_IP) > 0 ? var.Agent_IP : ""
+                                                ]) : []
+                  virtual_network_subnet_ids  = var.public_network_access_enabled ? compact([
+                                                  (var.infrastructure.virtual_networks.sap.subnet_db.defined || var.infrastructure.virtual_networks.sap.subnet_db.exists) ? (
+                                                    var.infrastructure.virtual_networks.sap.subnet_db.exists ? var.infrastructure.virtual_networks.sap.subnet_db.id : azurerm_subnet.db[0].id) : (
+                                                    null
+                                                  ),
+                                                  (var.infrastructure.virtual_networks.sap.subnet_app.defined || var.infrastructure.virtual_networks.sap.subnet_app.exists) ? (
+                                                    var.infrastructure.virtual_networks.sap.subnet_app.exists ? var.infrastructure.virtual_networks.sap.subnet_app.id : azurerm_subnet.app[0].id) : (
+                                                    null
+                                                  ),
+                                                  length(local.deployer_subnet_management_id) > 0 ? local.deployer_subnet_management_id : null,
+                                                  length(var.infrastructure.additional_subnet_id) > 0 ? var.infrastructure.additional_subnet_id : null
+                                                ]) : null
+                  bypass                      = ["Metrics", "Logging", "AzureServices"]
+                }
+
   tags                                 = var.tags
 
+  lifecycle {
+              ignore_changes = [network_rules[0].virtual_network_subnet_ids]
+            }
 }
 
 
@@ -126,49 +150,6 @@ resource "azurerm_storage_container" "utility" {
   storage_account_id                   = azurerm_storage_account.utility[local.utility_blob_containers[count.index].acct_index].id
   container_access_type                = "private"
 
-}
-
-
-################################################################################
-#                                                                              #
-#                     Utility storage network rules                            #
-#                                                                              #
-################################################################################
-
-resource "azurerm_storage_account_network_rules" "utility" {
-  provider                             = azurerm.main
-  count                                = length(var.utility_storage_settings)
-  depends_on                           = [
-                                           azurerm_storage_account.utility,
-                                           azurerm_storage_share.utility,
-                                           azurerm_storage_container.utility,
-                                         ]
-
-  storage_account_id                   = azurerm_storage_account.utility[count.index].id
-  default_action                       = var.enable_firewall_for_keyvaults_and_storage ? "Deny" : "Allow"
-
-  ip_rules                             = var.public_network_access_enabled ? compact([
-                                           length(local.deployer_public_ip_address) > 0 ? local.deployer_public_ip_address : "",
-                                           length(var.Agent_IP) > 0 ? var.Agent_IP : ""
-                                         ]) : null
-
-  virtual_network_subnet_ids           = var.public_network_access_enabled ? compact([
-                                           (var.infrastructure.virtual_networks.sap.subnet_db.defined || var.infrastructure.virtual_networks.sap.subnet_db.exists) ? (
-                                             var.infrastructure.virtual_networks.sap.subnet_db.exists ? var.infrastructure.virtual_networks.sap.subnet_db.id : azurerm_subnet.db[0].id) : (
-                                             null
-                                           ),
-                                           (var.infrastructure.virtual_networks.sap.subnet_app.defined || var.infrastructure.virtual_networks.sap.subnet_app.exists) ? (
-                                             var.infrastructure.virtual_networks.sap.subnet_app.exists ? var.infrastructure.virtual_networks.sap.subnet_app.id : azurerm_subnet.app[0].id) : (
-                                             null
-                                           ),
-                                           length(local.deployer_subnet_management_id) > 0 ? local.deployer_subnet_management_id : null,
-                                           length(var.infrastructure.additional_subnet_id) > 0 ? var.infrastructure.additional_subnet_id : null
-                                         ]) : null
-
-  bypass                               = ["Metrics", "Logging", "AzureServices"]
-  lifecycle {
-              ignore_changes = [virtual_network_subnet_ids]
-            }
 }
 
 

--- a/deploy/terraform/terraform-units/modules/sap_landscape/utility_storage.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/utility_storage.tf
@@ -1,0 +1,325 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+################################################################################
+#                                                                              #
+#                     Utility storage accounts                                 #
+#                                                                              #
+################################################################################
+
+locals {
+
+  # Flatten file shares across all accounts, preserving parent account index
+  utility_file_shares = flatten([
+    for acct_idx, acct in var.utility_storage_settings : [
+      for share in acct.file_shares : {
+        acct_index = acct_idx
+        name       = share.name
+        quota      = share.quota
+        protocol   = share.protocol
+      }
+    ]
+  ])
+
+  # Flatten blob containers across all accounts, preserving parent account index
+  utility_blob_containers = flatten([
+    for acct_idx, acct in var.utility_storage_settings : [
+      for container in acct.blob_containers : {
+        acct_index = acct_idx
+        name       = container.name
+      }
+    ]
+  ])
+
+  # Account indices that have at least one file share (for file PEs)
+  utility_accounts_with_file_shares = [
+    for idx, acct in var.utility_storage_settings : idx if length(acct.file_shares) > 0
+  ]
+
+  # Account indices that have at least one blob container (for blob PEs)
+  utility_accounts_with_blob_containers = [
+    for idx, acct in var.utility_storage_settings : idx if length(acct.blob_containers) > 0
+  ]
+
+}
+
+################################################################################
+#                                                                              #
+#                     Utility storage account resources                        #
+#                                                                              #
+################################################################################
+
+resource "azurerm_storage_account" "utility" {
+  provider                             = azurerm.main
+  count                                = length(var.utility_storage_settings)
+  depends_on                           = [
+                                           azurerm_virtual_network_peering.peering_management_sap,
+                                           azurerm_virtual_network_peering.peering_sap_management,
+                                           azurerm_virtual_network_peering.peering_additional_network_sap,
+                                           azurerm_virtual_network_peering.peering_sap_additional_network,
+                                         ]
+  name                                 = replace(
+                                           lower(
+                                             format("%s", local.landscape_utility_storage_account_names[count.index])
+                                           ),
+                                           "/[^a-z0-9]/",
+                                           ""
+                                         )
+  resource_group_name                  = local.resource_group_exists ? (
+                                           data.azurerm_resource_group.resource_group[0].name) : (
+                                           azurerm_resource_group.resource_group[0].name
+                                         )
+  location                             = local.resource_group_exists ? (
+                                          data.azurerm_resource_group.resource_group[0].location) : (
+                                          azurerm_resource_group.resource_group[0].location
+                                        )
+
+  account_kind                         = var.utility_storage_settings[count.index].account_kind
+  account_tier                         = var.utility_storage_settings[count.index].account_tier
+  account_replication_type             = var.utility_storage_settings[count.index].account_replication_type
+  https_traffic_only_enabled           = var.utility_storage_settings[count.index].https_traffic_only_enabled
+  min_tls_version                      = "TLS1_2"
+  allow_nested_items_to_be_public      = false
+  cross_tenant_replication_enabled     = false
+  public_network_access_enabled        = var.public_network_access_enabled
+
+  shared_access_key_enabled            = var.utility_storage_settings[count.index].account_kind == "FileStorage" ? (
+                                           var.infrastructure.shared_access_key_enabled_nfs) : (
+                                           var.infrastructure.shared_access_key_enabled
+                                         )
+  default_to_oauth_authentication      = true
+
+  tags                                 = var.tags
+
+}
+
+
+################################################################################
+#                                                                              #
+#                     Utility file shares                                      #
+#                                                                              #
+################################################################################
+
+resource "azurerm_storage_share" "utility" {
+  provider                             = azurerm.main
+  count                                = length(local.utility_file_shares)
+
+  name                                 = local.utility_file_shares[count.index].name
+  storage_account_id                   = azurerm_storage_account.utility[local.utility_file_shares[count.index].acct_index].id
+  enabled_protocol                     = local.utility_file_shares[count.index].protocol
+  quota                                = local.utility_file_shares[count.index].quota
+
+}
+
+
+################################################################################
+#                                                                              #
+#                     Utility blob containers                                  #
+#                                                                              #
+################################################################################
+
+resource "azurerm_storage_container" "utility" {
+  provider                             = azurerm.main
+  count                                = length(local.utility_blob_containers)
+
+  name                                 = local.utility_blob_containers[count.index].name
+  storage_account_id                   = azurerm_storage_account.utility[local.utility_blob_containers[count.index].acct_index].id
+  container_access_type                = "private"
+
+}
+
+
+################################################################################
+#                                                                              #
+#                     Utility storage network rules                            #
+#                                                                              #
+################################################################################
+
+resource "azurerm_storage_account_network_rules" "utility" {
+  provider                             = azurerm.main
+  count                                = var.enable_firewall_for_keyvaults_and_storage ? length(var.utility_storage_settings) : 0
+  depends_on                           = [
+                                           azurerm_storage_account.utility,
+                                           azurerm_storage_share.utility,
+                                           azurerm_storage_container.utility,
+                                         ]
+
+  storage_account_id                   = azurerm_storage_account.utility[count.index].id
+  default_action                       = "Deny"
+
+  ip_rules                             = var.public_network_access_enabled ? compact([
+                                           length(local.deployer_public_ip_address) > 0 ? local.deployer_public_ip_address : "",
+                                           length(var.Agent_IP) > 0 ? var.Agent_IP : ""
+                                         ]) : null
+
+  virtual_network_subnet_ids           = var.public_network_access_enabled ? compact([
+                                           (var.infrastructure.virtual_networks.sap.subnet_db.defined || var.infrastructure.virtual_networks.sap.subnet_db.exists) ? (
+                                             var.infrastructure.virtual_networks.sap.subnet_db.exists ? var.infrastructure.virtual_networks.sap.subnet_db.id : azurerm_subnet.db[0].id) : (
+                                             null
+                                           ),
+                                           (var.infrastructure.virtual_networks.sap.subnet_app.defined || var.infrastructure.virtual_networks.sap.subnet_app.exists) ? (
+                                             var.infrastructure.virtual_networks.sap.subnet_app.exists ? var.infrastructure.virtual_networks.sap.subnet_app.id : azurerm_subnet.app[0].id) : (
+                                             null
+                                           ),
+                                           length(local.deployer_subnet_management_id) > 0 ? local.deployer_subnet_management_id : null
+                                         ]) : null
+
+  bypass                               = ["Metrics", "Logging", "AzureServices"]
+  lifecycle {
+              ignore_changes = [virtual_network_subnet_ids]
+            }
+}
+
+
+################################################################################
+#                                                                              #
+#                     Utility file private endpoints                           #
+#                                                                              #
+################################################################################
+
+resource "azurerm_private_endpoint" "utility_file" {
+  provider                             = azurerm.main
+  depends_on                           = [
+                                           azurerm_subnet.app,
+                                           azurerm_private_dns_zone_virtual_network_link.vnet_sap_file
+                                         ]
+  count                                = var.use_private_endpoint && (
+                                           var.infrastructure.virtual_networks.sap.subnet_app.defined || var.infrastructure.virtual_networks.sap.subnet_app.exists
+                                         ) ? length(local.utility_accounts_with_file_shares) : 0
+
+  name                                 = format("%s%s%s%02d",
+                                           var.naming.resource_prefixes.storage_private_link_utility_file,
+                                           local.prefix,
+                                           local.resource_suffixes.storage_private_link_utility_file,
+                                           local.utility_accounts_with_file_shares[count.index]
+                                         )
+  tags                                 = var.tags
+  custom_network_interface_name        = format("%s%s%s%02d%s",
+                                           var.naming.resource_prefixes.storage_private_link_utility_file,
+                                           local.prefix,
+                                           local.resource_suffixes.storage_private_link_utility_file,
+                                           local.utility_accounts_with_file_shares[count.index],
+                                           var.naming.resource_suffixes.nic
+                                         )
+
+  resource_group_name                  = local.resource_group_exists ? (
+                                           data.azurerm_resource_group.resource_group[0].name) : (
+                                           azurerm_resource_group.resource_group[0].name
+                                         )
+  location                             = local.resource_group_exists ? (
+                                          data.azurerm_resource_group.resource_group[0].location) : (
+                                          azurerm_resource_group.resource_group[0].location
+                                        )
+
+  subnet_id                            = var.infrastructure.virtual_networks.sap.subnet_app.exists ? (
+                                           var.infrastructure.virtual_networks.sap.subnet_app.id) : (
+                                           azurerm_subnet.app[0].id
+                                         )
+
+  private_service_connection {
+                               name = format("%s%s%s%02d",
+                                 var.naming.resource_prefixes.storage_private_svc_utility_file,
+                                 local.prefix,
+                                 local.resource_suffixes.storage_private_svc_utility_file,
+                                 local.utility_accounts_with_file_shares[count.index]
+                               )
+                               is_manual_connection          = false
+                               private_connection_resource_id = azurerm_storage_account.utility[local.utility_accounts_with_file_shares[count.index]].id
+                               subresource_names = [
+                                 "File"
+                               ]
+                             }
+
+  dynamic "private_dns_zone_group" {
+                                     for_each = range(var.dns_settings.register_endpoints_with_dns ? 1 : 0)
+                                     content {
+                                       name                 = var.dns_settings.dns_zone_names.file_dns_zone_name
+                                       private_dns_zone_ids = local.privatelink_file_defined ? (
+                                        [var.dns_settings.privatelink_file_id]) : (
+                                        [data.azurerm_private_dns_zone.file[0].id]
+                                        )
+                                     }
+                                   }
+
+  timeouts {
+             create = "10m"
+             delete = "30m"
+           }
+}
+
+
+################################################################################
+#                                                                              #
+#                     Utility blob private endpoints                           #
+#                                                                              #
+################################################################################
+
+resource "azurerm_private_endpoint" "utility_blob" {
+  provider                             = azurerm.main
+  depends_on                           = [
+                                           azurerm_subnet.app,
+                                           azurerm_private_dns_zone_virtual_network_link.vnet_sap
+                                         ]
+  count                                = var.use_private_endpoint && (
+                                           var.infrastructure.virtual_networks.sap.subnet_app.defined || var.infrastructure.virtual_networks.sap.subnet_app.exists
+                                         ) ? length(local.utility_accounts_with_blob_containers) : 0
+
+  name                                 = format("%s%s%s%02d",
+                                           var.naming.resource_prefixes.storage_private_link_utility_blob,
+                                           local.prefix,
+                                           local.resource_suffixes.storage_private_link_utility_blob,
+                                           local.utility_accounts_with_blob_containers[count.index]
+                                         )
+  tags                                 = var.tags
+  custom_network_interface_name        = format("%s%s%s%02d%s",
+                                           var.naming.resource_prefixes.storage_private_link_utility_blob,
+                                           local.prefix,
+                                           local.resource_suffixes.storage_private_link_utility_blob,
+                                           local.utility_accounts_with_blob_containers[count.index],
+                                           var.naming.resource_suffixes.nic
+                                         )
+
+  resource_group_name                  = local.resource_group_exists ? (
+                                           data.azurerm_resource_group.resource_group[0].name) : (
+                                           azurerm_resource_group.resource_group[0].name
+                                         )
+  location                             = local.resource_group_exists ? (
+                                          data.azurerm_resource_group.resource_group[0].location) : (
+                                          azurerm_resource_group.resource_group[0].location
+                                        )
+
+  subnet_id                            = var.infrastructure.virtual_networks.sap.subnet_app.exists ? (
+                                           var.infrastructure.virtual_networks.sap.subnet_app.id) : (
+                                           azurerm_subnet.app[0].id
+                                         )
+
+  private_service_connection {
+                               name = format("%s%s%s%02d",
+                                 var.naming.resource_prefixes.storage_private_svc_utility_blob,
+                                 local.prefix,
+                                 local.resource_suffixes.storage_private_svc_utility_blob,
+                                 local.utility_accounts_with_blob_containers[count.index]
+                               )
+                               is_manual_connection          = false
+                               private_connection_resource_id = azurerm_storage_account.utility[local.utility_accounts_with_blob_containers[count.index]].id
+                               subresource_names = [
+                                 "blob"
+                               ]
+                             }
+
+  dynamic "private_dns_zone_group" {
+                                     for_each = range(var.dns_settings.register_endpoints_with_dns ? 1 : 0)
+                                     content {
+                                       name                 = var.dns_settings.dns_zone_names.blob_dns_zone_name
+                                       private_dns_zone_ids = local.privatelink_storage_defined ? (
+                                        [var.dns_settings.privatelink_storage_id]) : (
+                                        [data.azurerm_private_dns_zone.storage[0].id]
+                                        )
+                                     }
+                                   }
+
+  timeouts {
+             create = "10m"
+             delete = "30m"
+           }
+}

--- a/deploy/terraform/terraform-units/modules/sap_landscape/variables_global.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/variables_global.tf
@@ -257,6 +257,26 @@ variable "vm_settings"                                   {
                                                            }
                                                          }
 
+variable "utility_storage_settings"                      {
+                                                           description = "List of utility storage account configurations (normalized from transform.tf)"
+                                                           type = list(object({
+                                                             name                       = string
+                                                             account_kind               = string
+                                                             account_tier               = string
+                                                             account_replication_type    = string
+                                                             https_traffic_only_enabled = bool
+                                                             file_shares = list(object({
+                                                               name     = string
+                                                               quota    = number
+                                                               protocol = string
+                                                             }))
+                                                             blob_containers = list(object({
+                                                               name = string
+                                                             }))
+                                                           }))
+                                                           default = []
+                                                         }
+
 variable "peer_with_control_plane_vnet"                  { description = "Defines in the SAP VNet will be peered with the controlplane VNet" }
 
 variable "enable_firewall_for_keyvaults_and_storage"     { description = "Boolean value indicating if firewall should be enabled for key vaults and storage" }

--- a/deploy/terraform/terraform-units/modules/sap_landscape/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/variables_local.tf
@@ -13,7 +13,7 @@ locals {
   landscape_keyvault_names                        = var.naming.keyvault_names.WORKLOAD_ZONE
   landscape_shared_install_storage_account_name   = var.naming.storageaccount_names.WORKLOAD_ZONE.landscape_shared_install_storage_account_name
   landscape_shared_transport_storage_account_name = var.naming.storageaccount_names.WORKLOAD_ZONE.landscape_shared_transport_storage_account_name
-  landscape_utility_storage_account_names         = var.naming.storageaccount_names.WORKLOAD_ZONE.landscape_utility_storage_account_names
+  landscape_utility_storage_account_names         = try(var.naming.storageaccount_names.WORKLOAD_ZONE.landscape_utility_storage_account_names, [])
   resource_suffixes                               = var.naming.resource_suffixes
   sid_keyvault_names                              = var.naming.keyvault_names.SDU
   virtualmachine_names                            = var.naming.virtualmachine_names.ISCSI_COMPUTERNAME

--- a/deploy/terraform/terraform-units/modules/sap_landscape/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/variables_local.tf
@@ -13,6 +13,7 @@ locals {
   landscape_keyvault_names                        = var.naming.keyvault_names.WORKLOAD_ZONE
   landscape_shared_install_storage_account_name   = var.naming.storageaccount_names.WORKLOAD_ZONE.landscape_shared_install_storage_account_name
   landscape_shared_transport_storage_account_name = var.naming.storageaccount_names.WORKLOAD_ZONE.landscape_shared_transport_storage_account_name
+  landscape_utility_storage_account_names         = var.naming.storageaccount_names.WORKLOAD_ZONE.landscape_utility_storage_account_names
   resource_suffixes                               = var.naming.resource_suffixes
   sid_keyvault_names                              = var.naming.keyvault_names.SDU
   virtualmachine_names                            = var.naming.virtualmachine_names.ISCSI_COMPUTERNAME

--- a/deploy/terraform/terraform-units/modules/sap_namegenerator/output.tf
+++ b/deploy/terraform/terraform-units/modules/sap_namegenerator/output.tf
@@ -51,6 +51,7 @@ output "naming" {
                              witness_storageaccount_name                     = local.witness_storageaccount_name
                              landscape_shared_transport_storage_account_name = local.landscape_shared_transport_storage_account_name
                              landscape_shared_install_storage_account_name   = local.landscape_shared_install_storage_account_name
+                             landscape_utility_storage_account_names         = local.landscape_utility_storage_account_names
                            }
                            LIBRARY = {
                              library_storageaccount_name        = local.library_storageaccount_name

--- a/deploy/terraform/terraform-units/modules/sap_namegenerator/resourcegroup.tf
+++ b/deploy/terraform/terraform-units/modules/sap_namegenerator/resourcegroup.tf
@@ -25,6 +25,12 @@ locals {
   // Witness account
   witness_storageaccount_name = substr(replace(lower(format("%s%s%switness%s", local.landscape_env_verified, local.location_short, local.sap_vnet_verified, local.random_id_verified)), "/[^a-z0-9]/", ""), 0, var.azlimits.stgaccnt)
 
+  landscape_utility_storage_account_names         = [
+                                                      for idx in range(var.utility_storage_count) :
+                                                      substr(replace(lower(format("%s%s%sutil%02d%s",
+                                                        local.landscape_env_verified, local.location_short, local.sap_vnet_verified, idx, local.random_id_verified
+                                                      )), "/[^a-z0-9]/", ""), 0, var.azlimits.stgaccnt)
+                                                    ]
   network_security_perimeter_name  = upper(format("%s-%s%s", local.env_verified, local.location_short, "_network_security_perimeter"))
 
 }

--- a/deploy/terraform/terraform-units/modules/sap_namegenerator/variables_global.tf
+++ b/deploy/terraform/terraform-units/modules/sap_namegenerator/variables_global.tf
@@ -365,6 +365,8 @@ variable "resource_prefixes" {
     "storage_private_link_tf"        = ""
     "storage_private_link_transport" = ""
     "storage_private_link_witness"   = ""
+    "storage_private_link_utility_blob" = ""
+    "storage_private_link_utility_file" = ""
     "storage_private_svc_diag"       = ""
     "storage_private_svc_install"    = ""
     "storage_private_svc_sap"        = ""
@@ -372,6 +374,8 @@ variable "resource_prefixes" {
     "storage_private_svc_tf"         = ""
     "storage_private_svc_transport"  = ""
     "storage_private_svc_witness"    = ""
+    "storage_private_svc_utility_blob" = ""
+    "storage_private_svc_utility_file" = ""
     "storage_privatelink_hanashared" = ""
     "storage_subnet"                 = ""
     "storage_subnet_nsg"             = ""
@@ -510,6 +514,8 @@ variable "resource_suffixes" {
     "storage_private_link_tf"        = "-tf-storage-private-endpoint"
     "storage_private_link_transport" = "-transport-storage-private-endpoint"
     "storage_private_link_witness"   = "-witness-storage-private-endpoint"
+    "storage_private_link_utility_blob"   = "-utility-blob-storage-private-endpoint"
+    "storage_private_link_utility_file"   = "-utility-file-storage-private-endpoint"
     "storage_private_svc_diag"       = "-diag-storage-private-service"
     "storage_private_svc_install"    = "-install-storage-private-service"
     "storage_private_svc_sap"        = "-sap-storage-private-service"
@@ -517,6 +523,8 @@ variable "resource_suffixes" {
     "storage_private_svc_tf"         = "-tf-storage-private-service"
     "storage_private_svc_transport"  = "-transport-storage-private-service"
     "storage_private_svc_witness"    = "-witness-storage-private-service"
+    "storage_private_svc_utility_blob"    = "-utility-blob-storage-private-service"
+    "storage_private_svc_utility_file"    = "-utility-file-storage-private-service"
     "storage_privatelink_hanashared" = "-hanashared-storage-private-endpoint"
     "storage_subnet"                 = "storage-subnet"
     "storage_subnet_nsg"             = "storageSubnet-nsg"
@@ -586,6 +594,11 @@ variable "deployer_location" {
 }
 
 variable "utility_vm_count" {
+  type    = number
+  default = 0
+}
+
+variable "utility_storage_count" {
   type    = number
   default = 0
 }


### PR DESCRIPTION
This pull request introduces support for defining and managing utility storage accounts within the SAP landscape Terraform configuration. The changes allow users to specify multiple utility storage accounts and their settings, and expose their IDs and names as outputs for downstream use.

**Support for Utility Storage Accounts:**

* Added a new variable `utility_storage_accounts` to allow configuration of multiple utility storage accounts, including their kind, tier, replication type, file shares, and blob containers.
* Introduced a new local `utility_storage_settings` to transform the input variable into a normalized structure with default values and computed fields for use in module logic.
* Passed `utility_storage_settings` to the `sap_landscape` module and provided the count of utility storage accounts to the `sap_namegenerator` module for resource naming and provisioning. [[1]](diffhunk://#diff-a55556960d9c1e1561a72cf5921ced246585068c6c390dabba55c233a92f161bR60) [[2]](diffhunk://#diff-a55556960d9c1e1561a72cf5921ced246585068c6c390dabba55c233a92f161bR75)

**Outputs for Utility Storage Accounts:**

* Exposed new outputs `utility_storage_account_ids` and `utility_storage_account_names` in both the root and `sap_landscape` modules, making it easy to reference these resources in other modules or outputs. [[1]](diffhunk://#diff-550684b8ee5f25e90a70de6f51bf155b397964947f0401d0a0530c087cc83502R291-R301) [[2]](diffhunk://#diff-c0dc46f2d56972fc6d5c0eb1702101170bf2e613a211493988c33ea1b2d65b6dR307-R322)