### PR TITLE
Remove Swift connection setup for web app and related role assignments

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_deployer/app_service.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/app_service.tf
@@ -200,28 +200,3 @@ resource "azurerm_windows_web_app" "webapp" {
                                              }
 
 }
-
-
-# Set up Vnet integration for webapp and storage account interaction
-resource "azurerm_app_service_virtual_network_swift_connection" "webapp_vnet_connection" {
-  count          = var.app_service.use ? 1 : 0
-  app_service_id = azurerm_windows_web_app.webapp[0].id
-  subnet_id      = var.infrastructure.virtual_network.management.subnet_webapp.exists ? data.azurerm_subnet.webapp[0].id : azurerm_subnet.webapp[0].id
-}
-
-
-# resource "azurerm_role_assignment" "app_service_contributor" {
-#   provider             = azurerm.main
-#   count                = var.app_service.use && var.deployer.add_system_assigned_identity ? var.deployer_vm_count : 0
-#   scope                = azurerm_windows_web_app.webapp[0].id
-#   role_definition_name = "Website Contributor"
-#   principal_id         = azurerm_linux_virtual_machine.deployer[count.index].identity[0].principal_id
-# }
-
-# resource "azurerm_role_assignment" "app_service_contributor_msi" {
-#   provider             = azurerm.main
-#   count                = var.app_service.use ? 1 : 0
-#   scope                = azurerm_windows_web_app.webapp[0].id
-#   role_definition_name = "Website Contributor"
-#   principal_id         = azurerm_user_assigned_identity.deployer.principal_id
-# }


### PR DESCRIPTION
This pull request simplifies the `app_service.tf` Terraform module by removing the configuration for virtual network integration and some commented-out role assignments related to the web app. The main impact is that the web app will no longer be set up with a virtual network connection, and the unused or commented role assignment resources are cleaned up.

Key removals:

**Networking configuration:**
* Removed the `azurerm_app_service_virtual_network_swift_connection` resource, which previously set up VNet integration for the web app. This is not needed as the App Service is already attached to the subnet

**Role assignments cleanup:**
* Deleted commented-out `azurerm_role_assignment` resources for assigning the "Website Contributor" role to system-assigned and user-assigned identities, reducing clutter in the Terraform configuration.