### PR TITLE
Add Private Link outputs and variables for Azure resource IDs

### DIFF
--- a/deploy/terraform/run/sap_landscape/output.tf
+++ b/deploy/terraform/run/sap_landscape/output.tf
@@ -240,6 +240,16 @@ output "privatelink_file_id"                     {
                                                    value       = module.sap_landscape.privatelink_file_id
                                                  }
 
+output "privatelink_storage_id"                  {
+                                                   description = "Azure resource identifier for the zone for the blob storage resources"
+                                                   value       = module.sap_landscape.privatelink_storage_id
+                                                 }
+
+output "privatelink_keyvault_id"                 {
+                                                   description = "Azure resource identifier for the zone for the keyvault resources"
+                                                   value       = module.sap_landscape.privatelink_keyvault_id
+                                                 }
+
 output "register_virtual_network_to_dns"         {
                                                    description = "Boolean flag to indicate if the SAP virtual network are registered to DNS"
                                                    value       = var.register_virtual_network_to_dns

--- a/deploy/terraform/run/sap_landscape/transform.tf
+++ b/deploy/terraform/run/sap_landscape/transform.tf
@@ -382,6 +382,10 @@ dns_settings                         = {
                                            privatelink_dns_resourcegroup_name           = coalesce(var.privatelink_dns_resourcegroup_name, var.management_dns_resourcegroup_name, local.tfstate_storage_account_resource_group_name)
                                            privatelink_dns_subscription_id              = coalesce(var.privatelink_dns_subscription_id, var.management_dns_subscription_id, local.tfstate_storage_account_subscription_id)
 
+                                           privatelink_file_id                          = var.privatelink_file_id
+                                           privatelink_storage_id                       = var.privatelink_storage_id
+                                           privatelink_keyvault_id                      = var.privatelink_keyvault_id
+
                                            register_storage_accounts_keyvaults_with_dns = var.register_storage_accounts_keyvaults_with_dns
                                            register_endpoints_with_dns                  = var.register_endpoints_with_dns
                                            register_virtual_network_to_dns              = var.register_virtual_network_to_dns

--- a/deploy/terraform/run/sap_system/tfvar_variables.tf
+++ b/deploy/terraform/run/sap_system/tfvar_variables.tf
@@ -1257,6 +1257,36 @@ variable "privatelink_dns_resourcegroup_name"      {
                                                      type        = string
                                                      }
 
+variable "privatelink_file_id"                     {
+                                                     description = "If provided, the Azure resource id of the private DNS zone for file storage (privatelink.file.core.windows.net)"
+                                                     default     = ""
+                                                     type        = string
+                                                     validation    {
+                                                                     condition     = length(var.privatelink_file_id) == 0 ? true : can(provider::azurerm::parse_resource_id(var.privatelink_file_id))
+                                                                     error_message = "If specified the 'privatelink_file_id' variable must be a correct Azure resource identifier."
+                                                                   }
+                                                   }
+
+variable "privatelink_storage_id"                  {
+                                                     description = "If provided, the Azure resource id of the private DNS zone for blob storage (privatelink.blob.core.windows.net)"
+                                                     default     = ""
+                                                     type        = string
+                                                     validation    {
+                                                                     condition     = length(var.privatelink_storage_id) == 0 ? true : can(provider::azurerm::parse_resource_id(var.privatelink_storage_id))
+                                                                     error_message = "If specified the 'privatelink_storage_id' variable must be a correct Azure resource identifier."
+                                                                   }
+                                                   }
+
+variable "privatelink_keyvault_id"                 {
+                                                     description = "If provided, the Azure resource id of the private DNS zone for key vault (privatelink.vaultcore.azure.net)"
+                                                     default     = ""
+                                                     type        = string
+                                                     validation    {
+                                                                     condition     = length(var.privatelink_keyvault_id) == 0 ? true : can(provider::azurerm::parse_resource_id(var.privatelink_keyvault_id))
+                                                                     error_message = "If specified the 'privatelink_keyvault_id' variable must be a correct Azure resource identifier."
+                                                                   }
+                                                   }
+
 
 variable "dns_zone_names"                       {
                                                   description = "Private DNS zone names"

--- a/deploy/terraform/run/sap_system/transform.tf
+++ b/deploy/terraform/run/sap_system/transform.tf
@@ -655,6 +655,19 @@ locals {
                                                                                               ), " "
                                                                                             ))
 
+                                            privatelink_file_id                          = trimspace(coalesce(var.privatelink_file_id,
+                                                                                              try(data.terraform_remote_state.landscape.outputs.privatelink_file_id, ""),
+                                                                                              " "
+                                                                                            ))
+                                            privatelink_storage_id                       = trimspace(coalesce(var.privatelink_storage_id,
+                                                                                              try(data.terraform_remote_state.landscape.outputs.privatelink_storage_id, ""),
+                                                                                              " "
+                                                                                            ))
+                                            privatelink_keyvault_id                      = trimspace(coalesce(var.privatelink_keyvault_id,
+                                                                                              try(data.terraform_remote_state.landscape.outputs.privatelink_keyvault_id, ""),
+                                                                                              " "
+                                                                                            ))
+
                                             register_storage_accounts_keyvaults_with_dns = var.register_storage_accounts_keyvaults_with_dns
                                             register_endpoints_with_dns                  = var.register_endpoints_with_dns
 

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/storage_accounts.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/storage_accounts.tf
@@ -138,10 +138,10 @@ resource "azurerm_private_endpoint" "sapmnt" {
 
 
   dynamic "private_dns_zone_group" {
-                                     for_each = range(length(try(var.landscape_tfstate.privatelink_file_id, "")) > 0 && var.dns_settings.register_endpoints_with_dns ? 1 : 0)
+                                     for_each = range(length(try(var.dns_settings.privatelink_file_id, try(var.landscape_tfstate.privatelink_file_id, ""))) > 0 && var.dns_settings.register_endpoints_with_dns ? 1 : 0)
                                      content {
                                        name                 = var.dns_settings.dns_zone_names.file_dns_zone_name
-                                       private_dns_zone_ids = [var.landscape_tfstate.privatelink_file_id]
+                                       private_dns_zone_ids = [coalesce(try(var.dns_settings.privatelink_file_id, ""), try(var.landscape_tfstate.privatelink_file_id, ""))]
                                      }
                                    }
 

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/storage_accounts.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/storage_accounts.tf
@@ -142,10 +142,10 @@ resource "azurerm_private_endpoint" "hanashared" {
 
 
   dynamic "private_dns_zone_group" {
-                                     for_each = range(length(try(var.landscape_tfstate.privatelink_file_id, "")) > 0 && var.dns_settings.register_endpoints_with_dns ? 1 : 0)
+                                     for_each = range(length(try(var.dns_settings.privatelink_file_id, try(var.landscape_tfstate.privatelink_file_id, ""))) > 0 && var.dns_settings.register_endpoints_with_dns ? 1 : 0)
                                      content {
                                        name                 = var.dns_settings.dns_zone_names.file_dns_zone_name
-                                       private_dns_zone_ids = [var.landscape_tfstate.privatelink_file_id]
+                                       private_dns_zone_ids = [coalesce(try(var.dns_settings.privatelink_file_id, ""), try(var.landscape_tfstate.privatelink_file_id, ""))]
                                      }
                                    }
 


### PR DESCRIPTION
This pull request adds support for specifying Azure Private DNS zone resource IDs for file storage, blob storage, and key vault resources in the SAP landscape and system Terraform modules. The changes allow these resource IDs to be passed as variables, validated, and propagated through the modules for more flexible and robust DNS configuration.

**Support for Private DNS Zone Resource IDs:**

* Added new variables (`privatelink_file_id`, `privatelink_storage_id`, `privatelink_keyvault_id`) to allow users to specify Azure resource IDs for private DNS zones for file storage, blob storage, and key vaults, including validation to ensure correct Azure resource identifier format.
* Updated local variables and data flow to prioritize these new variables, falling back to remote state outputs if not set, ensuring the correct resource IDs are used throughout the configuration.
* Modified output definitions to expose the new DNS zone resource IDs from the landscape module, making them available for downstream consumption.

**Integration with DNS Settings and Private Endpoints:**

* Propagated the new resource IDs through the `dns_settings` map, ensuring they are available wherever DNS configuration is needed.
* Updated private endpoint resources to use the new DNS zone resource IDs, with logic to prefer explicitly set values and fall back to legacy or remote state values, improving flexibility and correctness in DNS zone association. [[1]](diffhunk://#diff-015927fb608f36defbf47b1c89dad1f8ee7f8d943d2154c7efebf9f35b089538L141-R144) [[2]](diffhunk://#diff-664f57b1550a1baa1f3af9c42c73065c9b7340e0271c4e2b0db76fdc31cdee9fL145-R148)