### PR TITLE
Hotfix for Oracle HA deployments

### DIFF
--- a/CHANGELOG/v3.21.0.0/CHANGELOG.md
+++ b/CHANGELOG/v3.21.0.0/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### 4. Miscellaneous fixes
 - Do not create a user profile for the 'grid' user on non-ORACLE-ASM deployments
+- Oracle HA configuration updates for non ASM deployments
 
 
 ## Notes

--- a/Webapp/SDAF/Models/EnvironmentModel.cs
+++ b/Webapp/SDAF/Models/EnvironmentModel.cs
@@ -26,20 +26,25 @@ namespace SDAFWebApp.Models
         public Variable ARM_CLIENT_SECRET { get; set; }
         public Variable ARM_SUBSCRIPTION_ID { get; set; }
         public Variable ARM_TENANT_ID { get; set; }
+
+        public Variable ARM_USE_MSI { get; set; }
+
         public Variable sap_fqdn { get; set; }
         public Variable POOL { get; set; }
 
-        public Variable Use_MSI { get; set; }
-        public Variable Terraform_Remote_Storage_Account_Name { get; set; }
+        public Variable USE_MSI { get; set; }
+        public Variable TERRAFORM_REMOTE_STORAGE_ACCOUNT_NAME { get; set; }
 
-        public Variable Terraform_Remote_Storage_Subscription { get; set; }
+        public Variable TERRAFORM_REMOTE_STORAGE_SUBSCRIPTION { get; set; }
 
-        public Variable Deployer_State_FileName { get; set; }
+        public Variable DEPLOYER_STATE_FILENAME { get; set; }
 
-        public Variable Deployer_Key_Vault { get; set; }
+        public Variable DEPLOYER_KEYVAULT { get; set; }
+        public Variable KEYVAULT { get; set; }
 
         public Variable IsControlPlane { get; set; }
 
+        public Variable CONTROL_PLANE_NAME { get; set; }
 
     }
 

--- a/Webapp/SDAF/SDAFWebApp.csproj
+++ b/Webapp/SDAF/SDAFWebApp.csproj
@@ -20,20 +20,20 @@
     <PackageReference Include="Azure.ResourceManager" Version="1.14.0" />
     <PackageReference Include="Azure.ResourceManager.Compute" Version="1.14.0" />
     <PackageReference Include="Azure.ResourceManager.KeyVault" Version="1.4.0" />
-    <PackageReference Include="Azure.ResourceManager.Network" Version="1.15.0" />
+    <PackageReference Include="Azure.ResourceManager.Network" Version="1.16.0" />
     <PackageReference Include="Azure.ResourceManager.Resources" Version="1.11.2" />
     <PackageReference Include="Azure.ResourceManager.Storage" Version="1.7.0" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.29.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.29.1" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.14.0" />
-    <PackageReference Include="Microsoft.Identity.Web" Version="4.10.0" />
-    <PackageReference Include="Microsoft.Identity.Web.UI" Version="4.10.0" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="4.11.0" />
+    <PackageReference Include="Microsoft.Identity.Web.UI" Version="4.11.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="NuGet.Packaging" Version="7.6.0" />
     <PackageReference Include="Octokit" Version="14.0.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.9.1" />
     <PackageReference Include="System.Linq.Async" Version="7.0.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Runtime.Caching" Version="10.0.8" />
+    <PackageReference Include="System.Runtime.Caching" Version="10.0.9" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 

--- a/Webapp/SDAF/Views/Environment/Create.cshtml
+++ b/Webapp/SDAF/Views/Environment/Create.cshtml
@@ -144,42 +144,42 @@
         </div>
         <div class="ms-TextField">
             <div class="left-input">
-                @Html.LabelFor(m => m.variables.Deployer_Key_Vault, new { @class = $"ms-Label" })
+                @Html.LabelFor(m => m.variables.DEPLOYER_KEYVAULT, new { @class = $"ms-Label" })
                 <p>Enter the name of the Control Plane keyvault.</p>
             </div>
             <div class="right-input">
-                @Html.TextBoxFor(m => m.variables.Deployer_Key_Vault.value, new { @class = "ms-TextField-field" })
-                @Html.ValidationMessageFor(m => m.variables.Deployer_Key_Vault)
+                @Html.TextBoxFor(m => m.variables.DEPLOYER_KEYVAULT.value, new { @class = "ms-TextField-field" })
+                @Html.ValidationMessageFor(m => m.variables.DEPLOYER_KEYVAULT)
             </div>
         </div>
         <div class="ms-TextField">
             <div class="left-input">
-                @Html.LabelFor(m => m.variables.Deployer_State_FileName, new { @class = $"ms-Label" })
-                <p>Enter the name of the state file for the Deployer.</p>
+                @Html.LabelFor(m => m.variables.KEYVAULT, new { @class = $"ms-Label" })
+                <p>Enter the name of the keyvault for the workload zone.</p>
             </div>
             <div class="right-input">
-                @Html.TextBoxFor(m => m.variables.Deployer_State_FileName.value, new { @class = "ms-TextField-field" })
-                @Html.ValidationMessageFor(m => m.variables.Deployer_State_FileName)
+                @Html.TextBoxFor(m => m.variables.KEYVAULT.value, new { @class = "ms-TextField-field" })
+                @Html.ValidationMessageFor(m => m.variables.KEYVAULT)
             </div>
         </div>
         <div class="ms-TextField">
             <div class="left-input">
-                @Html.LabelFor(m => m.variables.Terraform_Remote_Storage_Account_Name, new { @class = $"ms-Label" })
+                @Html.LabelFor(m => m.variables.TERRAFORM_REMOTE_STORAGE_ACCOUNT_NAME, new { @class = $"ms-Label" })
                 <p>Enter the name of the storage account containing the Terraform state files.</p>
             </div>
             <div class="right-input">
-                @Html.TextBoxFor(m => m.variables.Terraform_Remote_Storage_Account_Name.value, new { @class = "ms-TextField-field" })
-                @Html.ValidationMessageFor(m => m.variables.Terraform_Remote_Storage_Account_Name)
+                @Html.TextBoxFor(m => m.variables.TERRAFORM_REMOTE_STORAGE_ACCOUNT_NAME.value, new { @class = "ms-TextField-field" })
+                @Html.ValidationMessageFor(m => m.variables.TERRAFORM_REMOTE_STORAGE_ACCOUNT_NAME)
             </div>
         </div>
         <div class="ms-TextField">
             <div class="left-input">
-                @Html.LabelFor(m => m.variables.Terraform_Remote_Storage_Subscription, new { @class = $"ms-Label" })
+                @Html.LabelFor(m => m.variables.TERRAFORM_REMOTE_STORAGE_SUBSCRIPTION, new { @class = $"ms-Label" })
                 <p>Enter the Id of the subscription containing the storage account containing the Terraform state files.</p>
             </div>
             <div class="right-input">
-                @Html.TextBoxFor(m => m.variables.Terraform_Remote_Storage_Subscription.value, new { @class = "ms-TextField-field" })
-                @Html.ValidationMessageFor(m => m.variables.Terraform_Remote_Storage_Subscription)
+                @Html.TextBoxFor(m => m.variables.TERRAFORM_REMOTE_STORAGE_SUBSCRIPTION.value, new { @class = "ms-TextField-field" })
+                @Html.ValidationMessageFor(m => m.variables.TERRAFORM_REMOTE_STORAGE_SUBSCRIPTION)
             </div>
         </div>
 

--- a/Webapp/SDAF/Views/Environment/Edit.cshtml
+++ b/Webapp/SDAF/Views/Environment/Edit.cshtml
@@ -138,42 +138,42 @@
         </div>
         <div class="ms-TextField">
             <div class="left-input">
-                @Html.LabelFor(m => m.variables.Deployer_Key_Vault, new { @class = $"ms-Label" })
+                @Html.LabelFor(m => m.variables.DEPLOYER_KEYVAULT, new { @class = $"ms-Label" })
                 <p>Enter the name of the Control Plane keyvault.</p>
             </div>
             <div class="right-input">
-                @Html.TextBoxFor(m => m.variables.Deployer_Key_Vault.value, new { @class = "ms-TextField-field" })
-                @Html.ValidationMessageFor(m => m.variables.Deployer_Key_Vault)
+                @Html.TextBoxFor(m => m.variables.DEPLOYER_KEYVAULT.value, new { @class = "ms-TextField-field" })
+                @Html.ValidationMessageFor(m => m.variables.DEPLOYER_KEYVAULT)
             </div>
         </div>
         <div class="ms-TextField">
             <div class="left-input">
-                @Html.LabelFor(m => m.variables.Deployer_State_FileName, new { @class = $"ms-Label" })
-                <p>Enter the name of the state file for the Deployer.</p>
+                @Html.LabelFor(m => m.variables.KEYVAULT, new { @class = $"ms-Label" })
+                <p>Enter the name of the keyvault for the workload zone.</p>
             </div>
             <div class="right-input">
-                @Html.TextBoxFor(m => m.variables.Deployer_State_FileName.value, new { @class = "ms-TextField-field" })
-                @Html.ValidationMessageFor(m => m.variables.Deployer_State_FileName)
+                @Html.TextBoxFor(m => m.variables.KEYVAULT.value, new { @class = "ms-TextField-field" })
+                @Html.ValidationMessageFor(m => m.variables.KEYVAULT)
             </div>
         </div>
         <div class="ms-TextField">
             <div class="left-input">
-                @Html.LabelFor(m => m.variables.Terraform_Remote_Storage_Account_Name, new { @class = $"ms-Label" })
+                @Html.LabelFor(m => m.variables.TERRAFORM_REMOTE_STORAGE_ACCOUNT_NAME, new { @class = $"ms-Label" })
                 <p>Enter the name of the storage account containing the Terraform state files.</p>
             </div>
             <div class="right-input">
-                @Html.TextBoxFor(m => m.variables.Terraform_Remote_Storage_Account_Name.value, new { @class = "ms-TextField-field" })
-                @Html.ValidationMessageFor(m => m.variables.Terraform_Remote_Storage_Account_Name)
+                @Html.TextBoxFor(m => m.variables.TERRAFORM_REMOTE_STORAGE_ACCOUNT_NAME.value, new { @class = "ms-TextField-field" })
+                @Html.ValidationMessageFor(m => m.variables.TERRAFORM_REMOTE_STORAGE_ACCOUNT_NAME)
             </div>
         </div>
         <div class="ms-TextField">
             <div class="left-input">
-                @Html.LabelFor(m => m.variables.Terraform_Remote_Storage_Subscription, new { @class = $"ms-Label" })
+                @Html.LabelFor(m => m.variables.TERRAFORM_REMOTE_STORAGE_SUBSCRIPTION, new { @class = $"ms-Label" })
                 <p>Enter the Id of the subscription containing the storage account containing the Terraform state files.</p>
             </div>
             <div class="right-input">
-                @Html.TextBoxFor(m => m.variables.Terraform_Remote_Storage_Subscription.value, new { @class = "ms-TextField-field" })
-                @Html.ValidationMessageFor(m => m.variables.Terraform_Remote_Storage_Subscription)
+                @Html.TextBoxFor(m => m.variables.TERRAFORM_REMOTE_STORAGE_SUBSCRIPTION.value, new { @class = "ms-TextField-field" })
+                @Html.ValidationMessageFor(m => m.variables.TERRAFORM_REMOTE_STORAGE_SUBSCRIPTION)
             </div>
         </div>
         @Html.HiddenFor(m => m.name)

--- a/deploy/ansible/roles-db/4.1.0-ora-install/tasks/main.yaml
+++ b/deploy/ansible/roles-db/4.1.0-ora-install/tasks/main.yaml
@@ -125,7 +125,6 @@
     block: |
         # User Specific environment
         export ORACLE_HOME=/oracle/{{ db_sid | upper }}/{{ ora_version }}
-        export ORACLE_SID={{ db_sid | upper }}
         export ORACLE_BASE=/oracle
         export LD_LIBRARY_PATH=$ORACLE_HOME/lib
         export TNS_ADMIN=$ORACLE_HOME/network/admin
@@ -144,7 +143,6 @@
     block: |
         # User Specific environment
         setenv  ORACLE_HOME /oracle/{{ db_sid | upper }}/{{ ora_version }}
-        setenv  ORACLE_SID  {{ db_sid | upper }}
         setenv  ORACLE_BASE /oracle
         setenv  LD_LIBRARY_PATH $ORACLE_HOME/lib
         setenv  TNS_ADMIN $ORACLE_HOME/network/admin

--- a/deploy/ansible/roles-db/4.1.0-ora-install/tasks/main.yaml
+++ b/deploy/ansible/roles-db/4.1.0-ora-install/tasks/main.yaml
@@ -108,10 +108,6 @@
     ApplyRU:                           "{{ patch_grid_path }}"
     OracleImage:                       "{{ target_media_location }}/oraserver/LINUX_X86_64/db_home/LINUX.X64_193000_db_home.zip"
 
-- name:                                "4.1.0 Oracle Database Installation - Set SID"
-  ansible.builtin.set_fact:
-    this_sid:                          "{% if ora_primary == ansible_hostname %}{{ db_sid | upper }}{% else %}{{ db_sid | upper }}_STDBY{% endif %}"
-
 - name:                                "4.1.0 Oracle Database Installation - OPatch ID"
   ansible.builtin.debug:
     msg:
@@ -129,11 +125,11 @@
     block: |
         # User Specific environment
         export ORACLE_HOME=/oracle/{{ db_sid | upper }}/{{ ora_version }}
-        export ORACLE_SID={{ this_sid }}
+        export ORACLE_SID={{ db_sid | upper }}
         export ORACLE_BASE=/oracle
         export LD_LIBRARY_PATH=$ORACLE_HOME/lib
         export TNS_ADMIN=$ORACLE_HOME/network/admin
-        export DB_SID={{ this_sid }}
+        export DB_SID={{ db_sid | upper }}
         PATH="$PATH:$ORACLE_HOME/bin"
         export PATH
 
@@ -148,11 +144,11 @@
     block: |
         # User Specific environment
         setenv  ORACLE_HOME /oracle/{{ db_sid | upper }}/{{ ora_version }}
-        setenv  ORACLE_SID  {{ this_sid }}
+        setenv  ORACLE_SID  {{ db_sid | upper }}
         setenv  ORACLE_BASE /oracle
         setenv  LD_LIBRARY_PATH $ORACLE_HOME/lib
         setenv  TNS_ADMIN $ORACLE_HOME/network/admin
-        setenv  DB_SID {{ this_sid }}
+        setenv  DB_SID {{ db_sid | upper }}
         set path = ($path $ORACLE_HOME/bin)
     mode:                              '0755'
 

--- a/deploy/ansible/roles-db/4.1.0-ora-install/tasks/main.yaml
+++ b/deploy/ansible/roles-db/4.1.0-ora-install/tasks/main.yaml
@@ -108,6 +108,10 @@
     ApplyRU:                           "{{ patch_grid_path }}"
     OracleImage:                       "{{ target_media_location }}/oraserver/LINUX_X86_64/db_home/LINUX.X64_193000_db_home.zip"
 
+- name:                                "4.1.0 Oracle Database Installation - Set SID"
+  ansible.builtin.set_fact:
+    this_sid:                          "{% if ora_primary == ansible_hostname %}{{ db_sid | upper }}{% else %}{{ db_sid | upper }}_STDBY{% endif %}"
+
 - name:                                "4.1.0 Oracle Database Installation - OPatch ID"
   ansible.builtin.debug:
     msg:
@@ -125,11 +129,11 @@
     block: |
         # User Specific environment
         export ORACLE_HOME=/oracle/{{ db_sid | upper }}/{{ ora_version }}
-        export ORACLE_SID={{ db_sid | upper }}
+        export ORACLE_SID={{ this_sid }}
         export ORACLE_BASE=/oracle
         export LD_LIBRARY_PATH=$ORACLE_HOME/lib
         export TNS_ADMIN=$ORACLE_HOME/network/admin
-        export DB_SID={{ db_sid | upper }}
+        export DB_SID={{ this_sid }}
         PATH="$PATH:$ORACLE_HOME/bin"
         export PATH
 
@@ -144,11 +148,11 @@
     block: |
         # User Specific environment
         setenv  ORACLE_HOME /oracle/{{ db_sid | upper }}/{{ ora_version }}
-        setenv  ORACLE_SID  {{ db_sid | upper }}
+        setenv  ORACLE_SID  {{ this_sid }}
         setenv  ORACLE_BASE /oracle
         setenv  LD_LIBRARY_PATH $ORACLE_HOME/lib
         setenv  TNS_ADMIN $ORACLE_HOME/network/admin
-        setenv  DB_SID {{ db_sid | upper }}
+        setenv  DB_SID {{ this_sid }}
         set path = ($path $ORACLE_HOME/bin)
     mode:                              '0755'
 

--- a/deploy/ansible/roles-db/4.1.1-ora-asm-grid/tasks/main.yaml
+++ b/deploy/ansible/roles-db/4.1.1-ora-asm-grid/tasks/main.yaml
@@ -248,7 +248,7 @@
 
         - name:                            "4.1.1 ORACLE Grid Setup - Set STAGE_SBP_ACFSRU"
           ansible.builtin.set_fact:
-            STAGE_SBP_ACFSRU:              "{{ acfs_patch_grid_path }}/{{ bom.patch_information.SBP_ACFSRU }}"
+            STAGE_SBP_ACFSRU:              "{{ acfs_patch_grid_path }}"
 
         - name:                            "4.1.1 ORACLE Grid Setup - Show ACFS Release Update"
           ansible.builtin.debug:

--- a/deploy/ansible/roles-db/4.1.1-ora-asm-grid/tasks/main.yaml
+++ b/deploy/ansible/roles-db/4.1.1-ora-asm-grid/tasks/main.yaml
@@ -243,8 +243,12 @@
 
         - name:                            "4.1.1 ORACLE Grid Setup - Save ACFS Release Update"
           ansible.builtin.set_fact:
-            acfs_patch_grid_path:          "{{ acfs_patch_grid_id_directory.files[0].path | dirname }}"
+            acfs_patch_grid_path:          "{{ acfs_patch_grid_id_directory.files[0].path }}"
           when:                            acfs_patch_grid_id_directory.matched <= 2
+
+        - name:                            "4.1.1 ORACLE Grid Setup - Set STAGE_SBP_ACFSRU"
+          ansible.builtin.set_fact:
+            STAGE_SBP_ACFSRU:              "{{ acfs_patch_grid_path }}/{{ bom.patch_information.SBP_ACFSRU }}"
 
         - name:                            "4.1.1 ORACLE Grid Setup - Show ACFS Release Update"
           ansible.builtin.debug:
@@ -253,7 +257,9 @@
     - name:                            "4.1.1 ORACLE Grid Setup - Set STAGE_SBP_ACFSRU"
       ansible.builtin.set_fact:
         STAGE_SBP_ACFSRU:              "{{ patch_grid_path }}/{{ bom.patch_information.SBP_ACFSRU }}"
-      when:                            patch_grid_path is defined and bom.patch_information.SBP_ACFSRU is defined
+      when:
+        - STAGE_SBP_ACFSRU is not defined
+        - patch_grid_path is defined and bom.patch_information.SBP_ACFSRU is defined
 
     - name:                            "4.1.1 ORACLE Grid Setup - Set OneOffs"
       ansible.builtin.set_fact:

--- a/deploy/ansible/roles-db/4.1.1-ora-asm-grid/tasks/main.yaml
+++ b/deploy/ansible/roles-db/4.1.1-ora-asm-grid/tasks/main.yaml
@@ -225,6 +225,26 @@
         STAGE_SBP_OCWRU:               "{{ patch_grid_path }}/{{ bom.patch_information.SBP_OCWRU }}"
       when:                            patch_grid_path is defined and bom.patch_information.SBP_OCWRU is defined
 
+    - name:                            "4.1.1 ORACLE Grid Setup - Find Patch ID for Database ACFS Release Update"
+      become:                          true
+      become_user:                     root
+      ansible.builtin.find:
+        paths:                         "{{ target_media_location }}/SBP/"
+        patterns:                      ["{{ STAGE_SBP_ACFSRU }}"]
+        file_type:                     directory
+        recurse:                       true
+      register:                        acfs_patch_grid_id_directory
+
+
+    - name:                            "4.1.1 ORACLE Grid Setup - Save ACFS Release Update"
+      ansible.builtin.set_fact:
+        acfs_patch_grid_path:          "{{ acfs_patch_grid_id_directory.files[0].path | dirname }}"
+      when:                            acfs_patch_grid_id_directory.matched <= 2
+
+    - name:                            "4.1.1 ORACLE Grid Setup - Show ACFS Release Update"
+      ansible.builtin.debug:
+        msg:                           "Patch ACFS path {{ acfs_patch_grid_path }}"
+
     - name:                            "4.1.1 ORACLE Grid Setup - Set STAGE_SBP_ACFSRU"
       ansible.builtin.set_fact:
         STAGE_SBP_ACFSRU:              "{{ patch_grid_path }}/{{ bom.patch_information.SBP_ACFSRU }}"

--- a/deploy/ansible/roles-db/4.1.1-ora-asm-grid/tasks/main.yaml
+++ b/deploy/ansible/roles-db/4.1.1-ora-asm-grid/tasks/main.yaml
@@ -226,24 +226,29 @@
       when:                            patch_grid_path is defined and bom.patch_information.SBP_OCWRU is defined
 
     - name:                            "4.1.1 ORACLE Grid Setup - Find Patch ID for Database ACFS Release Update"
-      become:                          true
-      become_user:                     root
-      ansible.builtin.find:
-        paths:                         "{{ target_media_location }}/SBP/"
-        patterns:                      ["{{ STAGE_SBP_ACFSRU }}"]
-        file_type:                     directory
-        recurse:                       true
-      register:                        acfs_patch_grid_id_directory
+      when:                            patch_grid_path is defined and bom.patch_information.SBP_ACFSRU is defined
+      block:
+
+        - name:                            "4.1.1 ORACLE Grid Setup - Find Patch ID for Database ACFS Release Update"
+          when:                            patch_grid_path is defined and bom.patch_information.SBP_ACFSRU is defined
+          become:                          true
+          become_user:                     root
+          ansible.builtin.find:
+            paths:                         "{{ target_media_location }}/SBP/"
+            patterns:                      ["{{ bom.patch_information.SBP_ACFSRU }}"]
+            file_type:                     directory
+            recurse:                       true
+          register:                        acfs_patch_grid_id_directory
 
 
-    - name:                            "4.1.1 ORACLE Grid Setup - Save ACFS Release Update"
-      ansible.builtin.set_fact:
-        acfs_patch_grid_path:          "{{ acfs_patch_grid_id_directory.files[0].path | dirname }}"
-      when:                            acfs_patch_grid_id_directory.matched <= 2
+        - name:                            "4.1.1 ORACLE Grid Setup - Save ACFS Release Update"
+          ansible.builtin.set_fact:
+            acfs_patch_grid_path:          "{{ acfs_patch_grid_id_directory.files[0].path | dirname }}"
+          when:                            acfs_patch_grid_id_directory.matched <= 2
 
-    - name:                            "4.1.1 ORACLE Grid Setup - Show ACFS Release Update"
-      ansible.builtin.debug:
-        msg:                           "Patch ACFS path {{ acfs_patch_grid_path }}"
+        - name:                            "4.1.1 ORACLE Grid Setup - Show ACFS Release Update"
+          ansible.builtin.debug:
+            msg:                           "Patch ACFS path {{ acfs_patch_grid_path }}"
 
     - name:                            "4.1.1 ORACLE Grid Setup - Set STAGE_SBP_ACFSRU"
       ansible.builtin.set_fact:

--- a/deploy/ansible/roles-db/4.1.1-ora-asm-grid/tasks/update.yaml
+++ b/deploy/ansible/roles-db/4.1.1-ora-asm-grid/tasks/update.yaml
@@ -137,6 +137,15 @@
     owner:                             "{{ grid_user_name }}"
     group:                             oinstall
 
+- name:                                "4.1.1 ORACLE Grid Update - copy MOPatch from {{ mopatch_path }} to /oracle/{{ db_sid | upper }}/{{ ora_version }}"
+  ansible.builtin.copy:
+    src:                               "{{ mopatch_path }}"
+    dest:                              "/oracle/{{ db_sid | upper }}/{{ ora_version }}"
+    remote_src:                        true
+    mode:                              '0777'
+    owner:                             "{{ oracle_user_name }}"
+    group:                             oinstall
+
 - name:                                "4.1.1 ORACLE Grid Update - Check if backup exists for GRID"
   ansible.builtin.stat:
     path:                              "/oracle/GRID/{{ ora_version }}/bin/oradism"

--- a/deploy/ansible/roles-db/4.1.2-ora-asm-db-install/tasks/cleanup.yaml
+++ b/deploy/ansible/roles-db/4.1.2-ora-asm-db-install/tasks/cleanup.yaml
@@ -26,15 +26,12 @@
                                     for seg in $(ipcs -m | grep oracle | awk '$6==0 {print $2}'); do ipcrm -m $seg; done || true
   failed_when:                         false
 
-- name:                                "4.1.2 Oracle ASM database software Installation - Pre-Create Cleanup: Force remount ASM diskgroups to clear stale clients"
+- name:                                "4.1.2 Oracle ASM database software Installation - Pre-Create Cleanup: Set ASM diskgroup attribute compatible.rdbms to 19.0.0.0.0"
   become:                              true
   become_user:                         "{{ grid_user_name }}"
   ansible.builtin.shell: |
                                     sqlplus -S / as sysasm <<EOF
-                                    ALTER DISKGROUP DATA DISMOUNT FORCE;
-                                    ALTER DISKGROUP DATA MOUNT;
-                                    ALTER DISKGROUP RECO DISMOUNT FORCE;
-                                    ALTER DISKGROUP RECO MOUNT;
+                                    ALTER DISKGROUP DATA SET ATTRIBUTE 'compatible.rdbms' = '19.0.0.0.0';
                                     EXIT;
                                     EOF
   register:                            asm_remount_results
@@ -42,7 +39,7 @@
   failed_when:                         false
   environment:                         "{{ grid_env }}"
 
-- name:                                "4.1.2 Oracle ASM database software Installation - Pre-Create Cleanup: Dismount ASM diskgroups to evict stale client registrations"
+- name:                                "4.1.2 Oracle ASM database software Installation - Pre-Create Cleanup: Dismount ASM disk groups to evict stale client registrations"
   become:                              true
   become_user:                         "{{ grid_user_name }}"
   ansible.builtin.shell: |

--- a/deploy/ansible/roles-db/4.1.2-ora-asm-db-install/tasks/main.yaml
+++ b/deploy/ansible/roles-db/4.1.2-ora-asm-db-install/tasks/main.yaml
@@ -124,7 +124,6 @@
     block: |
         # User Specific environment
         export ORACLE_HOME=/oracle/{{ db_sid | upper }}/{{ ora_version }}
-        export ORACLE_SID={{ db_sid | upper }}
         export ORACLE_BASE=/oracle
         export LD_LIBRARY_PATH=$ORACLE_HOME/lib
         export TNS_ADMIN=$ORACLE_HOME/network/admin
@@ -143,7 +142,6 @@
     block: |
         # User Specific environment
         setenv  ORACLE_HOME /oracle/{{ db_sid | upper }}/{{ ora_version }}
-        setenv  ORACLE_SID  {{ db_sid | upper }}
         setenv  ORACLE_BASE /oracle
         setenv  LD_LIBRARY_PATH $ORACLE_HOME/lib
         setenv  TNS_ADMIN $ORACLE_HOME/network/admin

--- a/deploy/ansible/roles-db/4.1.2-ora-asm-db-install/tasks/main.yaml
+++ b/deploy/ansible/roles-db/4.1.2-ora-asm-db-install/tasks/main.yaml
@@ -107,11 +107,6 @@
     ApplyRU:                           "{{ patch_grid_path }}"
     OracleImage:                       "{{ target_media_location }}/oraserver/LINUX_X86_64/db_home/LINUX.X64_193000_db_home.zip"
 
-- name:                                "4.1.2 Oracle ASM database software Installation - Set SID"
-  ansible.builtin.set_fact:
-    this_sid:                          "{% if ora_primary == ansible_hostname %}{{ db_sid | upper }}{% else %}{{ db_sid | upper }}_STDBY{% endif %}"
-
-
 - name:                                "4.1.2 Oracle ASM database software Installation - OPatch ID"
   ansible.builtin.debug:
     msg:
@@ -129,11 +124,11 @@
     block: |
         # User Specific environment
         export ORACLE_HOME=/oracle/{{ db_sid | upper }}/{{ ora_version }}
-        export ORACLE_SID={{ this_sid }}
+        export ORACLE_SID={{ db_sid | upper }}
         export ORACLE_BASE=/oracle
         export LD_LIBRARY_PATH=$ORACLE_HOME/lib
         export TNS_ADMIN=$ORACLE_HOME/network/admin
-        export DB_SID={{ this_sid }}
+        export DB_SID={{ db_sid | upper }}
         PATH="$PATH:$ORACLE_HOME/bin"
         export PATH
 
@@ -148,11 +143,11 @@
     block: |
         # User Specific environment
         setenv  ORACLE_HOME /oracle/{{ db_sid | upper }}/{{ ora_version }}
-        setenv  ORACLE_SID  {{ this_sid }}
+        setenv  ORACLE_SID  {{ db_sid | upper }}
         setenv  ORACLE_BASE /oracle
         setenv  LD_LIBRARY_PATH $ORACLE_HOME/lib
         setenv  TNS_ADMIN $ORACLE_HOME/network/admin
-        setenv  DB_SID {{ this_sid }}
+        setenv  DB_SID {{ db_sid | upper }}
         set path = ($path $ORACLE_HOME/bin)
     mode:                              '0755'
 

--- a/deploy/ansible/roles-db/4.1.2-ora-asm-db-install/tasks/main.yaml
+++ b/deploy/ansible/roles-db/4.1.2-ora-asm-db-install/tasks/main.yaml
@@ -107,6 +107,11 @@
     ApplyRU:                           "{{ patch_grid_path }}"
     OracleImage:                       "{{ target_media_location }}/oraserver/LINUX_X86_64/db_home/LINUX.X64_193000_db_home.zip"
 
+- name:                                "4.1.2 Oracle ASM database software Installation - Set SID"
+  ansible.builtin.set_fact:
+    this_sid:                          "{% if ora_primary == ansible_hostname %}{{ db_sid | upper }}{% else %}{{ db_sid | upper }}_STDBY{% endif %}"
+
+
 - name:                                "4.1.2 Oracle ASM database software Installation - OPatch ID"
   ansible.builtin.debug:
     msg:
@@ -124,11 +129,11 @@
     block: |
         # User Specific environment
         export ORACLE_HOME=/oracle/{{ db_sid | upper }}/{{ ora_version }}
-        export ORACLE_SID={{ db_sid | upper }}
+        export ORACLE_SID={{ this_sid }}
         export ORACLE_BASE=/oracle
         export LD_LIBRARY_PATH=$ORACLE_HOME/lib
         export TNS_ADMIN=$ORACLE_HOME/network/admin
-        export DB_SID={{ db_sid | upper }}
+        export DB_SID={{ this_sid }}
         PATH="$PATH:$ORACLE_HOME/bin"
         export PATH
 
@@ -143,11 +148,11 @@
     block: |
         # User Specific environment
         setenv  ORACLE_HOME /oracle/{{ db_sid | upper }}/{{ ora_version }}
-        setenv  ORACLE_SID  {{ db_sid | upper }}
+        setenv  ORACLE_SID  {{ this_sid }}
         setenv  ORACLE_BASE /oracle
         setenv  LD_LIBRARY_PATH $ORACLE_HOME/lib
         setenv  TNS_ADMIN $ORACLE_HOME/network/admin
-        setenv  DB_SID {{ db_sid | upper }}
+        setenv  DB_SID {{ this_sid }}
         set path = ($path $ORACLE_HOME/bin)
     mode:                              '0755'
 

--- a/deploy/ansible/roles-db/4.1.2-ora-asm-db-install/tasks/main.yaml
+++ b/deploy/ansible/roles-db/4.1.2-ora-asm-db-install/tasks/main.yaml
@@ -231,7 +231,7 @@
 # | Before running Installer set DB_SID and CV_ASSUME_DISTID according to      |
 # | SAP Note 2660017 Oracle Software Installation on Unix                      |
 # |                                                                            |
-# | Step 2 run the installation check                                          |
+# | Step 2 run the installation                                                |
 # +------------------------------------4--------------------------------------*/
     - name:                            "4.1.2 Oracle ASM database software Installation - Execute RUNINSTALLER command"
       ansible.builtin.debug:

--- a/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/00-restart-instance.yaml
+++ b/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/00-restart-instance.yaml
@@ -111,7 +111,7 @@
       become:                          true
       become_user:                     root
       ansible.builtin.file:
-        path:                          "/oracle/{{ db_sid | upper }}/{{ ora_version }}/dbs/ls{{ current_sid }}"
+        path:                          "/oracle/{{ db_sid | upper }}/{{ ora_version }}/dbs/lk{{ current_sid }}"
         state:                         absent
       failed_when:                     false
 

--- a/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/00-restart-instance.yaml
+++ b/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/00-restart-instance.yaml
@@ -41,7 +41,35 @@
   failed_when:                         false
   when:                                standby_pmon.stdout | length > 0
 
+- name:                                "4.1.3 Oracle Data Guard - Shutdown instance - Remove lock file"
+  become:                              true
+  become_user:                         root
+  ansible.builtin.file:
+    path:                              "/oracle/{{ db_sid | upper }}/{{ ora_version }}/dbs/lk{{ current_sid }}"
+    state:                             absent
+  failed_when:                         false
+
 - name:                                "4.1.3 Oracle Data Guard - Shutdown instance - Start instance with NOMOUNT"
+  when:                                not use_pfile_on_startup
+  block:
+    - name:                            "4.1.3 Oracle Data Guard - Start Instance - Start instance"
+      become_user:                     "{{ oracle_user_name }}"
+      become:                          true
+      ansible.builtin.shell: |
+                                       export ORACLE_SID={{ current_sid }}
+                                       sqlplus -s / as sysdba <<EOF
+                                       STARTUP;
+                                       EXIT;
+                                       EOF
+      register:                        startup_result
+      failed_when:                     startup_result.rc != 0
+      environment:                     "{{ oracle_env }}"
+      args:
+        chdir:                         "/etc/sap_deployment_automation/dataguard_scripts/"
+        creates:                       /etc/sap_deployment_automation/dataguard_scripts/standby_started.txt
+
+- name:                                "4.1.3 Oracle Data Guard - Shutdown instance - Start instance with NOMOUNT"
+  when:                                use_pfile_on_startup
   block:
     - name:                            "4.1.3 Oracle Data Guard - Start Instance - Start instance with NOMOUNT using PFile"
       become_user:                     "{{ oracle_user_name }}"
@@ -114,7 +142,6 @@
         path:                          "/oracle/{{ db_sid | upper }}/{{ ora_version }}/dbs/lk{{ current_sid }}"
         state:                         absent
       failed_when:                     false
-
 
     - name:                            "4.1.3 Oracle Data Guard - Start Instance - Start instance with NOMOUNT using PFile"
       when:                            use_pfile_on_startup

--- a/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/00-restart-instance.yaml
+++ b/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/00-restart-instance.yaml
@@ -180,13 +180,17 @@
   become_user:                         "{{ oracle_user_name }}"
   become:                              true
   ansible.builtin.shell: |
-                                       export ORACLE_SID={{ current_sid }}
+
                                        sqlplus -S / as sysdba <<EOF
+                                       ALTER SYSTEM SET local_listener='(ADDRESS=(PROTOCOL=TCP)(HOST={{ ansible_hostname }})(PORT={{ listener_port }}))' SCOPE=MEMORY;
                                        ALTER SYSTEM REGISTER;
                                        EXIT;
                                        EOF
   register:                            startup_result
-  environment:                         "{{ oracle_env }}"
+  environment:
+    ORACLE_HOME:                       "/oracle/{{ db_sid | upper }}/{{ ora_version }}"
+    ORACLE_SID:                        "{{ current_sid }}"
+    PATH:                              "/oracle/{{ db_sid | upper }}/{{ ora_version }}/bin:{{ ansible_env.PATH }}"
   args:
     chdir:                            "/etc/sap_deployment_automation/dataguard_scripts/"
 

--- a/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/00-restart-instance.yaml
+++ b/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/00-restart-instance.yaml
@@ -190,7 +190,7 @@
   args:
     chdir:                            "/etc/sap_deployment_automation/dataguard_scripts/"
 
-- name:                                "4.1.3 Oracle Data Guard - Start Instance - Verify standby instance running"
+- name:                                "4.1.3 Oracle Data Guard - Start Instance - Verify instance is running"
   become_user:                         "{{ oracle_user_name }}"
   become:                              true
   ansible.builtin.shell: |
@@ -204,9 +204,9 @@
   become_user:                         "{% if node_tier == 'oracle-asm' %}{{ grid_user_name }}{% else %}{{ oracle_user_name }}{% endif %}"
   become:                              true
   ansible.builtin.shell: |
-                                       export ORACLE_SID={{ current_sid }}
+                                       export ORACLE_SID={{ '+ASM' if node_tier == 'oracle-asm' else current_sid }}
                                        /oracle/{{ db_path }}/{{ ora_version }}/bin/lsnrctl reload
-  environment:                         "{{ grid_env }}"
+  environment:                         "{% if node_tier == 'oracle-asm' %}{{ grid_env }}{% else %}{{ oracle_env }}{% endif %}"
   register:                            listener_reload_results
   failed_when:
                                       - listener_reload_results.rc not in [0, 1]
@@ -215,9 +215,9 @@
   become_user:                         "{% if node_tier == 'oracle-asm' %}{{ grid_user_name }}{% else %}{{ oracle_user_name }}{% endif %}"
   become:                              true
   ansible.builtin.shell: |
-                                       export ORACLE_SID={{ current_sid }}
+                                       export ORACLE_SID={{ '+ASM' if node_tier == 'oracle-asm' else current_sid }}
                                        /oracle/{{ db_path }}/{{ ora_version }}/bin/lsnrctl start
-  environment:                         "{{ grid_env }}"
+  environment:                         "{% if node_tier == 'oracle-asm' %}{{ grid_env }}{% else %}{{ oracle_env }}{% endif %}"
   args:
     chdir:                             "/oracle/{{ db_path }}/{{ ora_version }}/bin"
   register:                            listener_start_results
@@ -233,9 +233,9 @@
   become_user:                         "{% if node_tier == 'oracle-asm' %}{{ grid_user_name }}{% else %}{{ oracle_user_name }}{% endif %}"
   become:                              true
   ansible.builtin.shell: |
-                                       export ORACLE_SID={{ current_sid }}
+                                       export ORACLE_SID={{ '+ASM' if node_tier == 'oracle-asm' else current_sid }}
                                        /oracle/{{ db_path }}/{{ ora_version }}/bin/lsnrctl status
-  environment:                         "{{ grid_env }}"
+  environment:                         "{% if node_tier == 'oracle-asm' %}{{ grid_env }}{% else %}{{ oracle_env }}{% endif %}"
   args:
     chdir:                             "/oracle/{{ db_path }}/{{ ora_version }}/bin"
   register:                            listener_status

--- a/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/00-restart-instance.yaml
+++ b/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/00-restart-instance.yaml
@@ -160,7 +160,7 @@
         chdir:                         "/etc/sap_deployment_automation/dataguard_scripts/"
         creates:                       /etc/sap_deployment_automation/dataguard_scripts/standby_started.txt
 
-    - name:                            "4.1.3 Oracle Data Guard - Start Instance - Start instance with NOMOUNT using PFile"
+    - name:                            "4.1.3 Oracle Data Guard - Start Instance - Start instance with NOMOUNT"
       when:                            not use_pfile_on_startup
       become_user:                     "{{ oracle_user_name }}"
       become:                          true

--- a/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/00-validate-primary.yaml
+++ b/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/00-validate-primary.yaml
@@ -1,6 +1,8 @@
 ---
 
-
+- name:                                "4.1.3 Oracle Data Guard - Preparation - Set DB Path "
+  ansible.builtin.set_fact:
+    db_path:                           "{% if node_tier == 'oracle-asm' %}GRID{% else %}{{ db_sid | upper }}{% endif %}"
 
 - name:                                "4.1.3 Oracle Data Guard - Check ASM status"
   become_user:                         "{{ grid_user_name }}"

--- a/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/00-validate-primary.yaml
+++ b/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/00-validate-primary.yaml
@@ -69,8 +69,6 @@
 
 - name:                                "4.1.3 Oracle Data Guard - Restart Primary instance"
   when:
-    - not primary_mounted
-    - not primary_open
     - needs_mounting or primary_exclusive
   block:
     - name:                            "4.1.3 Oracle Data Guard: - Restart Primary instance"

--- a/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/00-validate-primary.yaml
+++ b/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/00-validate-primary.yaml
@@ -64,14 +64,14 @@
       - "Database instance:               {{ ansible_hostname }}"
       - "Primary mounted status:          {{ primary_mounted or primary_open }}"
       - "Primary open status:             {{ primary_open }}"
-      - "Primary instance open_mode:      {{ dg_status.stdout }}"
       - "Primary instance needs mounting: {{ needs_mounting }}"
+      - "Primary instance open_mode:      {{ dg_status.stdout }}"
 
 - name:                                "4.1.3 Oracle Data Guard - Restart Primary instance"
   when:
     - not primary_mounted
     - not primary_open
-    - not needs_mounting or primary_exclusive
+    - needs_mounting or primary_exclusive
   block:
     - name:                            "4.1.3 Oracle Data Guard: - Restart Primary instance"
       ansible.builtin.include_tasks:   "00-restart-instance.yaml"

--- a/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/00-validate-primary.yaml
+++ b/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/00-validate-primary.yaml
@@ -101,10 +101,6 @@
   args:
     chdir:                             "/etc/sap_deployment_automation/dataguard_scripts/"
 
-- name:                                "4.1.3 Oracle Data Guard - Set status on Primary"
-  ansible.builtin.set_fact:
-    primary_exclusive:                 "{{ (db_mounted.stdout is search('ORA-01102')) | bool }}"
-
 - name:                                "4.1.3 Oracle Data Guard - Verify Status on Primary"
   become_user:                         "{{ oracle_user_name }}"
   become:                              true

--- a/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/00-validate-primary.yaml
+++ b/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/00-validate-primary.yaml
@@ -1,12 +1,6 @@
 ---
 
-- name:                                "4.1.3 Oracle Data Guard - Setup Primary: - Test network connectivity to peer"
-  ansible.builtin.wait_for:
-    host:                              "{{ hostvars[item]['ansible_host'] }}"
-    port:                              "{{ listener_port }}"
-    timeout:                           10
-  loop:                                 "{{ ansible_play_hosts_all }}"
-  when:                                item != inventory_hostname
+
 
 - name:                                "4.1.3 Oracle Data Guard - Check ASM status"
   become_user:                         "{{ grid_user_name }}"
@@ -61,24 +55,74 @@
   ansible.builtin.set_fact:
     primary_open:                      "{{ (dg_status.stdout is search('PRIMARY:READ WRITE')) | bool }}"
     primary_mounted:                   "{{ (dg_status.stdout is search('PRIMARY:MOUNTED')) | bool }}"
+    needs_mounting:                    "{{ (dg_status.stdout is search('RA-01507')) | bool }}"
 
 - name:                                "4.1.3 Oracle Data Guard - Show status on Primary"
   ansible.builtin.debug:
     msg:
       - "Database instance:            {{ ansible_hostname }}"
-      - "Primary instance open:        {{ primary_open }}"
-      - "Primary instance mounted:     {{ primary_mounted }}"
+      - "Primary mounted status:       {{ primary_mounted or primary_open }}"
+      - "Primary open status:          {{ primary_open }}"
+      - "Primary instance open_mode:   {{ dg_status.stdout }}"
+      - "Primary instance needs mounting: {{ needs_mounting }}"
+
+- name:                                "4.1.3 Oracle Data Guard - Mount Primary instance"
+  when:
+    - not primary_mounted
+    - needs_mounting
+  become_user:                         "{{ oracle_user_name }}"
+  become:                              true
+  ansible.builtin.shell: |
+                                       sqlplus -S / as sysdba <<EOF
+                                       WHENEVER SQLERROR EXIT SQL.SQLCODE
+                                       ALTER DATABASE MOUNT;
+                                       ALTER DATABASE OPEN;
+                                       EXIT;
+                                       EOF
+
+  register:                            db_mounted
+  changed_when:                        false
+  failed_when:                         false
+  environment:                         "{{ oracle_env }}"
+  args:
+    chdir:                             "/etc/sap_deployment_automation/dataguard_scripts/"
+
+- name:                                "4.1.3 Oracle Data Guard - Verify Status on Primary"
+  become_user:                         "{{ oracle_user_name }}"
+  become:                              true
+  ansible.builtin.shell: |
+                                       sqlplus -S / as sysdba <<EOF
+                                       SET PAGESIZE 0 FEEDBACK OFF HEADING OFF;
+                                       SELECT database_role || ':' || open_mode FROM v\$database;
+                                       EXIT;
+                                       EOF
+
+  register:                            dg_status
+  changed_when:                        false
+  failed_when:                         false
+  args:
+    chdir:                             "/etc/sap_deployment_automation/dataguard_scripts/"
+  environment:                         "{{ oracle_env }}"
+
+- name:                                "4.1.3 Oracle Data Guard - Set status on Primary"
+  ansible.builtin.set_fact:
+    primary_open:                      "{{ (dg_status.stdout is search('PRIMARY:READ WRITE')) | bool }}"
+    primary_mounted:                   "{{ (dg_status.stdout is search('PRIMARY:MOUNTED')) | bool }}"
+    needs_mounting:                    "{{ (dg_status.stdout is search('RA-01507')) | bool }}"
+
 
 - name:                                "4.1.3 Oracle Data Guard - Restart Primary instance"
   when:
     - not primary_mounted
+    - not primary_open
+    - not needs_mounting
   block:
     - name:                            "4.1.3 Oracle Data Guard - Restart Primary instance"
       become_user:                     "{{ oracle_user_name }}"
       become:                          true
       ansible.builtin.shell: |
                                        sqlplus -S / as sysdba <<EOF
-                                       SHUTDOWN;
+                                       SHUTDOWN IMMEDIATE;
                                        EXIT;
                                        EOF
 
@@ -121,43 +165,22 @@
       become:                          true
       become_user:                     root
       ansible.builtin.file:
-        path:                          "/oracle/{{ db_sid | upper }}/{{ ora_version }}/dbs/ls{{ db_sid | upper }}"
+        path:                          "/oracle/{{ db_sid | upper }}/{{ ora_version }}/dbs/lk{{ db_sid | upper }}"
         state:                         absent
       failed_when:                     false
 
-    - name:                            "4.1.3 Oracle Data Guard - Restart Primary instance"
+    - name:                            "4.1.3 Oracle Data Guard - Start Primary instance"
       become_user:                     "{{ oracle_user_name }}"
       become:                          true
       ansible.builtin.shell: |
-                                       sqlplus -S / as sysdba <<EOF
-                                       STARTUP NOMOUNT;
+                                       sqlplus -S / as sysdba <<'EOF'
+                                       WHENEVER SQLERROR EXIT SQL.SQLCODE
+                                       STARTUP;
                                        EXIT;
                                        EOF
-
-      register:                        db_started
-      changed_when:                    false
-      failed_when:                     false
       environment:                     "{{ oracle_env }}"
       args:
-        chdir:                         "/etc/sap_deployment_automation/dataguard_scripts/"
-
-    - name:                            "4.1.3 Oracle Data Guard - Mount Primary instance"
-      become_user:                     "{{ oracle_user_name }}"
-      become:                          true
-      ansible.builtin.shell: |
-                                       sqlplus -S / as sysdba <<EOF
-                                       ALTER DATABASE MOUNT;
-                                       ALTER DATABASE OPEN;
-                                       EXIT;
-                                       EOF
-
-      register:                        db_mounted
-      changed_when:                    false
-      failed_when:                     false
-      environment:                     "{{ oracle_env }}"
-      args:
-        chdir:                         "/etc/sap_deployment_automation/dataguard_scripts/"
-
+        chdir: "/etc/sap_deployment_automation/dataguard_scripts/"
 
 - name:                                "4.1.3 Oracle Data Guard - Verify Status on Primary"
   become_user:                         "{{ oracle_user_name }}"
@@ -176,11 +199,18 @@
     chdir:                             "/etc/sap_deployment_automation/dataguard_scripts/"
   environment:                         "{{ oracle_env }}"
 
-- name:                                "4.1.3 Oracle Data Guard - Set status on Primary"
+- name:                                "4.1.3 Oracle Data Guard - Get status from Primary"
   ansible.builtin.set_fact:
     primary_open:                      "{{ (dg_status.stdout is search('PRIMARY:READ WRITE')) | bool }}"
     primary_mounted:                   "{{ (dg_status.stdout is search('PRIMARY:MOUNTED')) | bool }}"
+    needs_mounting:                    "{{ (dg_status.stdout is search('RA-01507')) | bool }}"
 
+- name:                                "4.1.3 Oracle Data Guard - Show status on Primary"
+  ansible.builtin.debug:
+    msg:
+     - "Primary mounted status:       {{ primary_mounted or primary_open }}"
+     - "Primary open status:          {{ primary_open }}"
+     - "Primary instance open_mode:   {{ dg_status.stdout }}"
 
 - name:                                "4.1.3 Oracle Data Guard - Open Primary"
   when:
@@ -190,6 +220,7 @@
   become:                              true
   ansible.builtin.shell: |
                                        sqlplus -S / as sysdba <<EOF
+                                       WHENEVER SQLERROR EXIT SQL.SQLCODE
                                        ALTER DATABASE OPEN;
                                        EXIT;
                                        EOF
@@ -201,7 +232,6 @@
   args:
     chdir:                             "/etc/sap_deployment_automation/dataguard_scripts/"
 
-
 - name:                                "4.1.3 Oracle Data Guard - Verify Data Guard configuration on Primary"
   when:                                not primary_open
   become_user:                         "{{ oracle_user_name }}"
@@ -210,6 +240,7 @@
 
                                        printenv
                                        sqlplus -S / as sysdba <<EOF
+                                       WHENEVER SQLERROR EXIT SQL.SQLCODE
                                        SET PAGESIZE 0 FEEDBACK OFF HEADING OFF;
                                        SELECT database_role || ':' || open_mode FROM v\$database;
                                        EXIT;
@@ -222,32 +253,17 @@
   args:
     chdir:                             "/etc/sap_deployment_automation/dataguard_scripts/"
 
-- name:                                "4.1.3 Oracle Data Guard - Set Data Guard configuration status on Primary"
-  when:                                not primary_open
+- name:                                "4.1.3 Oracle Data Guard - Get status from Primary"
   ansible.builtin.set_fact:
-    primary_open:                      "{{ ((dg_status.stdout | default('UNKNOWN')) is search('PRIMARY:READ WRITE')) | bool }}"
+    primary_open:                      "{{ (dg_status.stdout is search('PRIMARY:READ WRITE')) | bool }}"
+    primary_mounted:                   "{{ (dg_status.stdout is search('PRIMARY:MOUNTED')) | bool }}"
+    needs_mounting:                    "{{ (dg_status.stdout is search('RA-01507')) | bool }}"
 
-- name:                                "4.1.3 Oracle Data Guard - Mount Primary instance"
-  when:
-    - not primary_open
-  become_user:                         "{{ oracle_user_name }}"
-  become:                              true
-  ansible.builtin.shell: |
-                                        sqlplus -S / as sysdba <<EOF
-                                        ALTER DATABASE OPEN;
-                                        EXIT;
-                                        EOF
-
-  register:                            db_opened
-  changed_when:                        false
-  failed_when:                         false
-  environment:                         "{{ oracle_env }}"
-  args:
-    chdir:                             "/etc/sap_deployment_automation/dataguard_scripts/"
-
-
-- name:                                "4.1.3 Oracle Data Guard - Display Data Guard status on Primary"
+- name:                                "4.1.3 Oracle Data Guard - Show status on Primary"
   ansible.builtin.debug:
     msg:
       - "Database instance:            {{ ansible_hostname }}"
-      - "Primary instance open:        {{ primary_open }}"
+      - "Primary mounted status:       {{ primary_mounted or primary_open }}"
+      - "Primary open status:          {{ primary_open }}"
+      - "Primary instance open_mode:   {{ dg_status.stdout }}"
+

--- a/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/00-validate-primary.yaml
+++ b/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/00-validate-primary.yaml
@@ -60,56 +60,11 @@
 - name:                                "4.1.3 Oracle Data Guard - Show status on Primary"
   ansible.builtin.debug:
     msg:
-      - "Database instance:            {{ ansible_hostname }}"
-      - "Primary mounted status:       {{ primary_mounted or primary_open }}"
-      - "Primary open status:          {{ primary_open }}"
-      - "Primary instance open_mode:   {{ dg_status.stdout }}"
+      - "Database instance:               {{ ansible_hostname }}"
+      - "Primary mounted status:          {{ primary_mounted or primary_open }}"
+      - "Primary open status:             {{ primary_open }}"
+      - "Primary instance open_mode:      {{ dg_status.stdout }}"
       - "Primary instance needs mounting: {{ needs_mounting }}"
-
-- name:                                "4.1.3 Oracle Data Guard - Mount Primary instance"
-  when:
-    - not primary_mounted
-    - needs_mounting
-  become_user:                         "{{ oracle_user_name }}"
-  become:                              true
-  ansible.builtin.shell: |
-                                       sqlplus -S / as sysdba <<EOF
-                                       WHENEVER SQLERROR EXIT SQL.SQLCODE
-                                       ALTER DATABASE MOUNT;
-                                       ALTER DATABASE OPEN;
-                                       EXIT;
-                                       EOF
-
-  register:                            db_mounted
-  changed_when:                        false
-  failed_when:                         false
-  environment:                         "{{ oracle_env }}"
-  args:
-    chdir:                             "/etc/sap_deployment_automation/dataguard_scripts/"
-
-- name:                                "4.1.3 Oracle Data Guard - Verify Status on Primary"
-  become_user:                         "{{ oracle_user_name }}"
-  become:                              true
-  ansible.builtin.shell: |
-                                       sqlplus -S / as sysdba <<EOF
-                                       SET PAGESIZE 0 FEEDBACK OFF HEADING OFF;
-                                       SELECT database_role || ':' || open_mode FROM v\$database;
-                                       EXIT;
-                                       EOF
-
-  register:                            dg_status
-  changed_when:                        false
-  failed_when:                         false
-  args:
-    chdir:                             "/etc/sap_deployment_automation/dataguard_scripts/"
-  environment:                         "{{ oracle_env }}"
-
-- name:                                "4.1.3 Oracle Data Guard - Set status on Primary"
-  ansible.builtin.set_fact:
-    primary_open:                      "{{ (dg_status.stdout is search('PRIMARY:READ WRITE')) | bool }}"
-    primary_mounted:                   "{{ (dg_status.stdout is search('PRIMARY:MOUNTED')) | bool }}"
-    needs_mounting:                    "{{ (dg_status.stdout is search('RA-01507')) | bool }}"
-
 
 - name:                                "4.1.3 Oracle Data Guard - Restart Primary instance"
   when:
@@ -182,6 +137,29 @@
       args:
         chdir: "/etc/sap_deployment_automation/dataguard_scripts/"
 
+
+- name:                                "4.1.3 Oracle Data Guard - Mount Primary instance"
+  when:
+    - not primary_mounted
+    - not primary_open
+    - needs_mounting
+  become_user:                         "{{ oracle_user_name }}"
+  become:                              true
+  ansible.builtin.shell: |
+                                       sqlplus -S / as sysdba <<EOF
+                                       WHENEVER SQLERROR EXIT SQL.SQLCODE
+                                       ALTER DATABASE MOUNT;
+                                       ALTER DATABASE OPEN;
+                                       EXIT;
+                                       EOF
+
+  register:                            db_mounted
+  changed_when:                        false
+  failed_when:                         false
+  environment:                         "{{ oracle_env }}"
+  args:
+    chdir:                             "/etc/sap_deployment_automation/dataguard_scripts/"
+
 - name:                                "4.1.3 Oracle Data Guard - Verify Status on Primary"
   become_user:                         "{{ oracle_user_name }}"
   become:                              true
@@ -199,7 +177,7 @@
     chdir:                             "/etc/sap_deployment_automation/dataguard_scripts/"
   environment:                         "{{ oracle_env }}"
 
-- name:                                "4.1.3 Oracle Data Guard - Get status from Primary"
+- name:                                "4.1.3 Oracle Data Guard - Set status on Primary"
   ansible.builtin.set_fact:
     primary_open:                      "{{ (dg_status.stdout is search('PRIMARY:READ WRITE')) | bool }}"
     primary_mounted:                   "{{ (dg_status.stdout is search('PRIMARY:MOUNTED')) | bool }}"
@@ -237,8 +215,6 @@
   become_user:                         "{{ oracle_user_name }}"
   become:                              true
   ansible.builtin.shell: |
-
-                                       printenv
                                        sqlplus -S / as sysdba <<EOF
                                        WHENEVER SQLERROR EXIT SQL.SQLCODE
                                        SET PAGESIZE 0 FEEDBACK OFF HEADING OFF;

--- a/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/00-validate-primary.yaml
+++ b/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/00-validate-primary.yaml
@@ -152,7 +152,6 @@
     chdir:                             "/etc/sap_deployment_automation/dataguard_scripts/"
 
 - name:                                "4.1.3 Oracle Data Guard - Verify Data Guard configuration on Primary"
-  when:                                not primary_open
   become_user:                         "{{ oracle_user_name }}"
   become:                              true
   ansible.builtin.shell: |
@@ -174,7 +173,7 @@
   ansible.builtin.set_fact:
     primary_open:                      "{{ (dg_status.stdout is search('PRIMARY:READ WRITE')) | bool }}"
     primary_mounted:                   "{{ (dg_status.stdout is search('PRIMARY:MOUNTED')) | bool }}"
-    needs_mounting:                    "{{ (dg_status.stdout is search('RA-01507')) | bool }}"
+    needs_mounting:                    "{{ (dg_status.stdout is search('ORA-01507')) | bool }}"
 
 - name:                                "4.1.3 Oracle Data Guard - Show status on Primary"
   ansible.builtin.debug:

--- a/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/00-validate-primary.yaml
+++ b/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/00-validate-primary.yaml
@@ -182,4 +182,3 @@
       - "Primary mounted status:       {{ primary_mounted or primary_open }}"
       - "Primary open status:          {{ primary_open }}"
       - "Primary instance open_mode:   {{ dg_status.stdout }}"
-

--- a/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/00-validate-primary.yaml
+++ b/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/00-validate-primary.yaml
@@ -55,7 +55,8 @@
   ansible.builtin.set_fact:
     primary_open:                      "{{ (dg_status.stdout is search('PRIMARY:READ WRITE')) | bool }}"
     primary_mounted:                   "{{ (dg_status.stdout is search('PRIMARY:MOUNTED')) | bool }}"
-    needs_mounting:                    "{{ (dg_status.stdout is search('RA-01507')) | bool }}"
+    needs_mounting:                    "{{ (dg_status.stdout is search('ORA-01507')) | bool }}"
+    primary_exclusive:                 "{{ (dg_status.stdout is search('ORA-01102')) | bool }}"
 
 - name:                                "4.1.3 Oracle Data Guard - Show status on Primary"
   ansible.builtin.debug:
@@ -70,73 +71,13 @@
   when:
     - not primary_mounted
     - not primary_open
-    - not needs_mounting
+    - not needs_mounting or primary_exclusive
   block:
-    - name:                            "4.1.3 Oracle Data Guard - Restart Primary instance"
-      become_user:                     "{{ oracle_user_name }}"
-      become:                          true
-      ansible.builtin.shell: |
-                                       sqlplus -S / as sysdba <<EOF
-                                       SHUTDOWN IMMEDIATE;
-                                       EXIT;
-                                       EOF
-
-      register:                        db_shut_down
-      changed_when:                    false
-      failed_when:                     false
-      environment:                     "{{ oracle_env }}"
-      args:
-        chdir:                         "/etc/sap_deployment_automation/dataguard_scripts/"
-
-    - name:                            "4.1.3 Oracle Data Guard - Shutdown instance - Check for zombie standby processes"
-      ansible.builtin.shell: |
-                                       set -o pipefail
-                                       ps -ef | grep ora_pmon_{{ db_sid | upper }} | grep -v grep || true
-      become_user:                     "root"
-      become:                          true
-      register:                        standby_pmon
-      changed_when:                    false
-
-    - name:                            "4.1.3 Oracle Data Guard - Shutdown instance - Kill zombie standby processes"
-      become:                          true
-      become_user:                     root
-      ansible.builtin.shell:           kill -9 {{ item.split()[1] }}
-      loop:                            "{{ standby_pmon.stdout_lines }}"
-      when:                            standby_pmon.stdout | length > 0
-      failed_when:                     false
-
-    - name:                            "4.1.3 Oracle Data Guard - Shutdown instance - Clean orphaned shared memory segments"
-      become:                          true
-      become_user:                     root
-      ansible.builtin.shell: |
-                                       set -o pipefail
-                                       for seg in $(ipcs -m | grep {{ oracle_user_name }} | awk '$6==0 {print $2}'); do
-                                         ipcrm -m $seg
-                                       done
-      failed_when:                     false
-      when:                            standby_pmon.stdout | length > 0
-
-    - name:                            "4.1.3 Oracle Data Guard - Shutdown instance - Remove lock file"
-      become:                          true
-      become_user:                     root
-      ansible.builtin.file:
-        path:                          "/oracle/{{ db_sid | upper }}/{{ ora_version }}/dbs/lk{{ db_sid | upper }}"
-        state:                         absent
-      failed_when:                     false
-
-    - name:                            "4.1.3 Oracle Data Guard - Start Primary instance"
-      become_user:                     "{{ oracle_user_name }}"
-      become:                          true
-      ansible.builtin.shell: |
-                                       sqlplus -S / as sysdba <<'EOF'
-                                       WHENEVER SQLERROR EXIT SQL.SQLCODE
-                                       STARTUP;
-                                       EXIT;
-                                       EOF
-      environment:                     "{{ oracle_env }}"
-      args:
-        chdir: "/etc/sap_deployment_automation/dataguard_scripts/"
-
+    - name:                            "4.1.3 Oracle Data Guard: - Restart Primary instance"
+      ansible.builtin.include_tasks:   "00-restart-instance.yaml"
+      vars:
+        current_sid:                   "{{ db_sid | upper }}"
+        use_pfile_on_startup:          false
 
 - name:                                "4.1.3 Oracle Data Guard - Mount Primary instance"
   when:
@@ -160,6 +101,10 @@
   args:
     chdir:                             "/etc/sap_deployment_automation/dataguard_scripts/"
 
+- name:                                "4.1.3 Oracle Data Guard - Set status on Primary"
+  ansible.builtin.set_fact:
+    primary_exclusive:                 "{{ (db_mounted.stdout is search('ORA-01102')) | bool }}"
+
 - name:                                "4.1.3 Oracle Data Guard - Verify Status on Primary"
   become_user:                         "{{ oracle_user_name }}"
   become:                              true
@@ -181,7 +126,7 @@
   ansible.builtin.set_fact:
     primary_open:                      "{{ (dg_status.stdout is search('PRIMARY:READ WRITE')) | bool }}"
     primary_mounted:                   "{{ (dg_status.stdout is search('PRIMARY:MOUNTED')) | bool }}"
-    needs_mounting:                    "{{ (dg_status.stdout is search('RA-01507')) | bool }}"
+    needs_mounting:                    "{{ (dg_status.stdout is search('ORA-01507')) | bool }}"
 
 - name:                                "4.1.3 Oracle Data Guard - Show status on Primary"
   ansible.builtin.debug:

--- a/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/00-validate-secondary.yaml
+++ b/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/00-validate-secondary.yaml
@@ -51,7 +51,7 @@
     group:                             oinstall
     recurse:                           "{{ item.recurse }}"
   loop:
-    - { state: 'directory', mode: '0775', recurse: false, path: "/oracle/{{ db_sid | upper }}" }
+    - { state: 'directory', mode: '0775', recurse: true, path: "/oracle/{{ db_sid | upper }}" }
 
 - name:                                "4.1.3 Oracle Data Guard - Check Database status on Secondary {{ ansible_hostname }}"
   become_user:                         "{{ oracle_user_name }}"
@@ -69,7 +69,7 @@
   changed_when:                        false
   failed_when:                         false
 
-- name:                                "4.1.3 Oracle Data Guard - Display Data Guard status"
+- name:                                "4.1.3 Oracle Data Guard - Display Data Guard status on secondary"
   ansible.builtin.debug:
     msg:                               "Database role: {{ rman_performed.stdout | default('UNKNOWN') }}"
 
@@ -77,7 +77,7 @@
   ansible.builtin.set_fact:
     secondary_duplicated:              "{{ (rman_performed.stdout | default('UNKNOWN')) is search('PHYSICAL STANDBY')  }}"
 
-- name:                                "4.1.3 Oracle Data Guard - Display Data Guard status"
+- name:                                "4.1.3 Oracle Data Guard - Display Data Guard status on secondary"
   ansible.builtin.debug:
     msg:
       - "Database instance:            {{ ansible_hostname }}"

--- a/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/00-validate-secondary.yaml
+++ b/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/00-validate-secondary.yaml
@@ -40,19 +40,6 @@
     - node_tier == "oracle-asm"
     - asm_status is defined
 
-- name:                                "4.1.3 Oracle Data Guard - Setup Secondary - Create directories as oracle user"
-  become:                              true
-  become_user:                         root
-  ansible.builtin.file:
-    path:                              "{{ item.path }}"
-    state:                             directory
-    mode:                              "{{ item.mode }}"
-    owner:                             "{{ oracle_user_name }}"
-    group:                             oinstall
-    recurse:                           "{{ item.recurse }}"
-  loop:
-    - { state: 'directory', mode: '0775', recurse: true, path: "/oracle/{{ db_sid | upper }}" }
-
 - name:                                "4.1.3 Oracle Data Guard - Check Database status on Secondary {{ ansible_hostname }}"
   become_user:                         "{{ oracle_user_name }}"
   become:                              true

--- a/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/01-prepare-primary.yaml
+++ b/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/01-prepare-primary.yaml
@@ -353,4 +353,6 @@
     timeout:                           10
   loop:                                 "{{ ansible_play_hosts_all }}"
   when:                                item != inventory_hostname
+  failed_when:                         false
+  register:                            connectivity_check
 ...

--- a/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/01-prepare-primary.yaml
+++ b/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/01-prepare-primary.yaml
@@ -346,13 +346,5 @@
     mode:                              '0777'
   when:                                primary_register_listener.stdout is defined
 
-- name:                                "4.1.3 Oracle Data Guard - Setup Primary: - Test network connectivity to peer"
-  ansible.builtin.wait_for:
-    host:                              "{{ hostvars[item]['ansible_host'] }}"
-    port:                              "{{ listener_port }}"
-    timeout:                           10
-  loop:                                 "{{ ansible_play_hosts_all }}"
-  when:                                item != inventory_hostname
-  failed_when:                         false
-  register:                            connectivity_check
+
 ...

--- a/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/01-prepare-primary.yaml
+++ b/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/01-prepare-primary.yaml
@@ -65,12 +65,13 @@
   become_user:                         "{% if node_tier == 'oracle-asm' %}{{ grid_user_name }}{% else %}{{ oracle_user_name }}{% endif %}"
   become:                              true
   ansible.builtin.shell: |
-                                       lsnrctl reload
-  environment:                         "{{ oracle_env }}"
+                                       /oracle/{{ db_path }}/{{ ora_version }}/bin/lsnrctl reload
+  environment:                         "{{ (node_tier == 'oracle-asm') | ternary(grid_env, oracle_env) }}"
   register:                            listener_reload_results
   failed_when:
                                       - listener_reload_results.rc not in [0, 1]
-
+  args:
+    chdir:                             "/oracle/{{ db_path }}/{{ ora_version }}/bin"
 
 - name:                                "4.1.3 Oracle Data Guard - Verify Status on Primary"
   become_user:                         "{{ oracle_user_name }}"

--- a/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/01-prepare-primary.yaml
+++ b/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/01-prepare-primary.yaml
@@ -48,6 +48,11 @@
     mode:                              '0644'
   register:                            listener_config
 
+- name:                                "4.1.3 Oracle Data Guard - Prepare Primary - Remove tnsnames.ora"
+  ansible.builtin.file:
+    path:                              "/oracle/{{ db_sid | upper }}/{{ ora_version }}/network/admin/tnsnames.ora"
+    state:                             absent
+
 - name:                                "4.1.3 Oracle Data Guard - Prepare Primary - Deploy tnsnames.ora"
   ansible.builtin.template:
     src:                               tnsnames_primary.ora.j2
@@ -55,6 +60,17 @@
     owner:                             "{{ oracle_user_name }}"
     group:                             "{{ oracle_group }}"
     mode:                              '0644'
+
+- name:                                "4.1.3 Oracle Data Guard - Prepare Primary - Reload listener"
+  become_user:                         "{% if node_tier == 'oracle-asm' %}{{ grid_user_name }}{% else %}{{ oracle_user_name }}{% endif %}"
+  become:                              true
+  ansible.builtin.shell: |
+                                       lsnrctl reload
+  environment:                         "{{ oracle_env }}"
+  register:                            listener_reload_results
+  failed_when:
+                                      - listener_reload_results.rc not in [0, 1]
+
 
 - name:                                "4.1.3 Oracle Data Guard - Verify Status on Primary"
   become_user:                         "{{ oracle_user_name }}"
@@ -330,4 +346,11 @@
     mode:                              '0777'
   when:                                primary_register_listener.stdout is defined
 
+- name:                                "4.1.3 Oracle Data Guard - Setup Primary: - Test network connectivity to peer"
+  ansible.builtin.wait_for:
+    host:                              "{{ hostvars[item]['ansible_host'] }}"
+    port:                              "{{ listener_port }}"
+    timeout:                           10
+  loop:                                 "{{ ansible_play_hosts_all }}"
+  when:                                item != inventory_hostname
 ...

--- a/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/02-prepare-secondary.yaml
+++ b/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/02-prepare-secondary.yaml
@@ -94,15 +94,6 @@
                                        - listener_start_results.rc not in [0, 1]
                                        - "'TNS-01106' not in listener_start_results.stdout"
 
-
-
-    - name:                            "4.1.3 Oracle Data Guard - Show Main Memory"
-      ansible.builtin.debug:
-          msg:
-          - "Total memory:         {{ main_mem1 }}"
-          - "sga_max_size:         {{ ora_sga }}"
-          - "pga_aggregate_target: {{ ora_pga }}"
-
     - name:                            "4.1.3 Oracle Data Guard - Prepare Secondary - Create standby initialization file"
       ansible.builtin.template:
         src:                           init_standby.ora.j2

--- a/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/02-prepare-secondary.yaml
+++ b/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/02-prepare-secondary.yaml
@@ -94,25 +94,7 @@
                                        - listener_start_results.rc not in [0, 1]
                                        - "'TNS-01106' not in listener_start_results.stdout"
 
-    - name:                            "4.1.3 Oracle Data Guard - Set Variables"
-      ansible.builtin.set_fact:
-        pga_temp_l4tb_std:             "{{ ((ansible_memory_mb.real.total * 0.60 ) * 0.2) | round | int }}"
-        pga_temp_l4tb_dis:             "{{ ((ansible_memory_mb.real.total * 0.80 ) * 0.2) | round | int }}"
 
-    - name:                            "4.1.3 Oracle Data Guard - Set the SGA and PGA Sizes for RAM < 4TB"
-      ansible.builtin.set_fact:
-        main_mem1:                     "{{ ansible_memory_mb.real.total }}"
-        ora_sga:                       "{{ (ansible_memory_mb.real.total * 0.60) | round | int }}"
-        ora_pga:                       "{{ [(pga_temp_l4tb_std | int), 4194304] | min }}"
-      when:
-        - ansible_memory_mb.real.total < 4194304
-
-    - name:                            "4.1.3 Oracle Data Guard - Set the SGA and PGA Sizes for RAM > 4TB"
-      ansible.builtin.set_fact:
-        ora_sga:                       "{{ (ansible_memory_mb.real.total * 0.65) | round | int }}"
-        ora_pga:                       "{{ ((ansible_memory_mb.real.total*0.65)*0.2) | round | int }}"
-      when:
-        - ansible_memory_mb.real.total > 4194304
 
     - name:                            "4.1.3 Oracle Data Guard - Show Main Memory"
       ansible.builtin.debug:

--- a/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/02-prepare-secondary.yaml
+++ b/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/02-prepare-secondary.yaml
@@ -14,6 +14,14 @@
   when:                                not spfile_stat.stat.exists
   block:
 
+    - name:                            "4.1.3 Oracle Data Guard - Ensure the files are owned by oracle user and group to avoid installation failure due to permission issues"
+      ansible.builtin.file:
+        name:                          "/oracle/{{ db_sid | upper }}/{{ ora_version }}/dbs"
+        owner:                         "{{ oracle_user_name }}"
+        group:                         oinstall
+        mode:                          0640
+        recurse:                       true
+
     - name:                            "4.1.3 Oracle Data Guard - Preparation: Create folders"
       when:                            node_tier == "oracle"
       become:                          true

--- a/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/02-prepare-secondary.yaml
+++ b/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/02-prepare-secondary.yaml
@@ -19,7 +19,7 @@
         name:                          "/oracle/{{ db_sid | upper }}/{{ ora_version }}/dbs"
         owner:                         "{{ oracle_user_name }}"
         group:                         oinstall
-        mode:                          0640
+        mode:                          0750
         recurse:                       true
 
     - name:                            "4.1.3 Oracle Data Guard - Preparation: Create folders"

--- a/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/02-prepare-secondary.yaml
+++ b/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/02-prepare-secondary.yaml
@@ -14,14 +14,6 @@
   when:                                not spfile_stat.stat.exists
   block:
 
-    - name:                            "4.1.3 Oracle Data Guard - Ensure the files are owned by oracle user and group to avoid installation failure due to permission issues"
-      ansible.builtin.file:
-        name:                          "/oracle/{{ db_sid | upper }}/{{ ora_version }}/dbs"
-        owner:                         "{{ oracle_user_name }}"
-        group:                         oinstall
-        mode:                          0750
-        recurse:                       true
-
     - name:                            "4.1.3 Oracle Data Guard - Preparation: Create folders"
       when:                            node_tier == "oracle"
       become:                          true

--- a/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/03-duplicate-database.yaml
+++ b/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/03-duplicate-database.yaml
@@ -14,7 +14,7 @@
                                        EXIT;
                                        EOF
   register:                            datafile_count
-  environment:                         "{{ oracle_env }}"
+  environment:                         "{{ oracle_standby_env }}"
   args:
     chdir:                             "/etc/sap_deployment_automation/dataguard_scripts/"
   changed_when:                        false
@@ -41,7 +41,7 @@
 
 - name:                                "4.1.3 Oracle Data Guard - Duplicate - Determine if RMAN duplicate is required"
   ansible.builtin.set_fact:
-    rman_duplication_required:         "{%if not datafile_count.stdout is defined %}True{% else %} {{ ((datafile_count.stdout | trim | int == 0) or (datafile_count.stderr is search('ORA-01507'))) }} {% endif %}"
+    rman_duplication_required:         "{{ (datafile_count.stdout | default('') | trim | int == 0) or (datafile_count.stderr | default('') is search('ORA-01507')) }}"
 
 - name:                                "4.1.3 Oracle Data Guard - Duplicate - Show if RMAN run is required"
   ansible.builtin.debug:
@@ -65,6 +65,39 @@
     - rman_duplication_required
   block:
 
+    - name:                            "4.1.3 Oracle Data Guard - Run TNSPING to check connectivity to primary database"
+      become_user:                     "{{ oracle_user_name }}"
+      become:                          true
+      ansible.builtin.shell: |
+                                       tnsping {{ db_sid | upper }}
+      environment:                     "{{ oracle_env }}"
+      args:
+        chdir:                         "/etc/sap_deployment_automation/dataguard_scripts/"
+      register:                        tnsping_result
+      failed_when:                     false
+
+    - name:                            "4.1.3 Oracle Data Guard - tnsping result"
+      ansible.builtin.debug:
+        msg:
+          - "TNSPING result: {{ tnsping_result.stdout | default('UNKNOWN') }}"
+
+    - name:                            "4.1.3 Oracle Data Guard - Run TNSPING to check connectivity to secondary database"
+      become_user:                     "{{ oracle_user_name }}"
+      become:                          true
+      ansible.builtin.shell: |
+                                       tnsping {{ db_sid | upper }}_STDBY
+      environment:                     "{{ oracle_env }}"
+      args:
+        chdir:                         "/etc/sap_deployment_automation/dataguard_scripts/"
+      register:                        tnsping_secondary_result
+      failed_when:                     false
+
+    - name:                            "4.1.3 Oracle Data Guard - tnsping result"
+      ansible.builtin.debug:
+        msg:
+          - "TNSPING result: {{ tnsping_secondary_result.stdout | default('UNKNOWN') }}"
+
+
     - name:                            "4.1.3 Oracle Data Guard - information"
       ansible.builtin.debug:
         msg:
@@ -79,16 +112,16 @@
                                        rman TARGET sys/'{{ main_password }}'@{{ db_sid | upper }} AUXILIARY sys/'{{ main_password }}'@{{ db_sid | upper }}_STDBY <<EOF
                                        DUPLICATE TARGET DATABASE FOR STANDBY FROM ACTIVE DATABASE DORECOVER
                                        SPFILE
-                                        SET DB_UNIQUE_NAME='{{ db_sid | upper }}_STDBY'
-                                        SET CONTROL_FILES='+DATA','+RECO','+ARCH'
-                                        SET FAL_SERVER='{{ db_sid | upper }}'
-                                        SET FAL_CLIENT='{{ db_sid | upper }}_STDBY'
-                                        SET STANDBY_FILE_MANAGEMENT='AUTO'
-                                        SET LOG_ARCHIVE_CONFIG='DG_CONFIG=({{ db_sid | upper }},{{ db_sid | upper }}_STDBY)'
-                                        SET LOG_ARCHIVE_DEST_1='LOCATION=USE_DB_RECOVERY_FILE_DEST VALID_FOR=(ALL_LOGFILES,ALL_ROLES) DB_UNIQUE_NAME={{ db_sid | upper }}_STDBY'
-                                        SET LOCAL_LISTENER='(ADDRESS=(PROTOCOL=TCP)(HOST={{ ora_secondary }})(PORT={{ listener_port }}))'
-                                        SET DB_RECOVERY_FILE_DEST_SIZE='{{ db_recovery_file_dest_size }}'
-                                        SET REMOTE_LOGIN_PASSWORDFILE='EXCLUSIVE'
+                                         SET DB_UNIQUE_NAME='{{ db_sid | upper }}_STDBY'
+                                         SET CONTROL_FILES='+DATA','+RECO','+ARCH'
+                                         SET FAL_SERVER='{{ db_sid | upper }}'
+                                         SET FAL_CLIENT='{{ db_sid | upper }}_STDBY'
+                                         SET STANDBY_FILE_MANAGEMENT='AUTO'
+                                         SET LOG_ARCHIVE_CONFIG='DG_CONFIG=({{ db_sid | upper }},{{ db_sid | upper }}_STDBY)'
+                                         SET LOG_ARCHIVE_DEST_1='LOCATION=USE_DB_RECOVERY_FILE_DEST VALID_FOR=(ALL_LOGFILES,ALL_ROLES) DB_UNIQUE_NAME={{ db_sid | upper }}_STDBY'
+                                         SET LOCAL_LISTENER='(ADDRESS=(PROTOCOL=TCP)(HOST={{ ora_secondary }})(PORT={{ listener_port }}))'
+                                         SET DB_RECOVERY_FILE_DEST_SIZE='{{ db_recovery_file_dest_size }}'
+                                         SET REMOTE_LOGIN_PASSWORDFILE='EXCLUSIVE'
                                        NOFILENAMECHECK;
                                        EXIT;
                                        EOF
@@ -103,23 +136,24 @@
       become_user:                     "{{ oracle_user_name }}"
       become:                          true
       ansible.builtin.shell: |
+                                       export ORACLE_SID={{ db_sid | upper }}_STDBY
                                        rman TARGET sys/'{{ main_password }}'@{{ db_sid | upper }} AUXILIARY sys/'{{ main_password }}'@{{ db_sid | upper }}_STDBY <<EOF
                                        DUPLICATE TARGET DATABASE FOR STANDBY FROM ACTIVE DATABASE DORECOVER
                                        SPFILE
-                                       SET DB_UNIQUE_NAME='{{ db_sid | upper }}_STDBY'
-                                       SET CONTROL_FILES='/oracle/{{ db_sid | upper }}/origlogA/cntrl/cntrl{{ db_sid | upper }}.dbf','/oracle/{{ db_sid | lower }}/origlogB/cntrl/cntrl{{ db_sid | upper }}.dbf','/oracle/{{ db_sid | lower }}/sapdata1/cntrl/cntrl{{ db_sid | upper }}.dbf'
-                                       SET FAL_SERVER='{{ db_sid | upper }}'
-                                       SET FAL_CLIENT='{{ db_sid | upper }}_STDBY'
-                                       SET STANDBY_FILE_MANAGEMENT='AUTO'
-                                       SET LOG_ARCHIVE_CONFIG='DG_CONFIG=({{ db_sid | upper }},{{ db_sid | upper }}_STDBY)'
-                                       SET LOG_ARCHIVE_DEST_1='LOCATION=USE_DB_RECOVERY_FILE_DEST VALID_FOR=(ALL_LOGFILES,ALL_ROLES) DB_UNIQUE_NAME={{ db_sid | upper }}_STDBY'
-                                       SET LOCAL_LISTENER='(ADDRESS=(PROTOCOL=TCP)(HOST={{ ora_secondary }})(PORT={{ listener_port }}))'
-                                       SET REMOTE_LOGIN_PASSWORDFILE='EXCLUSIVE'
-                                       SET DB_RECOVERY_FILE_DEST_SIZE='{{ db_recovery_file_dest_size }}'
+                                         SET DB_UNIQUE_NAME='{{ db_sid | upper }}_STDBY'
+                                         SET CONTROL_FILES='/oracle/{{ db_sid | upper }}/origlogA/cntrl/cntrl{{ db_sid | upper }}.dbf','/oracle/{{ db_sid | upper }}/origlogB/cntrl/cntrl{{ db_sid | upper }}.dbf','/oracle/{{ db_sid | upper }}/sapdata1/cntrl/cntrl{{ db_sid | upper }}.dbf'
+                                         SET FAL_SERVER='{{ db_sid | upper }}'
+                                         SET FAL_CLIENT='{{ db_sid | upper }}_STDBY'
+                                         SET STANDBY_FILE_MANAGEMENT='AUTO'
+                                         SET LOG_ARCHIVE_CONFIG='DG_CONFIG=({{ db_sid | upper }},{{ db_sid | upper }}_STDBY)'
+                                         SET LOG_ARCHIVE_DEST_1='LOCATION=USE_DB_RECOVERY_FILE_DEST VALID_FOR=(ALL_LOGFILES,ALL_ROLES) DB_UNIQUE_NAME={{ db_sid | upper }}_STDBY'
+                                         SET LOCAL_LISTENER='(ADDRESS=(PROTOCOL=TCP)(HOST={{ ora_secondary }})(PORT={{ listener_port }}))'
+                                         SET REMOTE_LOGIN_PASSWORDFILE='EXCLUSIVE'
+                                         SET DB_RECOVERY_FILE_DEST_SIZE='{{ db_recovery_file_dest_size }}'
                                        NOFILENAMECHECK;
                                        EXIT;
                                        EOF
-      environment:                     "{{ oracle_standby_env }}"
+      environment:                     "{{ oracle_env }}"
       args:
         chdir:                         "/etc/sap_deployment_automation/dataguard_scripts/"
       register:                        rman_duplicate
@@ -162,16 +196,16 @@
                                        rman TARGET sys/'{{ main_password }}'@{{ db_sid | upper }} AUXILIARY sys/'{{ main_password }}'@{{ db_sid | upper }}_STDBY <<EOF
                                        DUPLICATE TARGET DATABASE FOR STANDBY FROM ACTIVE DATABASE DORECOVER
                                        SPFILE
-                                        SET DB_UNIQUE_NAME='{{ db_sid | upper }}_STDBY'
-                                        SET CONTROL_FILES='+DATA','+RECO','+ARCH'
-                                        SET FAL_SERVER='{{ db_sid | upper }}'
-                                        SET FAL_CLIENT='{{ db_sid | upper }}_STDBY'
-                                        SET STANDBY_FILE_MANAGEMENT='AUTO'
-                                        SET LOG_ARCHIVE_CONFIG='DG_CONFIG=({{ db_sid | upper }},{{ db_sid | upper }}_STDBY)'
-                                        SET LOG_ARCHIVE_DEST_1='LOCATION=USE_DB_RECOVERY_FILE_DEST VALID_FOR=(ALL_LOGFILES,ALL_ROLES) DB_UNIQUE_NAME={{ db_sid | upper }}_STDBY'
-                                        SET LOCAL_LISTENER='(ADDRESS=(PROTOCOL=TCP)(HOST={{ ora_secondary }})(PORT={{ listener_port }}))'
-                                        SET DB_RECOVERY_FILE_DEST_SIZE='{{ db_recovery_file_dest_size }}'
-                                        SET REMOTE_LOGIN_PASSWORDFILE='EXCLUSIVE'
+                                         SET DB_UNIQUE_NAME='{{ db_sid | upper }}_STDBY'
+                                         SET CONTROL_FILES='+DATA','+RECO','+ARCH'
+                                         SET FAL_SERVER='{{ db_sid | upper }}'
+                                         SET FAL_CLIENT='{{ db_sid | upper }}_STDBY'
+                                         SET STANDBY_FILE_MANAGEMENT='AUTO'
+                                         SET LOG_ARCHIVE_CONFIG='DG_CONFIG=({{ db_sid | upper }},{{ db_sid | upper }}_STDBY)'
+                                         SET LOG_ARCHIVE_DEST_1='LOCATION=USE_DB_RECOVERY_FILE_DEST VALID_FOR=(ALL_LOGFILES,ALL_ROLES) DB_UNIQUE_NAME={{ db_sid | upper }}_STDBY'
+                                         SET LOCAL_LISTENER='(ADDRESS=(PROTOCOL=TCP)(HOST={{ ora_secondary }})(PORT={{ listener_port }}))'
+                                         SET DB_RECOVERY_FILE_DEST_SIZE='{{ db_recovery_file_dest_size }}'
+                                         SET REMOTE_LOGIN_PASSWORDFILE='EXCLUSIVE'
                                        NOFILENAMECHECK;
                                        EXIT;
                                        EOF
@@ -186,23 +220,24 @@
       become_user:                     "{{ oracle_user_name }}"
       become:                          true
       ansible.builtin.shell: |
+                                       export ORACLE_SID={{ db_sid | upper }}_STDBY
                                        rman TARGET sys/'{{ main_password }}'@{{ db_sid | upper }} AUXILIARY sys/'{{ main_password }}'@{{ db_sid | upper }}_STDBY <<EOF
                                        DUPLICATE TARGET DATABASE FOR STANDBY FROM ACTIVE DATABASE DORECOVER
                                        SPFILE
-                                       SET DB_UNIQUE_NAME='{{ db_sid | upper }}_STDBY'
-                                       SET CONTROL_FILES='/oracle/{{ db_sid | upper }}/origlogA/cntrl/cntrl{{ db_sid | upper }}.dbf','/oracle/{{ db_sid | lower }}/origlogB/cntrl/cntrl{{ db_sid | upper }}.dbf','/oracle/{{ db_sid | lower }}/sapdata1/cntrl/cntrl{{ db_sid | upper }}.dbf'
-                                       SET FAL_SERVER='{{ db_sid | upper }}'
-                                       SET FAL_CLIENT='{{ db_sid | upper }}_STDBY'
-                                       SET STANDBY_FILE_MANAGEMENT='AUTO'
-                                       SET LOG_ARCHIVE_CONFIG='DG_CONFIG=({{ db_sid | upper }},{{ db_sid | upper }}_STDBY)'
-                                       SET LOG_ARCHIVE_DEST_1='LOCATION=USE_DB_RECOVERY_FILE_DEST VALID_FOR=(ALL_LOGFILES,ALL_ROLES) DB_UNIQUE_NAME={{ db_sid | upper }}_STDBY'
-                                       SET LOCAL_LISTENER='(ADDRESS=(PROTOCOL=TCP)(HOST={{ ora_secondary }})(PORT={{ listener_port }}))'
-                                       SET REMOTE_LOGIN_PASSWORDFILE='EXCLUSIVE'
-                                       SET DB_RECOVERY_FILE_DEST_SIZE='{{ db_recovery_file_dest_size }}'
+                                         SET DB_UNIQUE_NAME='{{ db_sid | upper }}_STDBY'
+                                         SET CONTROL_FILES='/oracle/{{ db_sid | upper }}/origlogA/cntrl/cntrl{{ db_sid | upper }}.dbf','/oracle/{{ db_sid | upper }}/origlogB/cntrl/cntrl{{ db_sid | upper }}.dbf','/oracle/{{ db_sid | upper }}/sapdata1/cntrl/cntrl{{ db_sid | upper }}.dbf'
+                                         SET FAL_SERVER='{{ db_sid | upper }}'
+                                         SET FAL_CLIENT='{{ db_sid | upper }}_STDBY'
+                                         SET STANDBY_FILE_MANAGEMENT='AUTO'
+                                         SET LOG_ARCHIVE_CONFIG='DG_CONFIG=({{ db_sid | upper }},{{ db_sid | upper }}_STDBY)'
+                                         SET LOG_ARCHIVE_DEST_1='LOCATION=USE_DB_RECOVERY_FILE_DEST VALID_FOR=(ALL_LOGFILES,ALL_ROLES) DB_UNIQUE_NAME={{ db_sid | upper }}_STDBY'
+                                         SET LOCAL_LISTENER='(ADDRESS=(PROTOCOL=TCP)(HOST={{ ora_secondary }})(PORT={{ listener_port }}))'
+                                         SET REMOTE_LOGIN_PASSWORDFILE='EXCLUSIVE'
+                                         SET DB_RECOVERY_FILE_DEST_SIZE='{{ db_recovery_file_dest_size }}'
                                        NOFILENAMECHECK;
                                        EXIT;
                                        EOF
-      environment:                     "{{ oracle_standby_env }}"
+      environment:                     "{{ oracle_env }}"
       args:
         chdir:                         "/etc/sap_deployment_automation/dataguard_scripts/"
       register:                        rman_duplicate

--- a/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/03-duplicate-database.yaml
+++ b/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/03-duplicate-database.yaml
@@ -112,7 +112,7 @@
       become_user:                     "{{ oracle_user_name }}"
       become:                          true
       ansible.builtin.shell: |
-                                       rman TARGET sys/'{{ main_password }}'@{{ db_sid | upper }} AUXILIARY sys/'{{ main_password }}'@{{ db_sid | upper }}_STDBY <<EOF
+                                       rman TARGET sys/'{{ main_password }}'@{{ db_sid | upper }}.WORLD AUXILIARY sys/'{{ main_password }}'@{{ db_sid | upper }}_STDBY.WORLD <<EOF
                                        DUPLICATE TARGET DATABASE FOR STANDBY FROM ACTIVE DATABASE DORECOVER
                                        SPFILE
                                          SET DB_UNIQUE_NAME='{{ db_sid | upper }}_STDBY'
@@ -199,7 +199,7 @@
       become_user:                     "{{ oracle_user_name }}"
       become:                          true
       ansible.builtin.shell: |
-                                       rman TARGET sys/'{{ main_password }}'@{{ db_sid | upper }} AUXILIARY sys/'{{ main_password }}'@{{ db_sid | upper }}_STDBY <<EOF
+                                       rman TARGET sys/'{{ main_password }}'@{{ db_sid | upper }}.WORLD AUXILIARY sys/'{{ main_password }}'@{{ db_sid | upper }}_STDBY.WORLD <<EOF
                                        DUPLICATE TARGET DATABASE FOR STANDBY FROM ACTIVE DATABASE DORECOVER
                                        SPFILE
                                          SET DB_UNIQUE_NAME='{{ db_sid | upper }}_STDBY'

--- a/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/03-duplicate-database.yaml
+++ b/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/03-duplicate-database.yaml
@@ -2,42 +2,46 @@
 
 # In dg_duplicate/tasks/main.yml
 
-- name:                                "4.1.3 Oracle Data Guard - Duplicate - Check if standby already restored"
+- name:                                "4.1.3 Oracle Data Guard - Duplicate - ASM"
   when:                                node_tier == "oracle-asm"
   become_user:                         "{{ oracle_user_name }}"
   become:                              true
-  ansible.builtin.shell: |
+  block:
+
+    - name:                            "4.1.3 Oracle Data Guard - Duplicate - Check if standby already restored"
+      ansible.builtin.shell: |
                                        export ORACLE_SID={{ db_sid | upper }}_STDBY
                                        sqlplus -S sys/'{{ main_password }}'@{{ db_sid | upper }}_STDBY as sysdba <<EOF
                                        SET PAGESIZE 0 FEEDBACK OFF
                                        SELECT COUNT(*) FROM v\$datafile WHERE name LIKE '+DATA/{{ db_sid | upper }}_STDBY%';
                                        EXIT;
                                        EOF
-  register:                            datafile_count
-  environment:                         "{{ oracle_standby_env }}"
-  args:
-    chdir:                             "/etc/sap_deployment_automation/dataguard_scripts/"
-  changed_when:                        false
-  failed_when:                         false
+      register:                        datafile_count
+      environment:                     "{{ oracle_standby_env }}"
+      args:
+        chdir:                         "/etc/sap_deployment_automation/dataguard_scripts/"
+      changed_when:                    false
+      failed_when:                     false
 
-- name:                                "4.1.3 Oracle Data Guard - Duplicate - Check if standby already restored"
+- name:                                "4.1.3 Oracle Data Guard - Duplicate - ASM"
   when:                                node_tier == "oracle"
   become_user:                         "{{ oracle_user_name }}"
-
   become:                              true
-  ansible.builtin.shell: |
-                                       export ORACLE_SID={{ db_sid | upper }}_STDBY
-                                       sqlplus -S sys/'{{ main_password }}'@{{ db_sid | upper }}_STDBY as sysdba <<EOF
-                                       SET PAGESIZE 0 FEEDBACK OFF
-                                       SELECT COUNT(*) FROM v\$datafile;
-                                       EXIT;
-                                       EOF
-  register:                            datafile_count
-  environment:                         "{{ oracle_standby_env }}"
-  args:
-    chdir:                             "/etc/sap_deployment_automation/dataguard_scripts/"
-  changed_when:                        false
-  failed_when:                         false
+  block:
+    - name:                            "4.1.3 Oracle Data Guard - Duplicate - Check if standby already restored"
+      ansible.builtin.shell: |
+                                        export ORACLE_SID={{ db_sid | upper }}_STDBY
+                                        sqlplus -S sys/'{{ main_password }}'@{{ db_sid | upper }}_STDBY as sysdba <<EOF
+                                        SET PAGESIZE 0 FEEDBACK OFF
+                                        SELECT COUNT(*) FROM v\$datafile;
+                                        EXIT;
+                                        EOF
+      register:                         datafile_count
+      environment:                      "{{ oracle_standby_env }}"
+      args:
+        chdir:                          "/etc/sap_deployment_automation/dataguard_scripts/"
+      changed_when:                     false
+      failed_when:                      false
 
 - name:                                "4.1.3 Oracle Data Guard - Duplicate - Determine if RMAN duplicate is required"
   ansible.builtin.set_fact:
@@ -60,43 +64,42 @@
         current_sid:                   "{{ db_sid | upper }}_STDBY"
         use_pfile_on_startup:           true
 
+- name:                                "4.1.3 Oracle Data Guard - Run TNSPING to check connectivity to primary database"
+  become_user:                         "{{ oracle_user_name }}"
+  become:                              true
+  ansible.builtin.shell: |
+                                       tnsping {{ db_sid | upper }}
+  environment:                         "{{ oracle_env }}"
+  args:
+    chdir:                             "/etc/sap_deployment_automation/dataguard_scripts/"
+  register:                            tnsping_result
+  failed_when:                         false
+
+- name:                                "4.1.3 Oracle Data Guard - tnsping result"
+  ansible.builtin.debug:
+    msg:
+      - "TNSPING result (primary): {{ tnsping_result.stdout | default('UNKNOWN') }}"
+
+- name:                                "4.1.3 Oracle Data Guard - Run TNSPING to check connectivity to secondary database"
+  become_user:                         "{{ oracle_user_name }}"
+  become:                              true
+  ansible.builtin.shell: |
+                                       tnsping {{ db_sid | upper }}_STDBY
+  environment:                         "{{ oracle_standby_env }}"
+  args:
+    chdir:                             "/etc/sap_deployment_automation/dataguard_scripts/"
+  register:                            tnsping_secondary_result
+  failed_when:                         false
+
+- name:                                "4.1.3 Oracle Data Guard - tnsping result"
+  ansible.builtin.debug:
+    msg:
+      - "TNSPING result (secondary): {{ tnsping_secondary_result.stdout | default('UNKNOWN') }}"
+
 - name:                                "4.1.3 Oracle Data Guard - Configure Data Guard"
   when:
     - rman_duplication_required
   block:
-
-    - name:                            "4.1.3 Oracle Data Guard - Run TNSPING to check connectivity to primary database"
-      become_user:                     "{{ oracle_user_name }}"
-      become:                          true
-      ansible.builtin.shell: |
-                                       tnsping {{ db_sid | upper }}
-      environment:                     "{{ oracle_env }}"
-      args:
-        chdir:                         "/etc/sap_deployment_automation/dataguard_scripts/"
-      register:                        tnsping_result
-      failed_when:                     false
-
-    - name:                            "4.1.3 Oracle Data Guard - tnsping result"
-      ansible.builtin.debug:
-        msg:
-          - "TNSPING result: {{ tnsping_result.stdout | default('UNKNOWN') }}"
-
-    - name:                            "4.1.3 Oracle Data Guard - Run TNSPING to check connectivity to secondary database"
-      become_user:                     "{{ oracle_user_name }}"
-      become:                          true
-      ansible.builtin.shell: |
-                                       tnsping {{ db_sid | upper }}_STDBY
-      environment:                     "{{ oracle_env }}"
-      args:
-        chdir:                         "/etc/sap_deployment_automation/dataguard_scripts/"
-      register:                        tnsping_secondary_result
-      failed_when:                     false
-
-    - name:                            "4.1.3 Oracle Data Guard - tnsping result"
-      ansible.builtin.debug:
-        msg:
-          - "TNSPING result: {{ tnsping_secondary_result.stdout | default('UNKNOWN') }}"
-
 
     - name:                            "4.1.3 Oracle Data Guard - information"
       ansible.builtin.debug:
@@ -125,7 +128,7 @@
                                        NOFILENAMECHECK;
                                        EXIT;
                                        EOF
-      environment:                     "{{ oracle_env }}"
+      environment:                     "{{ oracle_standby_env }}"
       args:
         chdir:                         "/etc/sap_deployment_automation/dataguard_scripts/"
       register:                        rman_duplicate
@@ -153,7 +156,7 @@
                                        NOFILENAMECHECK;
                                        EXIT;
                                        EOF
-      environment:                     "{{ oracle_env }}"
+      environment:                     "{{ oracle_standby_env }}"
       args:
         chdir:                         "/etc/sap_deployment_automation/dataguard_scripts/"
       register:                        rman_duplicate
@@ -209,7 +212,7 @@
                                        NOFILENAMECHECK;
                                        EXIT;
                                        EOF
-      environment:                     "{{ oracle_env }}"
+      environment:                     "{{ oracle_standby_env }}"
       args:
         chdir:                         "/etc/sap_deployment_automation/dataguard_scripts/"
       register:                        rman_duplicate
@@ -237,7 +240,7 @@
                                        NOFILENAMECHECK;
                                        EXIT;
                                        EOF
-      environment:                     "{{ oracle_env }}"
+      environment:                     "{{ oracle_standby_env }}"
       args:
         chdir:                         "/etc/sap_deployment_automation/dataguard_scripts/"
       register:                        rman_duplicate

--- a/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/03-duplicate-database.yaml
+++ b/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/03-duplicate-database.yaml
@@ -96,33 +96,6 @@
     msg:
       - "TNSPING result (secondary): {{ tnsping_secondary_result.stdout | default('UNKNOWN') }}"
 
-
-- name:                                "4.1.3 Oracle Data Guard - Set the SGA and PGA Sizes for RAM < 4TB"
-  ansible.builtin.set_fact:
-    main_mem1:                         "{{ ansible_memory_mb.real.total }}"
-    ora_sga:                           "{{ (ansible_memory_mb.real.total * 0.60) | round | int }}"
-    ora_pga:                           "{{ [(pga_temp_l4tb_std | int), 4194304] | min }}"
-
-  when:
-    - ansible_memory_mb.real.total < 4194304
-    - "'pas' not in supported_tiers"
-- name:                                "4.1.3 Oracle Data Guard - Set the SGA and PGA Sizes for RAM < 4TB Single Node Deployments"
-  ansible.builtin.set_fact:
-    main_mem1:                         "{{ ansible_memory_mb.real.total }}"
-    ora_sga:                           "{{ (ansible_memory_mb.real.total * 0.75) | round | int }}"
-    ora_pga:                           "{{ [(pga_temp_l4tb_std | int), 4194304] | min }}"
-  when:
-    - ansible_memory_mb.real.total < 4194304
-    - "'pas' in supported_tiers"
-
-- name:                                "4.1.3 Oracle Data Guard - Show Main Memory"
-  ansible.builtin.debug:
-    msg:
-      - "Total memory:         {{ main_mem1 }}"
-      - "sga_max_size:         {{ ora_sga }}"
-      - "pga_aggregate_target: {{ ora_pga }}"
-
-
 - name:                                "4.1.3 Oracle Data Guard - Configure Data Guard"
   when:
     - rman_duplication_required
@@ -152,9 +125,6 @@
                                          SET LOCAL_LISTENER='(ADDRESS=(PROTOCOL=TCP)(HOST={{ ora_secondary }})(PORT={{ listener_port }}))'
                                          SET DB_RECOVERY_FILE_DEST_SIZE='{{ db_recovery_file_dest_size }}'
                                          SET REMOTE_LOGIN_PASSWORDFILE='EXCLUSIVE'
-                                         SET sga_max_size={{ ora_sga }}M
-                                         SET pga_aggregate_target={{ ora_pga }}M
-                                         SET use_large_pages=only
                                        NOFILENAMECHECK;
                                        EXIT;
                                        EOF
@@ -183,9 +153,6 @@
                                          SET LOCAL_LISTENER='(ADDRESS=(PROTOCOL=TCP)(HOST={{ ora_secondary }})(PORT={{ listener_port }}))'
                                          SET REMOTE_LOGIN_PASSWORDFILE='EXCLUSIVE'
                                          SET DB_RECOVERY_FILE_DEST_SIZE='{{ db_recovery_file_dest_size }}'
-                                         SET sga_max_size={{ ora_sga }}M
-                                         SET pga_aggregate_target={{ ora_pga }}M
-                                         SET use_large_pages=only
                                        NOFILENAMECHECK;
                                        EXIT;
                                        EOF
@@ -242,9 +209,6 @@
                                          SET LOCAL_LISTENER='(ADDRESS=(PROTOCOL=TCP)(HOST={{ ora_secondary }})(PORT={{ listener_port }}))'
                                          SET DB_RECOVERY_FILE_DEST_SIZE='{{ db_recovery_file_dest_size }}'
                                          SET REMOTE_LOGIN_PASSWORDFILE='EXCLUSIVE'
-                                         SET sga_max_size={{ ora_sga }}M
-                                         SET pga_aggregate_target={{ ora_pga }}M
-                                         SET use_large_pages=only
                                        NOFILENAMECHECK;
                                        EXIT;
                                        EOF
@@ -273,9 +237,6 @@
                                          SET LOCAL_LISTENER='(ADDRESS=(PROTOCOL=TCP)(HOST={{ ora_secondary }})(PORT={{ listener_port }}))'
                                          SET REMOTE_LOGIN_PASSWORDFILE='EXCLUSIVE'
                                          SET DB_RECOVERY_FILE_DEST_SIZE='{{ db_recovery_file_dest_size }}'
-                                         SET sga_max_size={{ ora_sga }}M
-                                         SET pga_aggregate_target={{ ora_pga }}M
-                                         SET use_large_pages=only
                                        NOFILENAMECHECK;
                                        EXIT;
                                        EOF

--- a/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/03-duplicate-database.yaml
+++ b/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/03-duplicate-database.yaml
@@ -131,6 +131,7 @@
       environment:
         ORACLE_HOME:                   "/oracle/{{ db_sid | upper }}/{{ ora_version }}"
         ORACLE_SID:                    ""
+        PATH:                          "/oracle/{{ db_sid | upper }}/{{ ora_version }}/bin:{{ ansible_env.PATH }}"
       args:
         chdir:                         "/etc/sap_deployment_automation/dataguard_scripts/"
       register:                        rman_duplicate
@@ -217,6 +218,7 @@
       environment:
         ORACLE_HOME:                   "/oracle/{{ db_sid | upper }}/{{ ora_version }}"
         ORACLE_SID:                    ""
+        PATH:                          "/oracle/{{ db_sid | upper }}/{{ ora_version }}/bin:{{ ansible_env.PATH }}"
       args:
         chdir:                         "/etc/sap_deployment_automation/dataguard_scripts/"
       register:                        rman_duplicate

--- a/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/03-duplicate-database.yaml
+++ b/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/03-duplicate-database.yaml
@@ -96,6 +96,33 @@
     msg:
       - "TNSPING result (secondary): {{ tnsping_secondary_result.stdout | default('UNKNOWN') }}"
 
+
+- name:                                "4.1.3 Oracle Data Guard - Set the SGA and PGA Sizes for RAM < 4TB"
+  ansible.builtin.set_fact:
+    main_mem1:                         "{{ ansible_memory_mb.real.total }}"
+    ora_sga:                           "{{ (ansible_memory_mb.real.total * 0.60) | round | int }}"
+    ora_pga:                           "{{ [(pga_temp_l4tb_std | int), 4194304] | min }}"
+
+  when:
+    - ansible_memory_mb.real.total < 4194304
+    - "'pas' not in supported_tiers"
+- name:                                "4.1.3 Oracle Data Guard - Set the SGA and PGA Sizes for RAM < 4TB Single Node Deployments"
+  ansible.builtin.set_fact:
+    main_mem1:                         "{{ ansible_memory_mb.real.total }}"
+    ora_sga:                           "{{ (ansible_memory_mb.real.total * 0.75) | round | int }}"
+    ora_pga:                           "{{ [(pga_temp_l4tb_std | int), 4194304] | min }}"
+  when:
+    - ansible_memory_mb.real.total < 4194304
+    - "'pas' in supported_tiers"
+
+- name:                                "4.1.3 Oracle Data Guard - Show Main Memory"
+  ansible.builtin.debug:
+    msg:
+      - "Total memory:         {{ main_mem1 }}"
+      - "sga_max_size:         {{ ora_sga }}"
+      - "pga_aggregate_target: {{ ora_pga }}"
+
+
 - name:                                "4.1.3 Oracle Data Guard - Configure Data Guard"
   when:
     - rman_duplication_required
@@ -125,6 +152,9 @@
                                          SET LOCAL_LISTENER='(ADDRESS=(PROTOCOL=TCP)(HOST={{ ora_secondary }})(PORT={{ listener_port }}))'
                                          SET DB_RECOVERY_FILE_DEST_SIZE='{{ db_recovery_file_dest_size }}'
                                          SET REMOTE_LOGIN_PASSWORDFILE='EXCLUSIVE'
+                                         SET sga_max_size={{ ora_sga }}M
+                                         SET pga_aggregate_target={{ ora_pga }}M
+                                         SET use_large_pages=only
                                        NOFILENAMECHECK;
                                        EXIT;
                                        EOF
@@ -153,6 +183,9 @@
                                          SET LOCAL_LISTENER='(ADDRESS=(PROTOCOL=TCP)(HOST={{ ora_secondary }})(PORT={{ listener_port }}))'
                                          SET REMOTE_LOGIN_PASSWORDFILE='EXCLUSIVE'
                                          SET DB_RECOVERY_FILE_DEST_SIZE='{{ db_recovery_file_dest_size }}'
+                                         SET sga_max_size={{ ora_sga }}M
+                                         SET pga_aggregate_target={{ ora_pga }}M
+                                         SET use_large_pages=only
                                        NOFILENAMECHECK;
                                        EXIT;
                                        EOF
@@ -209,6 +242,9 @@
                                          SET LOCAL_LISTENER='(ADDRESS=(PROTOCOL=TCP)(HOST={{ ora_secondary }})(PORT={{ listener_port }}))'
                                          SET DB_RECOVERY_FILE_DEST_SIZE='{{ db_recovery_file_dest_size }}'
                                          SET REMOTE_LOGIN_PASSWORDFILE='EXCLUSIVE'
+                                         SET sga_max_size={{ ora_sga }}M
+                                         SET pga_aggregate_target={{ ora_pga }}M
+                                         SET use_large_pages=only
                                        NOFILENAMECHECK;
                                        EXIT;
                                        EOF
@@ -237,6 +273,9 @@
                                          SET LOCAL_LISTENER='(ADDRESS=(PROTOCOL=TCP)(HOST={{ ora_secondary }})(PORT={{ listener_port }}))'
                                          SET REMOTE_LOGIN_PASSWORDFILE='EXCLUSIVE'
                                          SET DB_RECOVERY_FILE_DEST_SIZE='{{ db_recovery_file_dest_size }}'
+                                         SET sga_max_size={{ ora_sga }}M
+                                         SET pga_aggregate_target={{ ora_pga }}M
+                                         SET use_large_pages=only
                                        NOFILENAMECHECK;
                                        EXIT;
                                        EOF

--- a/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/03-duplicate-database.yaml
+++ b/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/03-duplicate-database.yaml
@@ -116,7 +116,7 @@
                                        DUPLICATE TARGET DATABASE FOR STANDBY FROM ACTIVE DATABASE DORECOVER
                                        SPFILE
                                          SET DB_UNIQUE_NAME='{{ db_sid | upper }}_STDBY'
-                                         SET CONTROL_FILES='+DATA','+RECO','+ARCH'
+                                         SET CONTROL_FILES='+DATA','+RECO'
                                          SET FAL_SERVER='{{ db_sid | upper }}'
                                          SET FAL_CLIENT='{{ db_sid | upper }}_STDBY'
                                          SET STANDBY_FILE_MANAGEMENT='AUTO'
@@ -128,7 +128,9 @@
                                        NOFILENAMECHECK;
                                        EXIT;
                                        EOF
-      environment:                     "{{ oracle_standby_env }}"
+      environment:
+        ORACLE_HOME:                   "/oracle/{{ db_sid | upper }}/{{ ora_version }}"
+        ORACLE_SID:                    ""
       args:
         chdir:                         "/etc/sap_deployment_automation/dataguard_scripts/"
       register:                        rman_duplicate
@@ -200,7 +202,7 @@
                                        DUPLICATE TARGET DATABASE FOR STANDBY FROM ACTIVE DATABASE DORECOVER
                                        SPFILE
                                          SET DB_UNIQUE_NAME='{{ db_sid | upper }}_STDBY'
-                                         SET CONTROL_FILES='+DATA','+RECO','+ARCH'
+                                         SET CONTROL_FILES='+DATA','+RECO'
                                          SET FAL_SERVER='{{ db_sid | upper }}'
                                          SET FAL_CLIENT='{{ db_sid | upper }}_STDBY'
                                          SET STANDBY_FILE_MANAGEMENT='AUTO'
@@ -212,7 +214,9 @@
                                        NOFILENAMECHECK;
                                        EXIT;
                                        EOF
-      environment:                     "{{ oracle_standby_env }}"
+      environment:
+        ORACLE_HOME:                   "/oracle/{{ db_sid | upper }}/{{ ora_version }}"
+        ORACLE_SID:                    ""
       args:
         chdir:                         "/etc/sap_deployment_automation/dataguard_scripts/"
       register:                        rman_duplicate

--- a/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/03-duplicate-database.yaml
+++ b/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/03-duplicate-database.yaml
@@ -268,6 +268,7 @@
     - rman_duplicate.stdout is defined
     - not rman_duplicate.stdout is search("Finished Duplicate Db")
 
+
 - name:                                "4.1.3 Oracle Data Guard - Duplicate - Check standby database mounted"
   become_user:                         "{{ oracle_user_name }}"
   become:                              true
@@ -291,11 +292,6 @@
   ansible.builtin.set_fact:
     secondary_duplicated:              "{{ 'PHYSICAL STANDBY:MOUNTED' in db_status.stdout or 'PHYSICAL STANDBY:READ ONLY' in db_status.stdout }}"
 
-- name:                                "4.1.3 Oracle Data Guard - Duplicate - Display duplication status"
-  ansible.builtin.debug:
-    msg:
-      - "Database instance:            {{ ansible_hostname }}"
-      - "Database duplicated:          {{ secondary_duplicated }}"
 
 - name:                                "4.1.3 Oracle Data Guard - Start Instance - Show SPFile location"
   become_user:                         "{{ oracle_user_name }}"
@@ -311,9 +307,13 @@
   args:
     chdir:                             "/etc/sap_deployment_automation/dataguard_scripts/"
 
-- name:                                "4.1.3 Oracle Data Guard - Duplicate - Show SPFile location"
+- name:                                "4.1.3 Oracle Data Guard - Duplicate - Display duplication status"
   ansible.builtin.debug:
-    msg:                               "SPFile location: {{ pfile_location.stdout }}"
+    msg:
+      - "RMAN DUPLICATE ran successfully."
+      - "Database instance:            {{ ansible_hostname }}"
+      - "Database duplicated:          {{ secondary_duplicated }}"
+      - "SPFile location:              {{ pfile_location.stdout }}"
 
 - name:                                "4.1.3 Oracle Data Guard - Duplicate - Create standby initialization file"
   when:                                node_tier == "oracle-asm"

--- a/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/04-postdeployment-primary.yaml
+++ b/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/04-postdeployment-primary.yaml
@@ -130,5 +130,5 @@
   when:                                item != inventory_hostname
   failed_when:                         false
   register:                            connectivity_check
-...
 
+...

--- a/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/04-postdeployment-primary.yaml
+++ b/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/04-postdeployment-primary.yaml
@@ -120,4 +120,15 @@
     content:                           "{{ enable_shipping.stdout }}"
     mode:                              '0777'
   when:                                enable_shipping.stdout is defined
+
+- name:                                "4.1.3 Oracle Data Guard - Post deployment on Primary - Test network connectivity to peer"
+  ansible.builtin.wait_for:
+    host:                              "{{ hostvars[item]['ansible_host'] }}"
+    port:                              "{{ listener_port }}"
+    timeout:                           10
+  loop:                                 "{{ ansible_play_hosts_all }}"
+  when:                                item != inventory_hostname
+  failed_when:                         false
+  register:                            connectivity_check
 ...
+

--- a/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/04-postdeployment-secondary.yaml
+++ b/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/04-postdeployment-secondary.yaml
@@ -15,26 +15,17 @@
   args:
     chdir:                             "/etc/sap_deployment_automation/dataguard_scripts/"
 
-- name:                                "4.1.3 Oracle Data Guard - Post deployment on Secondary - Set the SGA and PGA Sizes for RAM < 4TB"
+- name:                                "4.1.3 Oracle Data Guard - Post deployment on Secondary - Set Memory Variables"
   ansible.builtin.set_fact:
-    main_mem1:                         "{{ ansible_memory_mb.real.total }}"
+    pga_temp_l4tb_dis:                 "{{ ((ansible_memory_mb.real.total * 0.80 ) * 0.2) | round | int }}"
+    main_memory:                       "{{ ansible_memory_mb.real.total }}"
     ora_sga:                           "{{ (ansible_memory_mb.real.total * 0.60) | round | int }}"
-    ora_pga:                           "{{ [(pga_temp_l4tb_std | int), 4194304] | min }}"
-
-  when:
-    - ansible_memory_mb.real.total < 4194304
-- name:                                "4.1.3 Oracle Data Guard - Post deployment on Secondary - Set the SGA and PGA Sizes for RAM < 4TB Single Node Deployments"
-  ansible.builtin.set_fact:
-    main_mem1:                         "{{ ansible_memory_mb.real.total }}"
-    ora_sga:                           "{{ (ansible_memory_mb.real.total * 0.75) | round | int }}"
-    ora_pga:                           "{{ [(pga_temp_l4tb_std | int), 4194304] | min }}"
-  when:
-    - ansible_memory_mb.real.total < 4194304
+    ora_pga:                           "{{ [(pga_temp_l4tb_dis | int), 4194304] | min }}"
 
 - name:                                "4.1.3 Oracle Data Guard - Post deployment on Secondary - Show Main Memory"
   ansible.builtin.debug:
     msg:
-      - "Total memory:         {{ main_mem1 }}"
+      - "Total memory:         {{ main_memory }}"
       - "sga_max_size:         {{ ora_sga }}"
       - "pga_aggregate_target: {{ ora_pga }}"
 

--- a/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/04-postdeployment-secondary.yaml
+++ b/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/04-postdeployment-secondary.yaml
@@ -23,7 +23,6 @@
 
   when:
     - ansible_memory_mb.real.total < 4194304
-    - "'pas' not in supported_tiers"
 - name:                                "4.1.3 Oracle Data Guard - Post deployment on Secondary - Set the SGA and PGA Sizes for RAM < 4TB Single Node Deployments"
   ansible.builtin.set_fact:
     main_mem1:                         "{{ ansible_memory_mb.real.total }}"
@@ -31,7 +30,6 @@
     ora_pga:                           "{{ [(pga_temp_l4tb_std | int), 4194304] | min }}"
   when:
     - ansible_memory_mb.real.total < 4194304
-    - "'pas' in supported_tiers"
 
 - name:                                "4.1.3 Oracle Data Guard - Post deployment on Secondary - Show Main Memory"
   ansible.builtin.debug:

--- a/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/04-postdeployment-secondary.yaml
+++ b/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/04-postdeployment-secondary.yaml
@@ -15,6 +15,31 @@
   args:
     chdir:                             "/etc/sap_deployment_automation/dataguard_scripts/"
 
+- name:                                "4.1.3 Oracle Data Guard - Post deployment on Secondary - Set the SGA and PGA Sizes for RAM < 4TB"
+  ansible.builtin.set_fact:
+    main_mem1:                         "{{ ansible_memory_mb.real.total }}"
+    ora_sga:                           "{{ (ansible_memory_mb.real.total * 0.60) | round | int }}"
+    ora_pga:                           "{{ [(pga_temp_l4tb_std | int), 4194304] | min }}"
+
+  when:
+    - ansible_memory_mb.real.total < 4194304
+    - "'pas' not in supported_tiers"
+- name:                                "4.1.3 Oracle Data Guard - Post deployment on Secondary - Set the SGA and PGA Sizes for RAM < 4TB Single Node Deployments"
+  ansible.builtin.set_fact:
+    main_mem1:                         "{{ ansible_memory_mb.real.total }}"
+    ora_sga:                           "{{ (ansible_memory_mb.real.total * 0.75) | round | int }}"
+    ora_pga:                           "{{ [(pga_temp_l4tb_std | int), 4194304] | min }}"
+  when:
+    - ansible_memory_mb.real.total < 4194304
+    - "'pas' in supported_tiers"
+
+- name:                                "4.1.3 Oracle Data Guard - Post deployment on Secondary - Show Main Memory"
+  ansible.builtin.debug:
+    msg:
+      - "Total memory:         {{ main_mem1 }}"
+      - "sga_max_size:         {{ ora_sga }}"
+      - "pga_aggregate_target: {{ ora_pga }}"
+
 - name:                                "4.1.3 Oracle Data Guard - Post deployment on Secondary - Post deployment on Secondary - Show Configure check standby redo logs results"
   ansible.builtin.debug:
     var:                               srl_count.stdout_lines
@@ -67,11 +92,13 @@
     chdir:                             "/etc/sap_deployment_automation/dataguard_scripts/"
 
 - name:                                "4.1.3 Oracle Data Guard - Post deployment on Secondary - Start Data Guard Broker on standby"
-  when:                                node_tier == "oracle-asm"
   become_user:                         "{{ oracle_user_name }}"
   become:                              true
   ansible.builtin.shell: |
                                        sqlplus -s / as sysdba <<EOF
+                                       ALTER SYSTEM SET sga_max_size={{ ora_sga }}M SCOPE=spfile;
+                                       ALTER SYSTEM SET pga_aggregate_target={{ ora_pga }}M SCOPE=spfile;
+                                       ALTER SYSTEM SET use_large_pages=only SCOPE=spfile;
                                        ALTER SYSTEM SET DG_BROKER_START = true;
                                        EXIT;
                                        EOF
@@ -81,12 +108,12 @@
   args:
     chdir:                             "/etc/sap_deployment_automation/dataguard_scripts/"
 
-- name:                                "4.1.3 Oracle Data Guard - Post deployment on Secondary - Post deployment on Secondary - Show Configure standby Data Guard parameters"
+- name:                                "4.1.3 Oracle Data Guard - Post deployment on Secondary - Show Configure standby Data Guard parameters"
   ansible.builtin.debug:
     var:                               dg_standby_config_asm.stdout_lines
     verbosity:                         2
 
-- name:                                "4.1.3 Oracle Data Guard - Post deployment on Secondary - Post deployment on Secondary - Save configure standby Data Guard parameters"
+- name:                                "4.1.3 Oracle Data Guard - Post deployment on Secondary - Save configure standby Data Guard parameters"
   ansible.builtin.copy:
     dest:                              "/etc/sap_deployment_automation/dataguard_scripts/configure_data_guard_standby_{{ ansible_date_time.epoch }}.log"
     content:                           "{{ dg_standby_config_asm.stdout }}"

--- a/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/04-postdeployment-secondary.yaml
+++ b/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/04-postdeployment-secondary.yaml
@@ -20,6 +20,9 @@
     pga_temp_l4tb_dis:                 "{{ ((ansible_memory_mb.real.total * 0.80 ) * 0.2) | round | int }}"
     main_memory:                       "{{ ansible_memory_mb.real.total }}"
     ora_sga:                           "{{ (ansible_memory_mb.real.total * 0.60) | round | int }}"
+
+- name:                                "4.1.3 Oracle Data Guard - Post deployment on Secondary - Set Memory Variables"
+  ansible.builtin.set_fact:
     ora_pga:                           "{{ [(pga_temp_l4tb_dis | int), 4194304] | min }}"
 
 - name:                                "4.1.3 Oracle Data Guard - Post deployment on Secondary - Show Main Memory"

--- a/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/main.yaml
+++ b/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/main.yaml
@@ -51,15 +51,23 @@
                                        - tier != "observer"
   become:                              true
   become_user:                         "{{ oracle_user_name }}"
-
   ansible.builtin.shell:               "orapwd file=/oracle/{{ db_sid | upper }}/{{ ora_version }}/dbs/orapw{{ this_sid }} password='{{ main_password }}' entries=5 format=12 force=y"
   environment:
     ORACLE_SID:                        "{{ this_sid }}"
   args:
-    creates:                           /oracle/{{ db_sid | upper }}/{{ ora_version }}/dbs/orapw{{ this_sid }}
     executable:                        /bin/csh
     chdir:                             "/oracle/{{ db_sid | upper }}/{{ ora_version }}/bin"
   no_log:                              true
+
+- name:                                "4.1.3 Oracle Data Guard: - Set permissions for password file"
+  when:
+                                       - tier != "observer"
+  become:                              true
+  become_user:                         "{{ oracle_user_name }}"
+  ansible.builtin.file:
+    path:                              "/oracle/{{ db_sid | upper }}/{{ ora_version }}/dbs/orapw{{ this_sid }}"
+    mode:                              '0640'
+
 
 - name:                                "4.1.3 Oracle Data Guard: - Validate"
   when:

--- a/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/main.yaml
+++ b/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/main.yaml
@@ -19,6 +19,7 @@
   loop:
     - { mode: '0775', path: '/etc/sap_deployment_automation' }
     - { mode: '0775', path: '/etc/sap_deployment_automation/dataguard_scripts' }
+    - { mode: '0775', path: '/oracle/{{ db_sid | upper }}/{{ ora_version }}/dbs' }
     - { mode: '0775', path: '/oracle/{{ db_sid | upper }}/saptrace' }
     - { mode: '0775', path: '/oracle/{{ db_sid | upper }}/saparch' }
     - { mode: '0775', path: '/oracle/{{ db_sid | upper }}/sapprof' }
@@ -48,14 +49,12 @@
 - name:                                "4.1.3 Oracle Data Guard: - Preparation Create password file"
   when:
                                        - tier != "observer"
-                                       - not dg_configured_flag.stat.exists
   become:                              true
   become_user:                         "{{ oracle_user_name }}"
 
-  ansible.builtin.shell:               "orapwd file=$ORACLE_HOME/dbs/orapw{{ this_sid }} password='{{ main_password }}' entries=5 format=12 force=y"
+  ansible.builtin.shell:               "orapwd file=/oracle/{{ db_sid | upper }}/{{ ora_version }}/dbs/orapw{{ this_sid }} password='{{ main_password }}' entries=5 format=12 force=y"
   environment:
     ORACLE_SID:                        "{{ this_sid }}"
-    ORACLE_HOME:                       "/oracle/{{ db_sid | upper }}/{{ ora_version }}"
   args:
     creates:                           /oracle/{{ db_sid | upper }}/{{ ora_version }}/dbs/orapw{{ this_sid }}
     executable:                        /bin/csh

--- a/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/main.yaml
+++ b/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/main.yaml
@@ -59,6 +59,7 @@
     creates:                           /oracle/{{ db_sid | upper }}/{{ ora_version }}/dbs/orapw{{ this_sid }}
     executable:                        /bin/csh
     chdir:                             "/oracle/{{ db_sid | upper }}/{{ ora_version }}/bin"
+  no_log:                              true
 
 - name:                                "4.1.3 Oracle Data Guard: - Validate"
   when:

--- a/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/main.yaml
+++ b/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/main.yaml
@@ -52,7 +52,7 @@
   become:                              true
   become_user:                         "{{ oracle_user_name }}"
 
-  ansible.builtin.shell:               "orapwd file=$ORACLE_HOME/dbs/orapw{{ db_sid | upper }}_STDBY password='{{ main_password }}' entries=5 format=12 force=y"
+  ansible.builtin.shell:               "orapwd file=$ORACLE_HOME/dbs/orapw{{ this_sid }} password='{{ main_password }}' entries=5 format=12 force=y"
   environment:
     ORACLE_SID:                        "{{ this_sid }}"
     ORACLE_HOME:                       "/oracle/{{ db_sid | upper }}/{{ ora_version }}"

--- a/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/main.yaml
+++ b/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/main.yaml
@@ -67,7 +67,8 @@
   ansible.builtin.file:
     path:                              "/oracle/{{ db_sid | upper }}/{{ ora_version }}/dbs/orapw{{ this_sid }}"
     mode:                              '0640'
-
+    owner:                             "{{ oracle_user_name }}"
+    group:                             "oinstall"
 
 - name:                                "4.1.3 Oracle Data Guard: - Validate"
   when:

--- a/deploy/ansible/roles-db/4.1.4-oracle-data-guard-observer/tasks/configure.yaml
+++ b/deploy/ansible/roles-db/4.1.4-oracle-data-guard-observer/tasks/configure.yaml
@@ -263,7 +263,7 @@
   become:                              true
   become_user:                         "{{ oracle_user_name }}"
   ansible.builtin.shell: |
-                                       $ORACLE_HOME/OPatch/opatch apply -silent
+                                       $ORACLE_HOME/OPatch/opatch napply -silent
   register:                            orainstaller_results
   failed_when:                         orainstaller_results.rc >= 2              # installer returns rc=1 (exited with warning) by default when run is silent mode as the oratab file is created only after running the root.sh
   environment:                         "{{ oracle_env }}"

--- a/deploy/ansible/roles-db/4.1.4-oracle-data-guard-observer/tasks/configure.yaml
+++ b/deploy/ansible/roles-db/4.1.4-oracle-data-guard-observer/tasks/configure.yaml
@@ -263,7 +263,7 @@
 #   become:                              true
 #   become_user:                         "{{ oracle_user_name }}"
 #   ansible.builtin.shell: |
-#                                        $ORACLE_HOME/OPatch/opatch napply -silent
+#                                        $ORACLE_HOME/OPatch/opatch apply -silent
 #   register:                            orainstaller_results
 #   failed_when:                         orainstaller_results.rc >= 2              # installer returns rc=1 (exited with warning) by default when run is silent mode as the oratab file is created only after running the root.sh
 #   environment:                         "{{ oracle_env }}"

--- a/deploy/ansible/roles-db/4.1.4-oracle-data-guard-observer/tasks/configure.yaml
+++ b/deploy/ansible/roles-db/4.1.4-oracle-data-guard-observer/tasks/configure.yaml
@@ -166,180 +166,180 @@
 # | Post processing                                                     |
 # +------------------------------------4--------------------------------------*/
 
-- name:                                "4.1.4 Oracle Data Guard - Observer - Post Processing - Run orainstRoot.sh exists"
-  ansible.builtin.stat:
-    path:                              /oracle/oraInventory/orainstRoot.sh
-  register:                            orainstroot_exists
+# - name:                                "4.1.4 Oracle Data Guard - Observer - Post Processing - Run orainstRoot.sh exists"
+#   ansible.builtin.stat:
+#     path:                              /oracle/oraInventory/orainstRoot.sh
+#   register:                            orainstroot_exists
 
-- name:                                "4.1.4 Oracle Data Guard - Observer - Post Processing - Run orainstRoot.sh"
-  when:                                orainstroot_exists.stat.exists
-  block:
+# - name:                                "4.1.4 Oracle Data Guard - Observer - Post Processing - Run orainstRoot.sh"
+#   when:                                orainstroot_exists.stat.exists
+#   block:
 
-    - name:                            "4.1.4 Oracle Data Guard - Observer - Post Processing - Run orainstRoot.sh"
-      become:                          true
-      become_user:                     root
-      ansible.builtin.shell:           /oracle/oraInventory/orainstRoot.sh
-      register:                        orainstRoot_results
-      environment:                     "{{ oracle_env }}"
+#     - name:                            "4.1.4 Oracle Data Guard - Observer - Post Processing - Run orainstRoot.sh"
+#       become:                          true
+#       become_user:                     root
+#       ansible.builtin.shell:           /oracle/oraInventory/orainstRoot.sh
+#       register:                        orainstRoot_results
+#       environment:                     "{{ oracle_env }}"
 
-    - name:                            "4.1.4 Oracle Data Guard - Observer - Show orainstRoot output"
-      ansible.builtin.debug:
-        var:                           orainstRoot_results.stdout
-        verbosity:                     2
+#     - name:                            "4.1.4 Oracle Data Guard - Observer - Show orainstRoot output"
+#       ansible.builtin.debug:
+#         var:                           orainstRoot_results.stdout
+#         verbosity:                     2
 
-    - name:                            "4.1.4 Oracle Data Guard - Observer - Copy orainstRoot output to orainstRoot.log"
-      ansible.builtin.copy:
-        dest:                          "/etc/sap_deployment_automation/observer/orainstRoot.log"
-        content:                       "{{ orainstRoot_results.stdout }}"
-        owner:                         "{{ oracle_user_name }}"
-        group:                         oinstall
-        mode:                          '0655'
-      when:                            orainstRoot_results.stdout is defined
-# /*---------------------------------------------------------------------------8
+#     - name:                            "4.1.4 Oracle Data Guard - Observer - Copy orainstRoot output to orainstRoot.log"
+#       ansible.builtin.copy:
+#         dest:                          "/etc/sap_deployment_automation/observer/orainstRoot.log"
+#         content:                       "{{ orainstRoot_results.stdout }}"
+#         owner:                         "{{ oracle_user_name }}"
+#         group:                         oinstall
+#         mode:                          '0655'
+#       when:                            orainstRoot_results.stdout is defined
+# # /*---------------------------------------------------------------------------8
 
-- name:                                "4.1.4 Oracle Data Guard - Observer - Post Processing - Check if root.sh exists"
-  ansible.builtin.stat:
-    path:                              /oracle/{{ db_sid | upper }}/{{ ora_version }}/root.sh
-  register:                            root_exists
+# - name:                                "4.1.4 Oracle Data Guard - Observer - Post Processing - Check if root.sh exists"
+#   ansible.builtin.stat:
+#     path:                              /oracle/{{ db_sid | upper }}/{{ ora_version }}/root.sh
+#   register:                            root_exists
 
-- name:                                "4.1.4 Oracle Data Guard - Observer - Post Processing - Run root.sh"
-  when:                                root_exists.stat.exists
-  block:
-    - name:                            "4.1.4 Oracle Data Guard - Observer - Post Processing - Run Root.sh"
-      become:                          true
-      become_user:                     root
-      ansible.builtin.shell:           /oracle/{{ db_sid | upper }}/{{ ora_version }}/root.sh
-      register:                        rootscript_results
-      environment:                     "{{ oracle_env }}"
+# - name:                                "4.1.4 Oracle Data Guard - Observer - Post Processing - Run root.sh"
+#   when:                                root_exists.stat.exists
+#   block:
+#     - name:                            "4.1.4 Oracle Data Guard - Observer - Post Processing - Run Root.sh"
+#       become:                          true
+#       become_user:                     root
+#       ansible.builtin.shell:           /oracle/{{ db_sid | upper }}/{{ ora_version }}/root.sh
+#       register:                        rootscript_results
+#       environment:                     "{{ oracle_env }}"
 
-    - name:                            "4.1.4 Oracle Data Guard - Observer - Show root.sh script output"
-      ansible.builtin.debug:
-        var:                           rootscript_results.stdout
-        verbosity:                     2
+#     - name:                            "4.1.4 Oracle Data Guard - Observer - Show root.sh script output"
+#       ansible.builtin.debug:
+#         var:                           rootscript_results.stdout
+#         verbosity:                     2
 
-    - name:                            "4.1.4 Oracle Data Guard - Observer - Copy root.sh script output log to rootscript.log"
-      ansible.builtin.copy:
-        dest:                          "/etc/sap_deployment_automation/observer/rootscript.log"
-        content:                       "{{ rootscript_results.stdout }}"
-        owner:                         "{{ oracle_user_name }}"
-        group:                         oinstall
-        mode:                          '0655'
-      when:                            rootscript_results.stdout is defined
+#     - name:                            "4.1.4 Oracle Data Guard - Observer - Copy root.sh script output log to rootscript.log"
+#       ansible.builtin.copy:
+#         dest:                          "/etc/sap_deployment_automation/observer/rootscript.log"
+#         content:                       "{{ rootscript_results.stdout }}"
+#         owner:                         "{{ oracle_user_name }}"
+#         group:                         oinstall
+#         mode:                          '0655'
+#       when:                            rootscript_results.stdout is defined
 
-- name:                                "4.1.4 Oracle Data Guard - Observer - Remove old OPatch"
-  ansible.builtin.file:
-    path:                              "/oracle/{{ db_sid | upper }}/{{ ora_version }}/OPatch"
-    state:                             absent
+# - name:                                "4.1.4 Oracle Data Guard - Observer - Remove old OPatch"
+#   ansible.builtin.file:
+#     path:                              "/oracle/{{ db_sid | upper }}/{{ ora_version }}/OPatch"
+#     state:                             absent
 
-- name:                                "4.1.4 Oracle Data Guard - Observer - Copy OPatch from downloads"
-  ansible.builtin.copy:
-    src:                               "{{ target_media_location }}/SBP/OPATCH/OPatch"
-    dest:                              "/oracle/{{ db_sid | upper }}/{{ ora_version }}"
-    remote_src:                        true
-    owner:                             "{{ oracle_user_name }}"
-    group:                             oinstall
-    mode:                              '0655'
+# - name:                                "4.1.4 Oracle Data Guard - Observer - Copy OPatch from downloads"
+#   ansible.builtin.copy:
+#     src:                               "{{ target_media_location }}/SBP/OPATCH/OPatch"
+#     dest:                              "/oracle/{{ db_sid | upper }}/{{ ora_version }}"
+#     remote_src:                        true
+#     owner:                             "{{ oracle_user_name }}"
+#     group:                             oinstall
+#     mode:                              '0655'
 
-- name:                                "4.1.4 Oracle Data Guard - Observer - Set folder permissions for OPatch"
-  ansible.builtin.file:
-    path:                              "/oracle/{{ db_sid | upper }}/{{ ora_version }}/OPatch"
-    owner:                             "{{ oracle_user_name }}"
-    group:                             oinstall
-    recurse:                           true
-    mode:                              '0755'
+# - name:                                "4.1.4 Oracle Data Guard - Observer - Set folder permissions for OPatch"
+#   ansible.builtin.file:
+#     path:                              "/oracle/{{ db_sid | upper }}/{{ ora_version }}/OPatch"
+#     owner:                             "{{ oracle_user_name }}"
+#     group:                             oinstall
+#     recurse:                           true
+#     mode:                              '0755'
 
-- name:                                "4.1.4 Oracle Data Guard - Observer - Find Patch ID for SBP_DBRU"
-  become:                              true
-  become_user:                         root
-  ansible.builtin.find:
-    paths:                             "{{ target_media_location }}/SBP/"
-    patterns:                          "{{ bom.patch_information.SBP_DBRU }}"
-    file_type:                         directory
-    recurse:                           true
-  register:                            patch_SBP_DBRU_directory
+# - name:                                "4.1.4 Oracle Data Guard - Observer - Find Patch ID for SBP_DBRU"
+#   become:                              true
+#   become_user:                         root
+#   ansible.builtin.find:
+#     paths:                             "{{ target_media_location }}/SBP/"
+#     patterns:                          "{{ bom.patch_information.SBP_DBRU }}"
+#     file_type:                         directory
+#     recurse:                           true
+#   register:                            patch_SBP_DBRU_directory
 
-- name:                                "4.1.4 Oracle Data Guard - Observer - Execute OPatch for SBP_DBRU"
-  when:                                patch_SBP_DBRU_directory.matched == 1
-  become:                              true
-  become_user:                         "{{ oracle_user_name }}"
-  ansible.builtin.shell: |
-                                       $ORACLE_HOME/OPatch/opatch napply -silent
-  register:                            orainstaller_results
-  failed_when:                         orainstaller_results.rc >= 2              # installer returns rc=1 (exited with warning) by default when run is silent mode as the oratab file is created only after running the root.sh
-  environment:                         "{{ oracle_env }}"
-  args:
-    chdir:                             "{{ patch_SBP_DBRU_directory.files[0].path }}"
-    creates:                           "/etc/sap_deployment_automation/observer/SBP_DBRU_oracle_installed.txt"
+# - name:                                "4.1.4 Oracle Data Guard - Observer - Execute OPatch for SBP_DBRU"
+#   when:                                patch_SBP_DBRU_directory.matched == 1
+#   become:                              true
+#   become_user:                         "{{ oracle_user_name }}"
+#   ansible.builtin.shell: |
+#                                        $ORACLE_HOME/OPatch/opatch napply -silent
+#   register:                            orainstaller_results
+#   failed_when:                         orainstaller_results.rc >= 2              # installer returns rc=1 (exited with warning) by default when run is silent mode as the oratab file is created only after running the root.sh
+#   environment:                         "{{ oracle_env }}"
+#   args:
+#     chdir:                             "{{ patch_SBP_DBRU_directory.files[0].path }}"
+#     creates:                           "/etc/sap_deployment_automation/observer/SBP_DBRU_oracle_installed.txt"
 
-- name:                                "4.1.4 Oracle Data Guard - Observer - Debug: OPatch SBP_DBRU output"
-  ansible.builtin.debug:
-    msg:                               "OPatch SBP_DBRU output {{ orainstaller_results.stdout }}"
-    verbosity:                         2
-  when:                                orainstaller_results.stdout is defined
+# - name:                                "4.1.4 Oracle Data Guard - Observer - Debug: OPatch SBP_DBRU output"
+#   ansible.builtin.debug:
+#     msg:                               "OPatch SBP_DBRU output {{ orainstaller_results.stdout }}"
+#     verbosity:                         2
+#   when:                                orainstaller_results.stdout is defined
 
-- name:                                "4.1.4 Oracle Data Guard - Observer - Debug installer output log"
-  ansible.builtin.copy:
-    dest:                              "/etc/sap_deployment_automation/observer/SBP_DBRU.log"
-    content:                           "{{ orainstaller_results.stdout }}"
-    owner:                             "{{ oracle_user_name }}"
-    group:                             oinstall
-    mode:                              '0655'
-  when:                                orainstaller_results.stdout is defined
+# - name:                                "4.1.4 Oracle Data Guard - Observer - Debug installer output log"
+#   ansible.builtin.copy:
+#     dest:                              "/etc/sap_deployment_automation/observer/SBP_DBRU.log"
+#     content:                           "{{ orainstaller_results.stdout }}"
+#     owner:                             "{{ oracle_user_name }}"
+#     group:                             oinstall
+#     mode:                              '0655'
+#   when:                                orainstaller_results.stdout is defined
 
-- name:                                "4.1.4 Oracle Data Guard - Observer - Create SBP_DBRU_oracle_installed.txt"
-  ansible.builtin.file:
-    path:                              "/etc/sap_deployment_automation/observer/SBP_DBRU_oracle_installed.txt"
-    state:                             touch
-    mode:                              '0755'
-    owner:                             "{{ oracle_user_name }}"
-    group:                             oinstall
-  when:                                orainstaller_results.rc | default(1) == 0
+# - name:                                "4.1.4 Oracle Data Guard - Observer - Create SBP_DBRU_oracle_installed.txt"
+#   ansible.builtin.file:
+#     path:                              "/etc/sap_deployment_automation/observer/SBP_DBRU_oracle_installed.txt"
+#     state:                             touch
+#     mode:                              '0755'
+#     owner:                             "{{ oracle_user_name }}"
+#     group:                             oinstall
+#   when:                                orainstaller_results.rc | default(1) == 0
 
-- name:                                "4.1.4 Oracle Data Guard - Observer - Find Patch ID for SBP_JDKRU"
-  become:                              true
-  become_user:                         root
-  ansible.builtin.find:
-    paths:                             "{{ target_media_location }}/SBP/"
-    patterns:                          "{{ bom.patch_information.SBP_JDKRU }}"
-    file_type:                         directory
-    recurse:                           true
-  register:                            patch_SBP_JDKRU_directory
+# - name:                                "4.1.4 Oracle Data Guard - Observer - Find Patch ID for SBP_JDKRU"
+#   become:                              true
+#   become_user:                         root
+#   ansible.builtin.find:
+#     paths:                             "{{ target_media_location }}/SBP/"
+#     patterns:                          "{{ bom.patch_information.SBP_JDKRU }}"
+#     file_type:                         directory
+#     recurse:                           true
+#   register:                            patch_SBP_JDKRU_directory
 
-- name:                                "4.1.4 Oracle Data Guard - Observer - Execute OPatch for SBP_JDKRU"
-  when:                                patch_SBP_JDKRU_directory.matched == 1
-  become:                              true
-  become_user:                         "{{ oracle_user_name }}"
-  ansible.builtin.shell: |
-                                       $ORACLE_HOME/OPatch/opatch apply -silent
-  register:                            orainstaller_results
-  failed_when:                         orainstaller_results.rc >= 2              # installer returns rc=1 (exited with warning) by default when run is silent mode as the oratab file is created only after running the root.sh
-  environment:                         "{{ oracle_env }}"
-  args:
-    chdir:                             "{{ patch_SBP_JDKRU_directory.files[0].path }}"
-    creates:                           "/etc/sap_deployment_automation/observer/SBP_JDKRU_oracle_installed.txt"
+# - name:                                "4.1.4 Oracle Data Guard - Observer - Execute OPatch for SBP_JDKRU"
+#   when:                                patch_SBP_JDKRU_directory.matched == 1
+#   become:                              true
+#   become_user:                         "{{ oracle_user_name }}"
+#   ansible.builtin.shell: |
+#                                        $ORACLE_HOME/OPatch/opatch apply -silent
+#   register:                            orainstaller_results
+#   failed_when:                         orainstaller_results.rc >= 2              # installer returns rc=1 (exited with warning) by default when run is silent mode as the oratab file is created only after running the root.sh
+#   environment:                         "{{ oracle_env }}"
+#   args:
+#     chdir:                             "{{ patch_SBP_JDKRU_directory.files[0].path }}"
+#     creates:                           "/etc/sap_deployment_automation/observer/SBP_JDKRU_oracle_installed.txt"
 
-- name:                                "4.1.4 Oracle Data Guard - Observer - Debug installer output log"
-  ansible.builtin.copy:
-    dest:                              "/etc/sap_deployment_automation/observer/SBP_JDKRU.log"
-    content:                           "{{ orainstaller_results.stdout }}"
-    owner:                             "{{ oracle_user_name }}"
-    group:                             oinstall
-    mode:                              '0655'
-  when:                                orainstaller_results.stdout is defined
+# - name:                                "4.1.4 Oracle Data Guard - Observer - Debug installer output log"
+#   ansible.builtin.copy:
+#     dest:                              "/etc/sap_deployment_automation/observer/SBP_JDKRU.log"
+#     content:                           "{{ orainstaller_results.stdout }}"
+#     owner:                             "{{ oracle_user_name }}"
+#     group:                             oinstall
+#     mode:                              '0655'
+#   when:                                orainstaller_results.stdout is defined
 
-- name:                                "4.1.4 Oracle Data Guard - Observer - Debug: OPatch SBP_DBRU output"
-  ansible.builtin.debug:
-    var:                               orainstaller_results.stdout_lines
-    verbosity:                         2
+# - name:                                "4.1.4 Oracle Data Guard - Observer - Debug: OPatch SBP_DBRU output"
+#   ansible.builtin.debug:
+#     var:                               orainstaller_results.stdout_lines
+#     verbosity:                         2
 
-- name:                                "4.1.4 Oracle Data Guard - Observer - Create SBP_JDKRU_oracle_installed.txt"
-  ansible.builtin.file:
-    path:                              "/etc/sap_deployment_automation/observer/SBP_JDKRU_oracle_installed.txt"
-    state:                             touch
-    mode:                              '0755'
-    owner:                             "{{ oracle_user_name }}"
-    group:                             oinstall
-  when:                                orainstaller_results.rc | default(1) == 0
+# - name:                                "4.1.4 Oracle Data Guard - Observer - Create SBP_JDKRU_oracle_installed.txt"
+#   ansible.builtin.file:
+#     path:                              "/etc/sap_deployment_automation/observer/SBP_JDKRU_oracle_installed.txt"
+#     state:                             touch
+#     mode:                              '0755'
+#     owner:                             "{{ oracle_user_name }}"
+#     group:                             oinstall
+#   when:                                orainstaller_results.rc | default(1) == 0
 
 #  SBP_DBRU:                                  37960098
 #  SBP_JDKRU:                                 37860476

--- a/deploy/ansible/roles-os/1.9-kernelparameters/tasks/main.yaml
+++ b/deploy/ansible/roles-os/1.9-kernelparameters/tasks/main.yaml
@@ -142,6 +142,8 @@
         ignoreerrors:                  true
 
     - name:                            "1.9 Kernel parameters - Set limits"
+      when:
+        - node_tier in ["oracle"]
       ansible.builtin.blockinfile:
         path:                          /etc/security/limits.d/99-sap.conf
         insertafter:                   '#@student        -       maxlogins       4'
@@ -160,6 +162,32 @@
                 oracle     hard   nofile    unlimited
                 oracle     soft   nproc     unlimited
                 oracle     hard   nproc     unlimited
+
+    - name:                            "1.9 Kernel parameters - Set limits"
+      when:
+        - node_tier in ["oracle-asm"]
+      ansible.builtin.blockinfile:
+        path:                          /etc/security/limits.d/99-sap.conf
+        insertafter:                   '#@student        -       maxlogins       4'
+        create:                        true
+        mode:                          '0644'
+        state:                         present
+        block: |
+                @oinstall  soft    nproc    unlimited
+                oracle     soft  memlock    unlimited
+                oracle     hard  memlock    unlimited
+                @sapsys    hard    nproc    unlimited
+                @sapsys    soft    nproc    unlimited
+                @dba       hard    nproc    unlimited
+                @dba       soft    nproc    unlimited
+                oracle     soft   nofile    unlimited
+                oracle     hard   nofile    unlimited
+                oracle     soft   nproc     unlimited
+                oracle     hard   nproc     unlimited
+                grid       soft   nofile    unlimited
+                grid       hard   nofile    unlimited
+                grid       soft   nproc     unlimited
+                grid       hard   nproc     unlimited
 
 - name:                                "1.9 Kernel parameters - Set limits for DB2"
   ansible.builtin.blockinfile:

--- a/deploy/ansible/roles-os/1.9-kernelparameters/tasks/main.yaml
+++ b/deploy/ansible/roles-os/1.9-kernelparameters/tasks/main.yaml
@@ -112,6 +112,8 @@
 # Huge pages for Oracle Database VMs
 # SAP Note 1672954 : Usage of hugepages on a Linux system that runs an Oracle database.
 - name:                                "1.9 Kernel parameters - Oracle Specific Parameters"
+  when:
+    - node_tier in ["oracle","oracle-asm","oracle-multi-sid"]
   block:
     - name:                            "1.9 Kernel parameters - Calculate the Huge Pages when RAM < 4TB"
       ansible.builtin.set_fact:
@@ -154,9 +156,10 @@
                 @sapsys    soft    nproc    unlimited
                 @dba       hard    nproc    unlimited
                 @dba       soft    nproc    unlimited
-
-  when:
-    - node_tier in ["oracle","oracle-asm","oracle-multi-sid"]
+                oracle     soft   nofile    unlimited
+                oracle     hard   nofile    unlimited
+                oracle     soft   nproc     unlimited
+                oracle     hard   nproc     unlimited
 
 - name:                                "1.9 Kernel parameters - Set limits for DB2"
   ansible.builtin.blockinfile:

--- a/deploy/ansible/roles-sap/5.1-dbload/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.1-dbload/tasks/main.yaml
@@ -268,7 +268,7 @@
         owner:                         "{{ oracle_user_name }}"
         group:                         oinstall
         mode:                          0640
-        recursive:                     true
+        recurse:                       true
       when:
         - platform in ["ORACLE", "ORACLE-ASM"]
 

--- a/deploy/ansible/roles-sap/5.1-dbload/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.1-dbload/tasks/main.yaml
@@ -262,6 +262,17 @@
       when:
         - platform in ["ORACLE", "ORACLE-ASM"]
 
+    - name:                            "5.1 Database Load  - Ensure the files are owned by oracle user and group to avoid installation failure due to permission issues"
+      ansible.builtin.file:
+        name:                          "/oracle/{{ db_sid | upper }}/{{ ora_version }}/dbs"
+        owner:                         "{{ oracle_user_name }}"
+        group:                         oinstall
+        mode:                          0640
+        recursive:                     true
+      when:
+        - platform in ["ORACLE", "ORACLE-ASM"]
+
+
     - name:                            "4.1.2 Oracle ASM Database Installation "
       when:
         - platform in ["ORACLE-ASM"]
@@ -295,9 +306,9 @@
                                        EOF
           register:                    asm_mount_results
           failed_when:                 false
-          environment:                 "{{ grid_env }}"
+          environment:                 "{{ oracle_env }}"
 
-        - name:                        "4.1.2 Oracle ASM Database Installation - Pre-Create Cleanup: Dismount all ASM diskgroups to evict stale client registrations"
+        - name:                        "4.1.2 Oracle ASM Database Installation - Pre-Create Cleanup: Dismount all ASM disk groups to evict stale client registrations"
           become_user:                 "{{ grid_user_name }}"
           become:                      true
           ansible.builtin.shell: |
@@ -315,7 +326,7 @@
           ansible.builtin.pause:
             seconds:                   10
 
-        - name:                        "4.1.2 Oracle ASM Database Installation - Pre-Create Cleanup: Mount all ASM diskgroups after stale client eviction"
+        - name:                        "4.1.2 Oracle ASM Database Installation - Pre-Create Cleanup: Mount all ASM disk groups after stale client eviction"
           become_user:                 "{{ grid_user_name }}"
           become:                      true
           ansible.builtin.shell: |
@@ -364,12 +375,12 @@
           become:                      true
           ansible.builtin.shell: |
                                         sqlplus -S / as sysdba <<EOF
-                                        SHUTDOWN ABORT;
+                                        SHUTDOWN IMMEDIATE;
                                         EXIT;
                                         EOF
           register:                    asm_shutdown_results
           failed_when:                 false
-          environment:                 "{{ grid_env }}"
+          environment:                 "{{ oracle_env }}"
         # Import this task only if the tier is ora.
     - name:                            "5.1 Database Load  - Import Oracle specific tasks"
       ansible.builtin.import_tasks:    oracle.yaml

--- a/deploy/ansible/vars/admin-accounts.yml
+++ b/deploy/ansible/vars/admin-accounts.yml
@@ -358,7 +358,7 @@ admin_users:
     groups:       ["oper", "sapsys", "sapinst", "asmdba", "dba", "asmadmin", "asmoper"]
     sudoers_role: "admin_no_password"
     password:     "{{ main_password }}"
-    shell:        /bin/csh
+    shell:        /bin/bash
     state:        present
     tier:         ora
     node_tier:    oracle
@@ -371,7 +371,7 @@ admin_users:
     groups:       ["oper","sapsys","sapinst","asmdba","dba","asmadmin","asmoper"]
     sudoers_role: "admin_no_password"
     password:     "{{ main_password }}"
-    shell:        /bin/csh
+    shell:        /bin/bash
     state:        present
     tier:         ora
     node_tier:    observer
@@ -400,7 +400,7 @@ admin_users:
     groups:       ["oper","sapsys","sapinst","asmdba","dba","asmadmin","asmoper"]
     sudoers_role: "admin_no_password"
     password:     "{{ main_password }}"
-    shell:        /bin/csh
+    shell:        /bin/bash
     state:        present
     tier:         ora
     node_tier:    oracle-multi-sid
@@ -428,7 +428,7 @@ admin_users:
     groups:       ["oper", "sapsys", "sapinst", "asmdba", "dba", "asmadmin", "asmoper"]
     sudoers_role: "admin_no_password"
     password:     "{{ main_password }}"
-    shell:        /bin/csh
+    shell:        /bin/bash
     state:        present
     tier:         ora
     node_tier:    oracle-asm
@@ -441,7 +441,7 @@ admin_users:
     groups:       ["oper", "sapsys", "sapinst", "asmdba", "dba", "asmadmin", "asmoper"]
     sudoers_role: "admin_no_password"
     password:     "{{ main_password }}"
-    shell:        /bin/csh
+    shell:        /bin/bash
     state:        present
     tier:         ora
     node_tier:    oracle-asm
@@ -470,7 +470,7 @@ admin_users:
     groups:       ["oper", "sapsys", "sapinst", "asmdba", "dba", "asmadmin", "asmoper"]
     sudoers_role: "admin_no_password"
     password:     "{{ main_password }}"
-    shell:        /bin/csh
+    shell:        /bin/bash
     state:        present
     tier:         ora
     node_tier:    observer

--- a/deploy/scripts/pipeline_scripts/helper.sh
+++ b/deploy/scripts/pipeline_scripts/helper.sh
@@ -67,6 +67,7 @@ function print_banner() {
     local padding_title=$(((width - ${#title}) / 2))
     local padding_message=$(((width - ${#message}) / 2))
     local padding_secondary_message=$(((width - ${#secondary_message}) / 2))
+    local padding_tertiary_message=$(((width - ${#tertiary_message}) / 2))
 
     local centered_title
     local centered_message
@@ -105,7 +106,7 @@ function getVariableFromVariableGroup() {
 	local environment_file_name="$3"
 	local environment_variable_name="$4"
 	local variable_value
-	# az pipelines variable-group throws a TF401019 error if the current directory is not the repository root, 
+	# az pipelines variable-group throws a TF401019 error if the current directory is not the repository root,
 	#		so change to the repository root for this command and then change back to the original directory when done.
 	pushd "$BUILD_SOURCESDIRECTORY" > /dev/null
 
@@ -126,7 +127,7 @@ function saveVariableInVariableGroup() {
 	local variable_name="$2"
 	local variable_value="$3"
 	local local_return_code=0
-	# az pipelines variable-group throws a TF401019 error if the current directory is not the repository root, 
+	# az pipelines variable-group throws a TF401019 error if the current directory is not the repository root,
 	#		so change to the repository root for this command and then change back to the original directory when done.
 	pushd "$BUILD_SOURCESDIRECTORY" > /dev/null
 
@@ -330,7 +331,7 @@ function get_variable_group_id() {
 	local variable_group_name="$1"
 	local variable_group_id
 	var_name="$2"
-	# az pipelines variable-group throws a TF401019 error if the current directory is not the repository root, 
+	# az pipelines variable-group throws a TF401019 error if the current directory is not the repository root,
 	#		so change to the repository root for this command and then change back to the original directory when done.
 	pushd "$BUILD_SOURCESDIRECTORY" > /dev/null
 

--- a/deploy/scripts/pipeline_scripts/v1/01-webapp-configuration.sh
+++ b/deploy/scripts/pipeline_scripts/v1/01-webapp-configuration.sh
@@ -81,7 +81,7 @@ printf "**Configure authentication**\n" >>"$BUILD_REPOSITORY_LOCALPATH/Web Appli
 
 printf "\n\n" >>"$BUILD_REPOSITORY_LOCALPATH/Web Application Configuration.md"
 
-printf "az ad app update --id %s --web-home-page-url https://%s.azurewebsites.net --web-redirect-uris https://%s.azurewebsites.net/ https://%s.azurewebsites.net/.auth/login/aad/callback\n\n" "$APP_REGISTRATION_APP_ID" "$APP_SERVICE_NAME" "$APP_SERVICE_NAME" "$APP_SERVICE_NAME" >>"$BUILD_REPOSITORY_LOCALPATH/Web Application Configuration.md"
+printf "az ad app update --id %s --enable-id-token-issuance true --web-home-page-url https://%s.azurewebsites.net --web-redirect-uris https://%s.azurewebsites.net/ https://%s.azurewebsites.net/.auth/login/aad/callback\n\n" "$APP_REGISTRATION_APP_ID" "$APP_SERVICE_NAME" "$APP_SERVICE_NAME" "$APP_SERVICE_NAME" >>"$BUILD_REPOSITORY_LOCALPATH/Web Application Configuration.md"
 
 printf "\n" >>"$BUILD_REPOSITORY_LOCALPATH/Web Application Configuration.md"
 printf "az role assignment create --assignee %s --role reader --subscription %s --scope /subscriptions/%s\n" "$APP_REGISTRATION_APP_ID" "$ARM_SUBSCRIPTION_ID" "$ARM_SUBSCRIPTION_ID" >>"$BUILD_REPOSITORY_LOCALPATH/Web Application Configuration.md"

--- a/deploy/scripts/pipeline_scripts/v2/01-webapp-configuration.sh
+++ b/deploy/scripts/pipeline_scripts/v2/01-webapp-configuration.sh
@@ -87,7 +87,7 @@ printf "**Configure authentication**\n" >>"$output_file"
 
 printf "\n\n" >>"$output_file"
 
-printf "az ad app update --id %s --web-home-page-url https://%s.azurewebsites.net --web-redirect-uris https://%s.azurewebsites.net/ https://%s.azurewebsites.net/.auth/login/aad/callback\n\n" "$APP_REGISTRATION_APP_ID" "$APP_SERVICE_NAME" "$APP_SERVICE_NAME" "$APP_SERVICE_NAME" >>"$output_file"
+printf "az ad app update --id %s --enable-id-token-issuance true --web-home-page-url https://%s.azurewebsites.net --web-redirect-uris https://%s.azurewebsites.net/ https://%s.azurewebsites.net/.auth/login/aad/callback\n\n" "$APP_REGISTRATION_APP_ID" "$APP_SERVICE_NAME" "$APP_SERVICE_NAME" "$APP_SERVICE_NAME" >>"$output_file"
 
 printf "\n" >>"$output_file"
 printf "az role assignment create --assignee %s --role reader --subscription %s --scope /subscriptions/%s\n" "$APP_REGISTRATION_APP_ID" "$ARM_SUBSCRIPTION_ID" "$ARM_SUBSCRIPTION_ID" >>"$output_file"

--- a/deploy/scripts/pipeline_scripts/v2/05-DB-and-SAP-installation-prepare.sh
+++ b/deploy/scripts/pipeline_scripts/v2/05-DB-and-SAP-installation-prepare.sh
@@ -105,7 +105,7 @@ if [ "$PLATFORM" == "devops" ]; then
 		ARM_USE_MSI=true
 		export ARM_USE_MSI
 	fi
-
+s
 	LogonToAzure "${USE_MSI:-true}"
 	return_code=$?
 	if [ 0 != $return_code ]; then
@@ -125,13 +125,12 @@ if is_valid_id "$APPLICATION_CONFIGURATION_ID" "/providers/Microsoft.AppConfigur
 	key_vault_id=$(getVariableFromApplicationConfiguration "$APPLICATION_CONFIGURATION_ID" "${WORKLOAD_ZONE_NAME}_KeyVaultResourceId" "${WORKLOAD_ZONE_NAME}")
 	key_vault=$(echo "$key_vault_id" | cut -d'/' -f9)
 	key_vault_subscription_id=$(echo "$key_vault_id" | cut -d'/' -f3)
+	az account set --subscription "$key_vault_subscription_id" --output none --only-show-errors
 
-	tfstate_resource_id=$(getVariableFromApplicationConfiguration "$APPLICATION_CONFIGURATION_ID" "${CONTROL_PLANE_NAME}_TerraformRemoteStateStorageAccountId" "${CONTROL_PLANE_NAME}")
-	tfstate_subscription_id=$(echo "$tfstate_resource_id" | cut -d'/' -f3)
 fi
 
+if [ ! -v APPLICATION_CONFIGURATION_ID ]; then
 
-az account set --subscription "$key_vault_subscription_id" --output none --only-show-errors
 
 echo "SID:                                 ${SID}"
 echo "Workload Zone Name:                  $WORKLOAD_ZONE_NAME"
@@ -159,8 +158,6 @@ else
 	fi
 	new_parameters="${EXTRA_PARAMETERS:-''} $PIPELINE_EXTRA_PARAMETERS"
 fi
-
-az account set --subscription "$tfstate_subscription_id" --output none --only-show-errors
 
 echo "##vso[task.setvariable variable=FOLDER;isOutput=true]$CONFIG_REPO_PATH/SYSTEM/$SAP_SYSTEM_CONFIGURATION_NAME"
 echo "##vso[task.setvariable variable=HOSTS;isOutput=true]${SID}_hosts.yaml"

--- a/deploy/scripts/pipeline_scripts/v2/05-DB-and-SAP-installation-prepare.sh
+++ b/deploy/scripts/pipeline_scripts/v2/05-DB-and-SAP-installation-prepare.sh
@@ -105,7 +105,7 @@ if [ "$PLATFORM" == "devops" ]; then
 		ARM_USE_MSI=true
 		export ARM_USE_MSI
 	fi
-s
+
 	LogonToAzure "${USE_MSI:-true}"
 	return_code=$?
 	if [ 0 != $return_code ]; then
@@ -129,7 +129,18 @@ if is_valid_id "$APPLICATION_CONFIGURATION_ID" "/providers/Microsoft.AppConfigur
 
 fi
 
-if [ ! -v APPLICATION_CONFIGURATION_ID ]; then
+if [ -z "$key_vault" ]; then
+	if [ -v KEYVAULT ]; then
+		key_vault=$KEYVAULT
+	else
+		echo "##vso[task.logissue type=error]Key Vault name is not defined."
+		exit 2
+	fi
+	key_vault_id=$(az graph query -q "Resources | join kind=leftouter (ResourceContainers | where type=='microsoft.resources/subscriptions' | project subscription=name, subscriptionId) on subscriptionId | where name == '$key_vault' | project id, name, subscription" --query data[0].id --output tsv)
+	key_vault_subscription_id=$(echo "$key_vault_id" | cut -d'/' -f3)
+	az account set --subscription "$key_vault_subscription_id" --output none --only-show-errors
+
+fi
 
 
 echo "SID:                                 ${SID}"

--- a/deploy/scripts/pipeline_scripts/v2/10-remover-terraform-system.sh
+++ b/deploy/scripts/pipeline_scripts/v2/10-remover-terraform-system.sh
@@ -318,27 +318,6 @@ else
         git pull -q origin "$GITHUB_REF_NAME"
     fi
     output_file="readme.md"
-    now=$(date +"%d of %b %Y at %H:%M:%S")
-    {
-        printf "**SAP System Infrastructure Removal**\n\n\n" >"$output_file"
-        printf "The SAP system infrastructure defined in %s has been removed on %s. The following files have been deleted from the repository:\n\n" "$SAP_SYSTEM_TFVARS_FILENAME" "$now" >>"$output_file"
-        if [ -f "sap-parameters.yaml" ]; then
-            printf "\t sap-parameters.yaml\n" >>"$output_file"
-        fi
-        if [ -f "${SID}_hosts.yaml" ]; then
-            printf "\t ${SID}_hosts.yaml\n" >>"$output_file"
-        fi
-        if [ -f "${SID}_inventory.md" ]; then
-            printf "\t ${SID}_inventory.md\n" >>"$output_file"
-        fi
-        if [ -f "${SID}_virtual_machines.json" ]; then
-            printf "\t ${SID}_virtual_machines.json\n" >>"$output_file"
-        fi
-        if [ -d "logs" ]; then
-            printf "\t logs/ (directory)\n" >>"$output_file"
-        fi
-    }
-
 
     # Clean up untracked files and directories, including ignored files, to ensure a clean working directory
     git clean -d -f -X
@@ -377,6 +356,28 @@ else
         git add "readme.md"
         changed=1
     fi
+
+    now=$(date +"%d of %b %Y at %H:%M:%S")
+    {
+        printf "**SAP System Infrastructure Removal**\n\n\n" >"$output_file"
+        printf "The SAP system infrastructure defined in %s has been removed on %s. The following files have been deleted from the repository:\n\n" "$SAP_SYSTEM_TFVARS_FILENAME" "$now" >>"$output_file"
+        if [ -f "sap-parameters.yaml" ]; then
+            printf "\t sap-parameters.yaml\n" >>"$output_file"
+        fi
+        if [ -f "${SID}_hosts.yaml" ]; then
+            printf "\t ${SID}_hosts.yaml\n" >>"$output_file"
+        fi
+        if [ -f "${SID}_inventory.md" ]; then
+            printf "\t ${SID}_inventory.md\n" >>"$output_file"
+        fi
+        if [ -f "${SID}_virtual_machines.json" ]; then
+            printf "\t ${SID}_virtual_machines.json\n" >>"$output_file"
+        fi
+        if [ -d "logs" ]; then
+            printf "\t logs/ (directory)\n" >>"$output_file"
+        fi
+    }
+
 
     if [ -f "${SID}_inventory.md" ]; then
         git rm --ignore-unmatch -q "${SID}_inventory.md"
@@ -438,7 +439,8 @@ else
         if [ "$PLATFORM" == "github" ]; then
             cat "${output_file}" >>"${GITHUB_STEP_SUMMARY}"
         else
-            echo "##vso[task.uploadsummary]${output_file}"
+					  sudo cp "readme.md" "$AGENT_TEMPDIRECTORY/readme.md"
+						echo "##vso[task.addattachment type=Distributedtask.Core.Summary;name=${SID}.md;]$AGENT_TEMPDIRECTORY/readme.md"
         fi
     fi
 


### PR DESCRIPTION
This pull request introduces several enhancements and fixes to the Oracle Data Guard Ansible roles, focusing on improving database instance management, environment variable handling, and configuration reliability. The main themes are improved handling of Oracle SID and environment variables, streamlined and more robust instance restart logic, and better status reporting and configuration steps for both primary and secondary nodes.

**Key changes include:**

**Oracle SID and Environment Variable Handling:**
- Introduced the `this_sid` variable to correctly set `ORACLE_SID` and related environment variables, ensuring the correct SID is used on both primary and standby nodes. (`deploy/ansible/roles-db/4.1.2-ora-asm-db-install/tasks/main.yaml`) [[1]](diffhunk://#diff-437852f6b1ef772346aec5fb8bff94557e814042386050cb8c2bc59999c8b9feR110-R114) [[2]](diffhunk://#diff-437852f6b1ef772346aec5fb8bff94557e814042386050cb8c2bc59999c8b9feL127-R136) [[3]](diffhunk://#diff-437852f6b1ef772346aec5fb8bff94557e814042386050cb8c2bc59999c8b9feL146-R155)

**Instance Restart and Lock File Management:**
- Refactored primary instance restart logic to use a shared task file, consolidating steps for shutting down, cleaning up, and starting the instance, and ensuring proper removal of lock files (`lk*` instead of `ls*`). (`deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/00-restart-instance.yaml`, `deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/00-validate-primary.yaml`) [[1]](diffhunk://#diff-df22a5a4972abf24b28ea32f7574741486c801cb74514034999b43008eeffea7R44-R72) [[2]](diffhunk://#diff-df22a5a4972abf24b28ea32f7574741486c801cb74514034999b43008eeffea7L114-L118) [[3]](diffhunk://#diff-daacaef627f8c1910dac5ef2441fcaabe273409f7780c19ac3c4c6885cb70714R60-R91)

**Status Reporting and Validation Improvements:**
- Enhanced status checks and debug output for primary and secondary nodes, making it clearer when the instance needs mounting, is open, or is in an exclusive state. (`deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/00-validate-primary.yaml`, `deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/00-validate-secondary.yaml`) [[1]](diffhunk://#diff-daacaef627f8c1910dac5ef2441fcaabe273409f7780c19ac3c4c6885cb70714R60-R91) [[2]](diffhunk://#diff-daacaef627f8c1910dac5ef2441fcaabe273409f7780c19ac3c4c6885cb70714R125-R132) [[3]](diffhunk://#diff-daacaef627f8c1910dac5ef2441fcaabe273409f7780c19ac3c4c6885cb70714L225-R185) [[4]](diffhunk://#diff-503ea98fdcc4b393599138a8c093675b9900b39ab4fa30c3d8d40deb1f5040d0L72-R80)

**Configuration and Listener Management:**
- Added steps to remove and redeploy `tnsnames.ora` before deployment and to explicitly reload the Oracle listener after configuration changes, improving reliability of connectivity. (`deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/01-prepare-primary.yaml`) [[1]](diffhunk://#diff-6edb00c35a78e94f6ad5e26fbb6ce38fa1c763807eb5a945f1b3380e9dafe34bR51-R55) [[2]](diffhunk://#diff-6edb00c35a78e94f6ad5e26fbb6ce38fa1c763807eb5a945f1b3380e9dafe34bR64-R74)

**General Fixes and Miscellaneous:**
- Updated directory creation to be recursive for Oracle base directories. (`deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/00-validate-secondary.yaml`)
- Added a changelog entry for Oracle HA configuration updates for non-ASM deployments. (`CHANGELOG/v3.21.0.0/CHANGELOG.md`)## Problem
<Please describe what problem this PR is trying to resolve>

## Solution
<Please elaborate the solution for the problem>

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>