### PR TITLE
Refine SAPmnt associations and update changelog

### DIFF
--- a/CHANGELOG/v3.21.0.0/CHANGELOG.md
+++ b/CHANGELOG/v3.21.0.0/CHANGELOG.md
@@ -11,8 +11,8 @@
 
 ### 3. Terraform and Infrastructure Changes
 - Terraform version references updated from 1.15.1 to 1.15.5
-- Remove the NFS sapmnt network perimeter association for Windows systems, as it is not required for Windows deployments.
-- Fix the additional IP for HA IPs for Windows deployments
+- Removed the NFS sapmnt network perimeter association for Windows systems, as it is not required for Windows deployments
+- Fixed the additional IP for HA IPs for Windows deployments
 
 
 ## Notes

--- a/CHANGELOG/v3.21.0.0/CHANGELOG.md
+++ b/CHANGELOG/v3.21.0.0/CHANGELOG.md
@@ -11,7 +11,8 @@
 
 ### 3. Terraform and Infrastructure Changes
 - Terraform version references updated from 1.15.1 to 1.15.5
-- Remove the NFS sapmnt network perimete3r association for Windows systems, as it is not required for Windows deployments.
+- Remove the NFS sapmnt network perimeter association for Windows systems, as it is not required for Windows deployments.
+- Fix the additional IP for HA IPs for Windows deployments
 
 
 ## Notes

--- a/CHANGELOG/v3.21.0.0/CHANGELOG.md
+++ b/CHANGELOG/v3.21.0.0/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### 3. Terraform and Infrastructure Changes
 - Terraform version references updated from 1.15.1 to 1.15.5
+- Remove the NFS sapmnt network perimete3r association for Windows systems, as it is not required for Windows deployments.
 
 
 ## Notes

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
@@ -342,7 +342,7 @@ locals {
                                                local.resource_suffixes.scs_clst_feip
                                              )
                                              subnet_id = local.enable_deployment ? (
-                                               var.infrastructure.virtual_networks.sap.subnet_app.exists ? (
+                                               var.infrastructure.virtual_networks.sap.subnet_app.exists || var.infrastructure.virtual_networks.sap.subnet_app.exists_in_workload ? (
                                                  data.azurerm_subnet.subnet_sap_app[0].id) : (
                                                  azurerm_subnet.subnet_sap_app[0].id
                                                )) : (
@@ -364,7 +364,7 @@ locals {
                                                local.resource_suffixes.scs_fs_feip
                                              )
                                              subnet_id = local.enable_deployment ? (
-                                               var.infrastructure.virtual_networks.sap.subnet_app.exists ? (
+                                               var.infrastructure.virtual_networks.sap.subnet_app.exists || var.infrastructure.virtual_networks.sap.subnet_app.exists_in_workload ? (
                                                  data.azurerm_subnet.subnet_sap_app[0].id) : (
                                                  azurerm_subnet.subnet_sap_app[0].id
                                                )) : (

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/network_security_perimeter.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/network_security_perimeter.tf
@@ -16,7 +16,7 @@ data "azurerm_network_security_perimeter_profile" "profile" {
 
 resource "azurerm_network_security_perimeter_association" "sapmnt" {
   provider                               = azurerm.deployer
-  count                                  = try(var.deployer_tfstate.network_security_perimeter_deployment, false) && upper(var.database.platform) != "SQLSERVER" ? 1 : 0
+  count                                  = try(var.deployer_tfstate.network_security_perimeter_deployment, false) && try(var.application_tier.use_AFS_for_sapmnt, false) && local.app_tier_os != "WINDOWS" ? 1 : 0
   name                                   = length(var.azure_files_sapmnt_id) > 0 ? (
                                                      data.azurerm_storage_account.sapmnt[0].name) : (
                                                      try(azurerm_storage_account.sapmnt[0].name, "")

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/network_security_perimeter.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/network_security_perimeter.tf
@@ -16,7 +16,7 @@ data "azurerm_network_security_perimeter_profile" "profile" {
 
 resource "azurerm_network_security_perimeter_association" "sapmnt" {
   provider                               = azurerm.deployer
-  count                                  = try(var.deployer_tfstate.network_security_perimeter_deployment, false) ? 1 : 0
+  count                                  = try(var.deployer_tfstate.network_security_perimeter_deployment, false) && upper(var.database.platform) != "SQLSERVER" ? 1 : 0
   name                                   = length(var.azure_files_sapmnt_id) > 0 ? (
                                                      data.azurerm_storage_account.sapmnt[0].name) : (
                                                      try(azurerm_storage_account.sapmnt[0].name, "")


### PR DESCRIPTION
This pull request makes targeted improvements to the Terraform configuration for SAP system deployments, with a focus on optimizing network security perimeter associations and enhancing subnet selection logic for Windows and high-availability (HA) scenarios. The changes primarily affect how resources are provisioned for Windows systems and improve compatibility with different virtual network setups.

**Terraform and Infrastructure Improvements:**

* Removed the NFS `sapmnt` network perimeter association for Windows systems, as it is not required for Windows deployments. This reduces unnecessary configuration and potential complexity for Windows-based SAP environments. [[1]](diffhunk://#diff-bbc04e6c19db10d78b334773dbb3fa55291d6dfa5f4a12b3c8a91b401e33eddbL19-R19) [[2]](diffhunk://#diff-b9c4a8cce6938d3134d16b3944a37af7868ae675f16f87e5ab4fce426518e653R14-R15)
* Fixed handling of additional IPs for HA IPs in Windows deployments, ensuring correct network configuration for high-availability scenarios.

**Subnet Selection Logic Enhancements:**

* Updated subnet selection logic in `variables_local.tf` to consider both `subnet_app.exists` and `subnet_app.exists_in_workload`. This improves compatibility and flexibility when deploying SAP systems in various network topologies. [[1]](diffhunk://#diff-b699c28af64737e85c13f9287a924deab8a27d94bfe5596f6d2da35d60d26c94L345-R345) [[2]](diffhunk://#diff-b699c28af64737e85c13f9287a924deab8a27d94bfe5596f6d2da35d60d26c94L367-R367)