### PR TITLE
Enhance fencing SPN validation and simplify encryption handling

### DIFF
--- a/deploy/ansible/playbook_04_00_01_db_ha.yaml
+++ b/deploy/ansible/playbook_04_00_01_db_ha.yaml
@@ -195,9 +195,9 @@
                 primary_instance_ip_db:    "{{ hostvars[ansible_play_hosts_all[0]]['primary_ip'] | string }}"
                 secondary_instance_name:   "{{ ansible_play_hosts_all[1] }}"         # Setting up Secondary Instance Name
                 secondary_instance_ip_db:  "{{ hostvars[ansible_play_hosts_all[1]]['primary_ip'] | string }}"
-                fencing_spn_client_id:     "{% if not use_msi_for_clusters %}{{ hostvars.localhost.sap_fencing_spn_client_id }}{% endif %}"
-                fencing_spn_client_pwd:    "{% if not use_msi_for_clusters %}{{ hostvars.localhost.sap_fencing_spn_pwd }}{% endif %}"
-                fencing_spn_tenant_id:     "{% if not use_msi_for_clusters %}{{ hostvars.localhost.sap_fencing_spn_tenant_id }}{% endif %}"
+                fencing_spn_client_id:     "{% if database_cluster_type == 'AFA' and not use_msi_for_clusters %}{{ hostvars.localhost.sap_fencing_spn_client_id }}{% endif %}"
+                fencing_spn_client_pwd:    "{% if database_cluster_type == 'AFA' and not use_msi_for_clusters %}{{ hostvars.localhost.sap_fencing_spn_pwd }}{% endif %}"
+                fencing_spn_tenant_id:     "{% if database_cluster_type == 'AFA' and not use_msi_for_clusters %}{{ hostvars.localhost.sap_fencing_spn_tenant_id }}{% endif %}"
               tags:
                                        - always
 
@@ -502,9 +502,9 @@
                 password_ha_db_cluster:    "{{ hostvars.localhost.db_cluster_password }}"
                 primary_instance_name:     "{{ ansible_play_hosts_all[0] }}"         # Setting up Primary Instance Name
                 secondary_instance_name:   "{{ ansible_play_hosts_all[1] }}"         # Setting up Secondary Instance Name
-                fencing_spn_client_id:     "{% if not use_msi_for_clusters %}{{ hostvars.localhost.sap_fencing_spn_client_id }}{% endif %}"
-                fencing_spn_client_pwd:    "{% if not use_msi_for_clusters %}{{ hostvars.localhost.sap_fencing_spn_pwd }}{% endif %}"
-                fencing_spn_tenant_id:     "{% if not use_msi_for_clusters %}{{ hostvars.localhost.sap_fencing_spn_tenant_id }}{% endif %}"
+                fencing_spn_client_id:     "{% if database_cluster_type == 'AFA' and not use_msi_for_clusters %}{{ hostvars.localhost.sap_fencing_spn_client_id }}{% endif %}"
+                fencing_spn_client_pwd:    "{% if database_cluster_type == 'AFA' and not use_msi_for_clusters %}{{ hostvars.localhost.sap_fencing_spn_pwd }}{% endif %}"
+                fencing_spn_tenant_id:     "{% if database_cluster_type == 'AFA' and not use_msi_for_clusters %}{{ hostvars.localhost.sap_fencing_spn_tenant_id }}{% endif %}"
 
             - name:                    "Database High Availability Configuration Playbook - DB2 : - repository check"
               block:

--- a/deploy/ansible/roles-sap/5.5-hanadb-pacemaker/tasks/5.5.2-pre_checks.yml
+++ b/deploy/ansible/roles-sap/5.5-hanadb-pacemaker/tasks/5.5.2-pre_checks.yml
@@ -23,7 +23,9 @@
       - "fencing_spn_client_pwd is defined"
       - "fencing_spn_client_pwd | trim | length > 0"
     fail_msg:                          Fencing SPN details are missing
-  when:                                not use_msi_for_clusters
+  when:
+                                       - database_cluster_type == "AFA"
+                                       - not use_msi_for_clusters
 
 - name:                                "5.5.2 HANA Pacemaker - Check the required cluster password is set"
   ansible.builtin.assert:

--- a/deploy/ansible/roles-sap/5.8-hanadb-scaleout-pacemaker/tasks/5.8.1-set_runtime_facts.yml
+++ b/deploy/ansible/roles-sap/5.8-hanadb-scaleout-pacemaker/tasks/5.8.1-set_runtime_facts.yml
@@ -254,6 +254,7 @@
     - name:                            "5.8 HANA Pacemaker Scale-out - Install resource-agents-sap-hana package [RHEL classic]"
       when:
                                        - not (use_hanasr_angi | default(false))
+                                       - ansible_facts.packages['resource-agents-sap-hana-scaleout'] is not defined
                                        - saphanaSR_version == "0.0.0"
       ansible.builtin.dnf:
         name:                          resource-agents-sap-hana

--- a/deploy/terraform/run/sap_landscape/transform.tf
+++ b/deploy/terraform/run/sap_landscape/transform.tf
@@ -335,10 +335,7 @@ locals {
                                                  name = length(ctr.name) > 0 ? ctr.name : format("container%02d", ctr_idx)
                                                }
                                              ]
-                                             https_traffic_only_enabled = (
-                                               acct.account_kind == "FileStorage" &&
-                                               length([for s in acct.file_shares : s if upper(s.protocol) == "NFS"]) > 0
-                                             ) ? false : (acct.account_kind == "FileStorage" ? var.AFS_enable_encryption_in_transit : true)
+                                             https_traffic_only_enabled = var.AFS_enable_encryption_in_transit
                                            }
                                            if (
                                              length(acct.file_shares) > 0


### PR DESCRIPTION
This pull request introduces several updates to the Ansible playbooks and Terraform code to improve conditional logic and package installation checks for SAP database high availability and HANA scale-out scenarios. The main focus is on ensuring fencing SPN credentials are only required for specific cluster types, refining package installation conditions, and simplifying encryption settings for Azure File Storage.

**Conditional logic improvements for fencing SPN credentials:**
* Updated the condition for setting `fencing_spn_client_id`, `fencing_spn_client_pwd`, and `fencing_spn_tenant_id` in `playbook_04_00_01_db_ha.yaml` to require these variables only when `database_cluster_type` is `'AFA'` and `use_msi_for_clusters` is false. This prevents unnecessary prompting for SPN credentials in other cluster types. [[1]](diffhunk://#diff-28866cc7bc2cd7b9342880fa6edfa12cc98d2ba9bb3f7bdb2e7f278a26071edfL198-R200) [[2]](diffhunk://#diff-28866cc7bc2cd7b9342880fa6edfa12cc98d2ba9bb3f7bdb2e7f278a26071edfL505-R507)
* Modified the assertion in `5.5.2-pre_checks.yml` to check for fencing SPN details only when `database_cluster_type` is `"AFA"` and `use_msi_for_clusters` is false, aligning with the updated playbook logic.

**Package installation and runtime facts:**
* Added a check in `5.8.1-set_runtime_facts.yml` to ensure the `resource-agents-sap-hana` package is only installed if the scale-out package is not already present, preventing redundant installations.

**Terraform encryption logic simplification:**
* Simplified the logic for `https_traffic_only_enabled` in `transform.tf` by directly using the `AFS_enable_encryption_in_transit` variable, removing complex conditional checks.
[Copilot is generating a summary...]