### PR TITLE
Add pacemaker.timer configuration for delayed startup

### DIFF
--- a/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.2-provision.yml
+++ b/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.2-provision.yml
@@ -89,3 +89,6 @@
 - name:                                "1.17 Generic Pacemaker - Cluster based on {{ ansible_os_family }} on VM {{ ansible_hostname }}"
   ansible.builtin.include_tasks:       "1.17.2.0-cluster-{{ ansible_os_family }}.yml"
   # when:                                cluster_existence_check != 0
+
+- name:                                "1.17 Generic Pacemaker - Configure pacemaker.timer for boot delay"
+  ansible.builtin.include_tasks:       1.17.2.1-pacemaker-timer.yml

--- a/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.2.0-cluster-Suse.yml
+++ b/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.2.0-cluster-Suse.yml
@@ -319,14 +319,14 @@
           ansible.builtin.shell: |
                                        crm configure primitive stonith-sbd stonith:external/sbd \
                                          params pcmk_delay_max="15" \
-                                         op monitor interval="600" timeout="15"
+                                         op monitor interval="600" timeout="120"
 
     - name:                            "1.17 Generic Pacemaker - Ensure Stonith SBD is configured in cluster"
       when:                            stonith_sbd_configured.rc != 0
       ansible.builtin.shell: |
                                        crm configure primitive stonith-sbd stonith:external/sbd \
                                          params pcmk_delay_max="15" \
-                                         op monitor interval="600" timeout="15"
+                                         op monitor interval="600" timeout="120"
 
     - name:                            "1.17 Generic Pacemaker - Set the Stonith SBD Timeout Property"
       ansible.builtin.shell:           crm configure property stonith-timeout=210

--- a/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.2.1-pacemaker-timer.yml
+++ b/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.2.1-pacemaker-timer.yml
@@ -1,0 +1,52 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+---
+# /*---------------------------------------------------------------------------8
+# |                                                                            |
+# | Configure pacemaker.timer to delay pacemaker startup after boot.          |
+# |                                                                            |
+# +------------------------------------4--------------------------------------*/
+
+- name:                                "1.17 Generic Pacemaker - Deploy pacemaker.timer unit"
+  ansible.builtin.template:
+    src:                               pacemaker.timer.j2
+    dest:                              /etc/systemd/system/pacemaker.timer
+    owner:                             root
+    group:                             root
+    mode:                              '0644'
+
+- name:                                "1.17 Generic Pacemaker - Reload systemd daemon"
+  ansible.builtin.systemd:
+    daemon_reload:                     true
+
+- name:                                "1.17 Generic Pacemaker - Enable pacemaker.timer"
+  ansible.builtin.systemd:
+    name:                              pacemaker.timer
+    enabled:                           true
+
+- name:                                "1.17 Generic Pacemaker - Disable SBD_DELAY_START (timer handles delay)"
+  when:                                cluster_stonith_type in ['ASD', 'ISCSI']
+  ansible.builtin.lineinfile:
+    path:                              /etc/sysconfig/sbd
+    regexp:                            '^SBD_DELAY_START=.*'
+    line:                              'SBD_DELAY_START=no'
+    owner:                             root
+    group:                             root
+    mode:                              '0644'
+    backup:                            true
+
+- name:                                "1.17 Generic Pacemaker - Disable pacemaker autostart (timer controls startup)"
+  ansible.builtin.systemd:
+    name:                              pacemaker
+    enabled:                           false
+
+- name:                                "1.17 Generic Pacemaker - Disable corosync autostart (timer controls startup)"
+  ansible.builtin.systemd:
+    name:                              corosync
+    enabled:                           false
+
+...
+# /*---------------------------------------------------------------------------8
+# |                                   END                                      |
+# +------------------------------------4--------------------------------------*/

--- a/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.2.1-pacemaker-timer.yml
+++ b/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.2.1-pacemaker-timer.yml
@@ -25,8 +25,21 @@
     name:                              pacemaker.timer
     enabled:                           true
 
-- name:                                "1.17 Generic Pacemaker - Disable SBD_DELAY_START (timer handles delay)"
+- name:                                "1.17 Generic Pacemaker - Start pacemaker.timer"
+  ansible.builtin.systemd:
+    name:                              pacemaker.timer
+    state:                             started
+
+- name:                                "1.17 Generic Pacemaker - Check if SBD sysconfig file exists"
   when:                                cluster_stonith_type in ['ASD', 'ISCSI']
+  ansible.builtin.stat:
+    path:                              /etc/sysconfig/sbd
+  register:                            sbd_sysconfig_file
+ 
+- name:                                "1.17 Generic Pacemaker - Disable SBD_DELAY_START (timer handles delay)"
+  when:
+                                       - cluster_stonith_type in ['ASD', 'ISCSI']
+                                       - sbd_sysconfig_file.stat.exists
   ansible.builtin.lineinfile:
     path:                              /etc/sysconfig/sbd
     regexp:                            '^SBD_DELAY_START=.*'

--- a/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.2.1-pacemaker-timer.yml
+++ b/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.2.1-pacemaker-timer.yml
@@ -24,10 +24,6 @@
   ansible.builtin.systemd:
     name:                              pacemaker.timer
     enabled:                           true
-
-- name:                                "1.17 Generic Pacemaker - Start pacemaker.timer"
-  ansible.builtin.systemd:
-    name:                              pacemaker.timer
     state:                             started
 
 - name:                                "1.17 Generic Pacemaker - Check if SBD sysconfig file exists"

--- a/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.2.1-pacemaker-timer.yml
+++ b/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.2.1-pacemaker-timer.yml
@@ -31,7 +31,7 @@
   ansible.builtin.stat:
     path:                              /etc/sysconfig/sbd
   register:                            sbd_sysconfig_file
- 
+
 - name:                                "1.17 Generic Pacemaker - Disable SBD_DELAY_START (timer handles delay)"
   when:
                                        - cluster_stonith_type in ['ASD', 'ISCSI']

--- a/deploy/ansible/roles-os/1.17-generic-pacemaker/templates/pacemaker.timer.j2
+++ b/deploy/ansible/roles-os/1.17-generic-pacemaker/templates/pacemaker.timer.j2
@@ -1,0 +1,9 @@
+[Unit]
+Description=Delay start of pacemaker.service after boot
+
+[Timer]
+OnBootSec={{ pacemaker_start_delay }}
+Unit=pacemaker.service
+
+[Install]
+WantedBy=timers.target

--- a/deploy/ansible/roles-os/1.17-generic-pacemaker/vars/main.yml
+++ b/deploy/ansible/roles-os/1.17-generic-pacemaker/vars/main.yml
@@ -12,6 +12,7 @@
 # |  They may be overridden, if required, but normally are not                 |
 # |                                                                           |
 # +------------------------------------4--------------------------------------*/
+pacemaker_start_delay:               "{{ '216' if ansible_os_family | upper == 'SUSE' else '186' }}"
 
 cluster_totem:
   token:                               30000

--- a/deploy/ansible/roles-os/1.18-scaleout-pacemaker/tasks/1.18.2.0-cluster-Suse.yml
+++ b/deploy/ansible/roles-os/1.18-scaleout-pacemaker/tasks/1.18.2.0-cluster-Suse.yml
@@ -272,7 +272,7 @@
       ansible.builtin.shell: >-
                                        crm configure primitive stonith-sbd stonith:external/sbd \
                                          params pcmk_delay_max="15" \
-                                         op monitor interval="600" timeout="15"
+                                         op monitor interval="600" timeout="120"
 
     - name:                            "1.18.2.0 Generic Pacemaker - Set the Stonith SBD Timeout Property"
       ansible.builtin.shell:           crm configure property stonith-timeout=210

--- a/deploy/ansible/roles-sap/5.5-hanadb-pacemaker/tasks/cluster-Suse-large-instance.yml
+++ b/deploy/ansible/roles-sap/5.5-hanadb-pacemaker/tasks/cluster-Suse-large-instance.yml
@@ -78,7 +78,7 @@
       ansible.builtin.command: >
         crm configure primitive stonith-sbd stonith:external/sbd \
         params pcmk_delay_max="15" \
-        op monitor interval="15" timeout="15"
+        op monitor interval="15" timeout="120"
 
     - name: Check the current SBD status
       ansible.builtin.shell: set -o pipefail && crm_mon -1 | grep sbd


### PR DESCRIPTION
This pull request introduces a new mechanism to control the startup timing of the Pacemaker service using a systemd timer, replacing previous autostart and delay logic. The main goal is to ensure Pacemaker starts after a configurable delay following system boot, improving cluster reliability and startup sequencing. The implementation includes new Ansible tasks, a template for the timer unit, and related variable configuration.

**Pacemaker startup delay and systemd timer integration:**

* Added a new Ansible task file (`1.17.2.1-pacemaker-timer.yml`) to deploy and configure a `pacemaker.timer` systemd unit, reload the systemd daemon, enable the timer, and disable Pacemaker and Corosync autostart. Also disables `SBD_DELAY_START` for certain stonith types, as the timer now handles the delay.
* Updated the main provisioning playbook (`1.17.2-provision.yml`) to include the new pacemaker timer configuration tasks.
* Introduced a new Jinja2 template (`pacemaker.timer.j2`) for the systemd timer unit, allowing the Pacemaker service to start after a configurable delay (`pacemaker_start_delay`).
* Defined the default `pacemaker_start_delay` variable in `main.yml`, with different defaults for SUSE and other OS families.