### PR TITLE
Update package references and GitHub Actions for security and functionality

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,12 +41,12 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
 
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,11 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
 
       - name: 'Checkout Repository'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0

--- a/.github/workflows/github-actions-ansible-lint.yml
+++ b/.github/workflows/github-actions-ansible-lint.yml
@@ -9,12 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
 
       - name: Checkout the code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 #v6.2.0

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -32,12 +32,12 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
 
       - name: "Checkout code"
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -73,6 +73,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
+        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           sarif_file: results.sarif

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -19,15 +19,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Harden Runner
-      uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+      uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
       with:
         egress-policy: audit
 
     - name: Checkout code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Run Trivy vulnerability scanner (file system)
-      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.34.2
+      uses: aquasecurity/trivy-action@c07df6fec6fa692e6fd1200d50aaa1fdd66f03c8 # 0.34.2
       with:
         scan-type: 'fs'
         ignore-unfixed: true
@@ -37,7 +37,7 @@ jobs:
         output: report-fs.sarif
 
     - name: Upload Trivy report (fs) GitHub Security
-      uses: github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
+      uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
       with:
         sarif_file: report-fs.sarif
         category: 'fs'

--- a/Webapp/SDAF/.config/dotnet-tools.json
+++ b/Webapp/SDAF/.config/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "dotnet-ef": {
-      "version": "10.0.7",
+      "version": "10.0.9",
       "commands": [
         "dotnet-ef"
       ]

--- a/Webapp/SDAF/ParameterDetails/VM-Images.json
+++ b/Webapp/SDAF/ParameterDetails/VM-Images.json
@@ -1,29 +1,5 @@
 [
   {
-    "name": "Red Hat 7.9",
-    "data": {
-      "os_type": "LINUX",
-      "source_image_id": "",
-      "publisher": "RedHat",
-      "offer": "RHEL-SAP-APPS",
-      "sku": "79sapha-gen2",
-      "version": "latest",
-      "type": "marketplace"
-    }
-  },
-  {
-    "name": "Red Hat 7.9 HA",
-    "data": {
-      "os_type": "LINUX",
-      "source_image_id": "",
-      "publisher": "RedHat",
-      "offer": "RHEL-SAP-HA",
-      "sku": "79sapha-gen2",
-      "version": "latest",
-      "type": "marketplace"
-    }
-  },
-  {
     "name": "Red Hat 8.4 App",
     "data": {
       "os_type": "LINUX",
@@ -215,19 +191,6 @@
       "type": "marketplace"
     }
   },
-
-  {
-    "name": "SUSE 12 SP5",
-    "data": {
-      "os_type": "LINUX",
-      "source_image_id": "",
-      "publisher": "SUSE",
-      "offer": "sles-sap-12-sp5",
-      "sku": "gen2",
-      "version": "latest",
-      "type": "marketplace"
-    }
-  },
   {
     "name": "SUSE 15 SP3",
     "data": {
@@ -344,42 +307,6 @@
       "publisher": "Oracle",
       "offer": "Oracle-Linux",
       "sku": "ol97-lvm-gen2",
-      "version": "latest",
-      "type": "marketplace"
-    }
-  },
-  {
-    "name": "Windows Server 2016",
-    "data": {
-      "os_type": "WINDOWS",
-      "source_image_id": "",
-      "publisher": "MicrosoftWindowsServer",
-      "offer": "windowsserver",
-      "sku": "2016-datacenter",
-      "version": "latest",
-      "type": "marketplace"
-    }
-  },
-  {
-    "name": "Windows Server 2019",
-    "data": {
-      "os_type": "WINDOWS",
-      "source_image_id": "",
-      "publisher": "MicrosoftWindowsServer",
-      "offer": "windowsserver",
-      "sku": "2019-datacenter",
-      "version": "latest",
-      "type": "marketplace"
-    }
-  },
-  {
-    "name": "Windows Server 2019-G2",
-    "data": {
-      "os_type": "WINDOWS",
-      "source_image_id": "",
-      "publisher": "MicrosoftWindowsServer",
-      "offer": "windowsserver",
-      "sku": "2019-datacenter-g2",
       "version": "latest",
       "type": "marketplace"
     }

--- a/Webapp/SDAF/SDAFWebApp.csproj
+++ b/Webapp/SDAF/SDAFWebApp.csproj
@@ -18,22 +18,22 @@
     <PackageReference Include="Azure.Data.Tables" Version="12.11.0" />
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="Azure.ResourceManager" Version="1.14.0" />
-    <PackageReference Include="Azure.ResourceManager.Compute" Version="1.14.0" />
+    <PackageReference Include="Azure.ResourceManager.Compute" Version="1.16.0" />
     <PackageReference Include="Azure.ResourceManager.KeyVault" Version="1.4.0" />
-    <PackageReference Include="Azure.ResourceManager.Network" Version="1.15.0" />
+    <PackageReference Include="Azure.ResourceManager.Network" Version="1.16.1" />
     <PackageReference Include="Azure.ResourceManager.Resources" Version="1.11.2" />
     <PackageReference Include="Azure.ResourceManager.Storage" Version="1.7.0" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.29.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.29.1" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.14.0" />
-    <PackageReference Include="Microsoft.Identity.Web" Version="4.10.0" />
-    <PackageReference Include="Microsoft.Identity.Web.UI" Version="4.10.0" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="4.12.0" />
+    <PackageReference Include="Microsoft.Identity.Web.UI" Version="4.12.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="NuGet.Packaging" Version="7.6.0" />
     <PackageReference Include="Octokit" Version="14.0.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.9.1" />
     <PackageReference Include="System.Linq.Async" Version="7.0.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Runtime.Caching" Version="10.0.8" />
+    <PackageReference Include="System.Runtime.Caching" Version="10.0.9" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 


### PR DESCRIPTION
This pull request primarily focuses on dependency and workflow updates to keep the project secure and up-to-date. It upgrades several GitHub Actions, .NET tools, NuGet packages, and also removes outdated VM image options from the configuration.

Dependency and package updates:

* Updated several NuGet package dependencies in `SDAFWebApp.csproj` to their latest patch or minor versions, including `Azure.ResourceManager.Compute`, `Azure.ResourceManager.Network`, `Azure.Storage.Blobs`, `Microsoft.Identity.Web`, `Microsoft.Identity.Web.UI`, and `System.Runtime.Caching`.
* Upgraded the `dotnet-ef` tool version from `10.0.7` to `10.0.9` in `dotnet-tools.json`.

Workflow and GitHub Actions updates:

* Updated `step-security/harden-runner` and `actions/checkout` to newer versions across multiple workflow files (`codeql.yml`, `dependency-review.yml`, `github-actions-ansible-lint.yml`, `ossf-scorecard.yml`, `trivy.yml`). [[1]](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27L44-R49) [[2]](diffhunk://#diff-7cdd3ccec44c8ba176bdc3b9ef54c3f56aa210a1a4e2bb5f79d87b1e50314a18L20-R25) [[3]](diffhunk://#diff-c2b1175e37346bfe0004c08887f4673c9e0b25cf1fa2052161c70439f6e34b37L12-R17) [[4]](diffhunk://#diff-0f32dffa00fbb4b53f979f3524fd4f69451050cda001ae563ed49e27e702da7bL35-R40) [[5]](diffhunk://#diff-c0c68244c39d0231fb6c8bf8113bb4673a9f6e833bdbc78f11904647ff40a46bL22-R30)
* Upgraded `github/codeql-action/upload-sarif` to version `v4.36.3` in relevant workflows, and updated `aquasecurity/trivy-action` to a new commit in `trivy.yml`. [[1]](diffhunk://#diff-0f32dffa00fbb4b53f979f3524fd4f69451050cda001ae563ed49e27e702da7bL76-R76) [[2]](diffhunk://#diff-c0c68244c39d0231fb6c8bf8113bb4673a9f6e833bdbc78f11904647ff40a46bL40-R40) [[3]](diffhunk://#diff-c0c68244c39d0231fb6c8bf8113bb4673a9f6e833bdbc78f11904647ff40a46bL22-R30)

Configuration cleanup:

* Removed several outdated or legacy VM image definitions (such as Red Hat 7.9, SUSE 12 SP5, and Windows Server 2016/2019) from `VM-Images.json`, leaving only more recent and supported images. [[1]](diffhunk://#diff-8a6acdf0eee50a382fe4a56a14f6e0b05300b423d395e0b96abb80faa80386adL2-L25) [[2]](diffhunk://#diff-8a6acdf0eee50a382fe4a56a14f6e0b05300b423d395e0b96abb80faa80386adL218-L230) [[3]](diffhunk://#diff-8a6acdf0eee50a382fe4a56a14f6e0b05300b423d395e0b96abb80faa80386adL351-L386)## Problem
<Please describe what problem this PR is trying to resolve>

## Solution
<Please elaborate the solution for the problem>

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>