### PR TITLE
Add utility VM zone support and enhance distribution validation

### DIFF
--- a/Webapp/SDAF/Models/LandscapeModel.cs
+++ b/Webapp/SDAF/Models/LandscapeModel.cs
@@ -596,6 +596,8 @@ namespace SDAFWebApp.Models
         [IpAddressValidator]
         public string[] utility_vm_nic_ips { get; set; }
 
+        public string[] utility_vm_zones { get; set; }
+
         public string storage_account_replication_type { get; set; } = "LRS";
 
         public string controlPlaneEnvironment { get; set; }

--- a/Webapp/SDAF/ParameterDetails/LandscapeDetails.json
+++ b/Webapp/SDAF/ParameterDetails/LandscapeDetails.json
@@ -1573,6 +1573,32 @@
         ],
         "Overrules": "",
         "Display": 3
+      },
+      {
+        "Name": "utility_vm_zones",
+        "Required": false,
+        "Description": "Defines the Availability zones for the utility virtual machines.",
+        "Type": "list",
+        "Options": [
+          {
+            "Text": "",
+            "Value": ""
+          },
+          {
+            "Text": "1",
+            "Value": "1"
+          },
+          {
+            "Text": "2",
+            "Value": "2"
+          },
+          {
+            "Text": "3",
+            "Value": "3"
+          }
+        ],
+        "Overrules": "",
+        "Display": 3
       }
     ]
   },

--- a/Webapp/SDAF/ParameterDetails/LandscapeTemplate.txt
+++ b/Webapp/SDAF/ParameterDetails/LandscapeTemplate.txt
@@ -647,6 +647,9 @@ $$utility_vm_image$$
 # Defines if the utility virtual machine IP
 $$utility_vm_nic_ips$$
 
+# Defines the Availability zones for the utility virtual machines
+$$utility_vm_zones$$
+
 ############################################################################################
 #                                                                                          #
 #                                  Tags for all resources                                  #

--- a/deploy/terraform/run/sap_landscape/tests/plan_shape_compute.tftest.hcl
+++ b/deploy/terraform/run/sap_landscape/tests/plan_shape_compute.tftest.hcl
@@ -394,13 +394,13 @@ run "utility_vm_zones_distribute_windows_vms" {
   command = plan
 
   variables {
-    utility_vm_count = 2
+    utility_vm_count = 3
     utility_vm_zones = ["1", "2"]
   }
 
   assert {
-    condition     = module.sap_landscape.utility_vm_zones == ["1", "2"]
-    error_message = "Utility VMs must be distributed across the configured zones in order."
+    condition     = module.sap_landscape.utility_vm_zones == ["1", "2", "1"]
+    error_message = "Utility VMs must be distributed round-robin across the configured zones."
   }
 }
 
@@ -408,7 +408,7 @@ run "utility_vm_zones_distribute_linux_vms" {
   command = plan
 
   variables {
-    utility_vm_count = 2
+    utility_vm_count = 3
     utility_vm_zones = ["1", "2"]
     utility_vm_image = {
       os_type         = "LINUX"
@@ -421,8 +421,8 @@ run "utility_vm_zones_distribute_linux_vms" {
   }
 
   assert {
-    condition     = module.sap_landscape.utility_vm_zones == ["1", "2"]
-    error_message = "Linux utility VMs must be distributed across the configured zones in order."
+    condition     = module.sap_landscape.utility_vm_zones == ["1", "2", "1"]
+    error_message = "Linux utility VMs must be distributed round-robin across the configured zones."
   }
 }
 

--- a/deploy/terraform/run/sap_landscape/tests/plan_shape_compute.tftest.hcl
+++ b/deploy/terraform/run/sap_landscape/tests/plan_shape_compute.tftest.hcl
@@ -383,6 +383,47 @@ run "utility_vm_count_drives_windows_vm_names" {
     condition     = module.sap_landscape.utility_vm_computer_names[0] == module.sap_namegenerator.naming.virtualmachine_names.WORKLOAD_VMNAME[0]
     error_message = "sap_namegenerator's utility_vm_count wiring must drive the planned utility VM computer names."
   }
+
+  assert {
+    condition     = alltrue([for zone in module.sap_landscape.utility_vm_zones : zone == null])
+    error_message = "Utility VMs must remain non-zonal when utility_vm_zones is not provided."
+  }
+}
+
+run "utility_vm_zones_distribute_windows_vms" {
+  command = plan
+
+  variables {
+    utility_vm_count = 2
+    utility_vm_zones = ["1", "2"]
+  }
+
+  assert {
+    condition     = module.sap_landscape.utility_vm_zones == ["1", "2"]
+    error_message = "Utility VMs must be distributed across the configured zones in order."
+  }
+}
+
+run "utility_vm_zones_distribute_linux_vms" {
+  command = plan
+
+  variables {
+    utility_vm_count = 2
+    utility_vm_zones = ["1", "2"]
+    utility_vm_image = {
+      os_type         = "LINUX"
+      source_image_id = ""
+      publisher       = "Canonical"
+      offer           = "ubuntu-24_04-lts"
+      sku             = "server"
+      version         = "latest"
+    }
+  }
+
+  assert {
+    condition     = module.sap_landscape.utility_vm_zones == ["1", "2"]
+    error_message = "Linux utility VMs must be distributed across the configured zones in order."
+  }
 }
 
 run "private_endpoint_enabled_with_keyvault_plans_endpoint" {

--- a/deploy/terraform/run/sap_landscape/tests/shard-manifest.json
+++ b/deploy/terraform/run/sap_landscape/tests/shard-manifest.json
@@ -3,10 +3,10 @@
   "shards": [
     { "file": "plan_shape_networking.tftest.hcl", "runs": 25 },
     { "file": "plan_shape_storage.tftest.hcl", "runs": 20 },
-    { "file": "plan_shape_compute.tftest.hcl", "runs": 15 },
+    { "file": "plan_shape_compute.tftest.hcl", "runs": 17 },
     { "file": "plan_shape_cross_sub.tftest.hcl", "runs": 16 },
     { "file": "validation_inputs.tftest.hcl", "runs": 46 },
     { "file": "validation_constraints.tftest.hcl", "runs": 46 }
   ],
-  "total_runs": 168
+  "total_runs": 170
 }

--- a/deploy/terraform/run/sap_landscape/tfvar_variables.tf
+++ b/deploy/terraform/run/sap_landscape/tfvar_variables.tf
@@ -1092,6 +1092,12 @@ variable "utility_vm_nic_ips"                      {
                                                      default     = []
                                                    }
 
+variable "utility_vm_zones"                        {
+                                                     description = "The zones for the utility virtual machines"
+                                                     type        = list(string)
+                                                     default     = []
+                                                   }
+
 #########################################################################################
 #                                                                                       #
 #  Utility Storage Accounts                                                             #
@@ -1331,5 +1337,4 @@ variable "control_plane_name"                   {
                                                   description = "The name of the control plane"
                                                   default     = ""
                                                 }
-
 

--- a/deploy/terraform/run/sap_landscape/transform.tf
+++ b/deploy/terraform/run/sap_landscape/transform.tf
@@ -315,6 +315,7 @@ locals {
                                            private_ip_address = var.utility_vm_nic_ips
                                            disk_size          = var.utility_vm_os_disk_size
                                            disk_type          = var.utility_vm_os_disk_type
+                                           zones              = distinct(var.utility_vm_zones)
                                          }
 
   utility_storage_settings             = [

--- a/deploy/terraform/terraform-units/modules/sap_landscape/README.md
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/README.md
@@ -330,6 +330,7 @@ No modules.
 | <a name="output_utility_storage_account_names"></a> [utility\_storage\_account\_names](#output\_utility\_storage\_account\_names) | List of utility storage account names |
 | <a name="output_utility_vm_computer_names"></a> [utility\_vm\_computer\_names](#output\_utility\_vm\_computer\_names) | Planned utility VM computer names |
 | <a name="output_utility_vm_count"></a> [utility\_vm\_count](#output\_utility\_vm\_count) | Number of utility VMs created by this module |
+| <a name="output_utility_vm_zones"></a> [utility\_vm\_zones](#output\_utility\_vm\_zones) | Planned availability zones for utility VMs |
 | <a name="output_vnet_sap_id"></a> [vnet\_sap\_id](#output\_vnet\_sap\_id) | Azure resource identifier for the Virtual Network |
 | <a name="output_vnet_tags"></a> [vnet\_tags](#output\_vnet\_tags) | Tags applied to the created workload VNet, if any |
 | <a name="output_web_nsg_id"></a> [web\_nsg\_id](#output\_web\_nsg\_id) | Azure resource identifier for the web subnet network security group |

--- a/deploy/terraform/terraform-units/modules/sap_landscape/outputs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/outputs.tf
@@ -843,3 +843,8 @@ output "utility_vm_computer_names"                  {
                                                      description = "Planned utility VM computer names"
                                                      value       = concat(azurerm_windows_virtual_machine.utility_vm[*].computer_name, azurerm_linux_virtual_machine.utility_vm[*].computer_name)
                                                     }
+
+output "utility_vm_zones"                           {
+                                                     description = "Planned availability zones for utility VMs"
+                                                     value       = concat(azurerm_windows_virtual_machine.utility_vm[*].zone, azurerm_linux_virtual_machine.utility_vm[*].zone)
+                                                    }

--- a/deploy/terraform/terraform-units/modules/sap_landscape/vm.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/vm.tf
@@ -79,6 +79,7 @@ resource "azurerm_windows_virtual_machine" "utility_vm" {
   automatic_updates_enabled                              = !(var.infrastructure.patch_mode == "ImageDefault")
 
   encryption_at_host_enabled                             = var.infrastructure.encryption_at_host_enabled
+  zone                                                   = try(var.vm_settings.zones[count.index % max(length(var.vm_settings.zones), 1)], null)
 
   os_disk {
                  name                 = format("%s%s%s%s%s",
@@ -148,6 +149,7 @@ resource "azurerm_linux_virtual_machine" "utility_vm" {
   bypass_platform_safety_checks_on_user_schedule_enabled = var.infrastructure.patch_mode != "AutomaticByPlatform" ? false : true
 
   encryption_at_host_enabled                             = var.infrastructure.encryption_at_host_enabled
+  zone                                                   = try(var.vm_settings.zones[count.index % max(length(var.vm_settings.zones), 1)], null)
   dynamic "admin_ssh_key"              {
                                         for_each = range(1)
                                         content {


### PR DESCRIPTION
This pull request introduces support for distributing SAP utility VMs across specified availability zones. It adds a new `utility_vm_zones` variable, updates the VM resource definitions to assign zones in order, and ensures the planned zones are testable and output for verification. The changes also include new tests to validate both zonal and non-zonal behavior for utility VMs.

**Support for utility VM zones:**

* Added a new variable `utility_vm_zones` in `tfvar_variables.tf` to allow configuration of availability zones for utility VMs.
* Updated `transform.tf` to pass the distinct list of zones to VM settings.

**Resource updates for zone assignment:**

* Modified both `azurerm_windows_virtual_machine.utility_vm` and `azurerm_linux_virtual_machine.utility_vm` resources in `vm.tf` to assign the `zone` property in a round-robin fashion based on the provided zones. [[1]](diffhunk://#diff-7c59cab86af546df033f2559689b4a2b4e7a006aa46c80ebeefa41e46c94665cR82) [[2]](diffhunk://#diff-7c59cab86af546df033f2559689b4a2b4e7a006aa46c80ebeefa41e46c94665cR152)

**Outputs and testing:**

* Added a new output `utility_vm_zones` in `outputs.tf` to expose the planned zones for utility VMs.
* Added new tests in `plan_shape_compute.tftest.hcl` to verify correct distribution of VMs across zones and enforce non-zonal behavior when zones are not specified.