### PR TITLE
Refactor Docker image build and validation workflow

### DIFF
--- a/.github/workflows/container-build.yaml
+++ b/.github/workflows/container-build.yaml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
         with:
           egress-policy: audit
 
@@ -43,11 +43,13 @@ jobs:
 
       - name: Determine package versions
         id: versions
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          yq_version=$(python3 -c 'import json, urllib.request; print(json.load(urllib.request.urlopen("https://api.github.com/repos/mikefarah/yq/releases/latest"))["tag_name"])')
-          echo "yq=${yq_version}" >> "$GITHUB_OUTPUT"
+          yq_version=$(gh api https://api.github.com/repos/mikefarah/yq/releases/latest | jq '.name' -r)
+          echo "yq=$yq_version" >> "$GITHUB_OUTPUT"
 
-          tf_version=$(python3 -c 'import json, re, urllib.request; versions=json.load(urllib.request.urlopen("https://releases.hashicorp.com/terraform/index.json"))["versions"]; stable=[v for v in versions if re.fullmatch(r"\d+\.\d+\.\d+", v)]; print(sorted(stable, key=lambda v: tuple(int(p) for p in v.split(".")))[-1])')
+          tf_version=$(curl -s https://releases.hashicorp.com/terraform/index.json | jq -r '.versions | keys[]' | grep -Ev 'alpha|beta|rc' | sort -V | tail -n 1)
           echo "tf=${tf_version}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
@@ -86,7 +88,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
         with:
           egress-policy: audit
 
@@ -95,11 +97,13 @@ jobs:
 
       - name: Determine package versions
         id: versions
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          yq_version=$(python3 -c 'import json, urllib.request; print(json.load(urllib.request.urlopen("https://api.github.com/repos/mikefarah/yq/releases/latest"))["tag_name"])')
-          echo "yq=${yq_version}" >> "$GITHUB_OUTPUT"
+          yq_version=$(gh api https://api.github.com/repos/mikefarah/yq/releases/latest | jq '.name' -r)
+          echo "yq=$yq_version" >> "$GITHUB_OUTPUT"
 
-          tf_version=$(python3 -c 'import json, re, urllib.request; versions=json.load(urllib.request.urlopen("https://releases.hashicorp.com/terraform/index.json"))["versions"]; stable=[v for v in versions if re.fullmatch(r"\d+\.\d+\.\d+", v)]; print(sorted(stable, key=lambda v: tuple(int(p) for p in v.split(".")))[-1])')
+          tf_version=$(curl -s https://releases.hashicorp.com/terraform/index.json | jq -r '.versions | keys[]' | grep -Ev 'alpha|beta|rc' | sort -V | tail -n 1)
           echo "tf=${tf_version}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx

--- a/.github/workflows/container-build.yaml
+++ b/.github/workflows/container-build.yaml
@@ -9,78 +9,134 @@ name: Build image
 on:
   push:
     branches:
-      - "main"
+      - main
+      - "development-*"
     tags:
       - "v*.*.*.*"
   pull_request:
     branches:
-      - "main"
+      - main
+      - "development-*"
   workflow_dispatch:
-  schedule:
-    - cron: "37 4 1 * *"
+
+permissions:
+  contents: read
 
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  Build:
+  validate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Determine package versions
+        id: versions
+        run: |
+          yq_version=$(python3 -c 'import json, urllib.request; print(json.load(urllib.request.urlopen("https://api.github.com/repos/mikefarah/yq/releases/latest"))["tag_name"])')
+          echo "yq=${yq_version}" >> "$GITHUB_OUTPUT"
+
+          tf_version=$(python3 -c 'import json, re, urllib.request; versions=json.load(urllib.request.urlopen("https://releases.hashicorp.com/terraform/index.json"))["versions"]; stable=[v for v in versions if re.fullmatch(r"\d+\.\d+\.\d+", v)]; print(sorted(stable, key=lambda v: tuple(int(p) for p in v.split(".")))[-1])')
+          echo "tf=${tf_version}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
+
+      - name: Build Docker image (validation only)
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: .
+          file: ./Dockerfile
+          build-args: |
+            YQ_VERSION=${{ steps.versions.outputs.yq }}
+            TF_VERSION=${{ steps.versions.outputs.tf }}
+          push: false
+          load: true
+          tags: ${{ env.IMAGE_NAME }}:validation
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Validate Docker image
+        run: |
+          echo "Validating Docker image..."
+          docker images "${{ env.IMAGE_NAME }}:validation"
+          docker run --rm "${{ env.IMAGE_NAME }}:validation" terraform version
+          docker run --rm "${{ env.IMAGE_NAME }}:validation" ansible --version
+          docker run --rm "${{ env.IMAGE_NAME }}:validation" az version
+          echo "Docker image validation successful"
+
+  push:
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: validate
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
 
     steps:
-    - name: Checkout main repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Harden Runner
+        uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0
+        with:
+          egress-policy: audit
 
-    - name: Determine package versions
-      id: versions
-      run: |
-        jq_version=$(gh api https://api.github.com/repos/mikefarah/yq/releases/latest | jq '.name' -r)
-        echo "jq=$jq_version" >> $GITHUB_OUTPUT
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-        tf_version=$(curl -s https://releases.hashicorp.com/terraform/index.json | jq -r '.versions | keys[]' | grep -Ev 'alpha|beta|rc' | sort -V | tail -n 1)
-        echo "tf=$tf_version" >> $GITHUB_OUTPUT
+      - name: Determine package versions
+        id: versions
+        run: |
+          yq_version=$(python3 -c 'import json, urllib.request; print(json.load(urllib.request.urlopen("https://api.github.com/repos/mikefarah/yq/releases/latest"))["tag_name"])')
+          echo "yq=${yq_version}" >> "$GITHUB_OUTPUT"
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v4
+          tf_version=$(python3 -c 'import json, re, urllib.request; versions=json.load(urllib.request.urlopen("https://releases.hashicorp.com/terraform/index.json"))["versions"]; stable=[v for v in versions if re.fullmatch(r"\d+\.\d+\.\d+", v)]; print(sorted(stable, key=lambda v: tuple(int(p) for p in v.split(".")))[-1])')
+          echo "tf=${tf_version}" >> "$GITHUB_OUTPUT"
 
-    - name: Log in to the Container registry
-      if: github.event_name != 'pull_request'
-      uses: docker/login-action@v4
-      with:
-        registry: ${{ env.REGISTRY }}
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
 
-    - name: Docker meta
-      id: meta
-      uses: docker/metadata-action@v6
-      with:
-        # list of Docker images to use as base name for tags
-        images: |
-          ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
-        # generate Docker tags based on the following events/attributes
-        tags: |
-          type=schedule
-          type=ref,event=branch
-          type=ref,event=pr
-          type=semver,pattern={{version}}
-          type=semver,pattern={{major}}.{{minor}}
-          type=semver,pattern={{major}}
-          type=sha
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Build and push Docker image
-      uses: docker/build-push-action@v7
-      with:
-        context: .
-        build-args: |
-          JQ_VERSION=${{ steps.versions.outputs.jq }}
-          TF_VERSION=${{ steps.versions.outputs.tf }}
-        push: ${{ github.event_name != 'pull_request' }}
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository }}
+          tags: |
+            type=ref,event=tag
+            type=raw,value=latest
+            type=sha,prefix=
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: .
+          file: ./Dockerfile
+          build-args: |
+            YQ_VERSION=${{ steps.versions.outputs.yq }}
+            TF_VERSION=${{ steps.versions.outputs.tf }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Image digest
+        run: |
+          echo "Image pushed to GHCR with tags:"
+          echo "${{ steps.meta.outputs.tags }}"


### PR DESCRIPTION
This pull request significantly refactors and enhances the container build GitHub Actions workflow. The workflow is now split into separate validation and push jobs, improves security, automates dependency version detection, and updates several actions to newer, pinned versions. These changes make the build process more robust, secure, and maintainable.

**Workflow structure and validation:**

* Splits the workflow into two jobs: `validate` (which builds and validates the Docker image without pushing) and `push` (which pushes the image to the registry only on tag events, and depends on successful validation).
* Expands workflow triggers to include branches matching `development-*` in addition to `main`.

**Security and reliability improvements:**

* Adds the `step-security/harden-runner` action to both jobs to audit and restrict network egress, increasing the security of the build environment.
* Pins all GitHub Actions to specific commit SHAs for improved reproducibility and security.

**Automation and modernization:**

* Automates the detection of the latest `yq` and `terraform` versions using Python scripts, replacing previous approaches that used `jq` and `curl`.
* Updates Docker-related actions (`setup-buildx`, `login-action`, `metadata-action`, `build-p