### PR TITLE
docs: add local execution journey

### DIFF
--- a/docs/deployment-options.md
+++ b/docs/deployment-options.md
@@ -141,6 +141,8 @@ support status from a filename. Use only an entry point that your release
 guidance identifies and validate it against the checked-out repository
 version.
 
+Continue with the complete [local execution journey](local/README.md).
+
 ## Shared samples and BOM files
 
 All execution models can use

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ configuration and automation assets for the first deployment stage.
 | Understand repository ownership | [SDAF repositories](repositories.md) |
 | Use GitHub Actions | [Start with GitHub Actions](deployment-options.md#github-actions) |
 | Use Azure DevOps | [Start with Azure DevOps](deployment-options.md#azure-devops) |
-| Run SDAF directly | [`deploy/scripts`](../deploy/scripts/) infrastructure scripts and [`deploy/ansible`](../deploy/ansible/) software-download and installation wrappers |
+| Run SDAF directly | [Run SDAF locally](local/README.md) |
 | Find Terraform samples and SAP BOMs | [`Azure/SAP-automation-samples`](https://github.com/Azure/SAP-automation-samples) |
 
 ## Understand the framework source

--- a/docs/local/01-00-prerequisites.md
+++ b/docs/local/01-00-prerequisites.md
@@ -14,9 +14,9 @@ required command-line dependencies. An operator-managed Linux host, including
 an SDAF deployer after it exists, provides the documented setup path. The
 repository's
 [`configure_deployer.sh`](../../deploy/scripts/configure_deployer.sh) setup
-path accepts Ubuntu, RHEL, SLES 15.0 through 15.3, and SLES 15.8 or later.
-This setup path requires an x86_64 or amd64 host because it downloads the
-Terraform `linux_amd64` archive.
+path recognizes Ubuntu, RHEL, and SLES. Consult the current script before setup
+for its release-specific validation. This setup path requires an x86_64 or
+amd64 host because it downloads the Terraform `linux_amd64` archive.
 
 On another Bash environment or on ARM64, install and validate the required
 tools through a separately reviewed process instead of

--- a/docs/local/01-00-prerequisites.md
+++ b/docs/local/01-00-prerequisites.md
@@ -93,7 +93,12 @@ Choose one identity model for each execution host:
   and use the signed-in user.
 - **Service principal**: Export the `ARM_CLIENT_ID`, `ARM_CLIENT_SECRET`,
   `ARM_TENANT_ID`, and `ARM_SUBSCRIPTION_ID` variables. Protect the secret from
-  shell history, process listings, logs, and source control.
+  shell history, logs, and source control. The current control-plane wrapper
+  passes the secret to `set_secrets.sh` as a command argument, so this path
+  can't protect it from process-argument inspection. Use the service-principal
+  path only on an isolated execution host with an approved process-inspection
+  policy, or use the approved managed-identity path when process-argument
+  exposure isn't permitted.
 - **Managed identity**: Use an Azure host with an assigned identity and the
   script family's managed-identity option only when your release guidance
   selects that path.

--- a/docs/local/01-00-prerequisites.md
+++ b/docs/local/01-00-prerequisites.md
@@ -133,7 +133,7 @@ as the owner of:
 - `BOM` software bills of materials.
 - `Ansible` sample inputs.
 
-Copy only the required examples into the customer configuration repository.
+Copy only the required examples into the deployment configuration repository.
 Review names, subscriptions, regions, networks, sizes, images, availability,
 credentials, and feature flags. Samples are not production approval.
 

--- a/docs/local/01-00-prerequisites.md
+++ b/docs/local/01-00-prerequisites.md
@@ -1,0 +1,136 @@
+# Review prerequisites for local execution
+
+## Outcome
+
+You have an approved architecture, execution host, identity, network design,
+quota, and configuration source before you install tools or create Azure
+resources.
+
+## Supported execution host
+
+The local entry points are Bash scripts that call Linux command-line tools.
+Run them on an operator-managed Linux host, including an SDAF deployer after
+it exists. The repository's
+[`configure_deployer.sh`](../../deploy/scripts/configure_deployer.sh) setup
+path recognizes Ubuntu, RHEL, and supported SLES releases. It rejects SLES 12
+and SLES 15.4 through 15.7.
+
+The source does not establish native Windows, Windows Subsystem for Linux, or
+macOS as supported deployment hosts. Do not infer host support from Bash
+availability alone.
+
+## Before you begin
+
+Confirm the following requirements:
+
+- An Azure subscription for the control plane and each workload subscription.
+- Permission to create the resource types selected in the `.tfvars` files.
+- Permission to create role assignments when the configuration requires SDAF
+  to assign Contributor, User Access Administrator, Key Vault, Storage, DNS,
+  or other roles.
+- An approved management virtual network and subnet, or approved address
+  spaces for SDAF to create them.
+- Name resolution and routing between the execution host, Azure Resource
+  Manager, Microsoft Entra ID, Azure Storage, Key Vault, and any private
+  endpoints.
+- Outbound access to provider and package sources used by Terraform, Azure
+  CLI, Ansible, operating-system repositories, and SAP software sources.
+- Azure compute quota for every selected VM family and region.
+- SAP software licenses and an SAP Support user when the selected download
+  method requires them.
+- A source-control and backup policy for configuration and operational
+  evidence.
+
+## Pin versions
+
+Treat the SDAF commit and tool versions as one reviewed release unit.
+
+1. Record the approved SDAF commit.
+
+   ```bash
+   git -C "$SAP_AUTOMATION_REPO_PATH" rev-parse HEAD
+   ```
+
+   The command returns one commit identifier.
+
+2. Review each Terraform root module's `providers.tf` before installation.
+
+   This baseline declares Terraform `>= 1.0` and pins root providers including
+   AzureRM `4.80.0`, AzAPI `2.7.0`, and AzureAD `3.8.0` where applicable. The
+   root modules declare the Random provider without a version constraint.
+
+3. If you use `configure_deployer.sh`, review its pinned defaults.
+
+   At this baseline it defaults to Terraform `1.14.6`. It selects Ansible 2.16
+   for Ubuntu 22.04, RHEL, and SLES 16, and Ansible 2.11 for other accepted
+   SLES versions.
+
+4. Record the installed versions after host preparation.
+
+   ```bash
+   "$SAP_AUTOMATION_REPO_PATH/deploy/scripts/helpers/check_workstation.sh"
+   ```
+
+   The command prints the detected Azure CLI, Terraform, Ansible, and `jq`
+   versions.
+
+> [!IMPORTANT]
+> Do not update the SDAF checkout, Terraform, providers, or Ansible between a
+> plan and its apply. Replan after any version change.
+
+## Plan identity and access
+
+Choose one identity model for each execution host:
+
+- **Azure CLI user sign-in**: Run `az login`, select the target subscription,
+  and use the signed-in user.
+- **Service principal**: Export the `ARM_CLIENT_ID`, `ARM_CLIENT_SECRET`,
+  `ARM_TENANT_ID`, and `ARM_SUBSCRIPTION_ID` variables. Protect the secret from
+  shell history, process listings, logs, and source control.
+- **Managed identity**: Use an Azure host with an assigned identity and the
+  script family's managed-identity option only when your release guidance
+  selects that path.
+
+The deployment identity must be able to read existing networks, DNS zones,
+Key Vaults, and the remote-state storage account that the configuration
+references. It must also be able to create the role assignments represented
+by the selected Terraform configuration.
+
+## Review networking, DNS, and quota
+
+1. Validate every virtual network and subnet CIDR against the enterprise IP
+   allocation.
+2. Validate peering, routes, firewalls, and network security controls.
+3. Decide whether public endpoints or private endpoints provide access to
+   Storage, Key Vault, and other services.
+4. Validate the management and private-link DNS subscription and resource
+   group values when DNS is managed outside the deployment subscription.
+5. Confirm that the execution host's public IP can be authorized temporarily
+   when a selected script updates Key Vault or Storage network rules.
+6. Confirm regional VM-family and total vCPU quota for the complete SAP
+   system, including high-availability nodes.
+
+## Review configuration ownership
+
+Use
+[`Azure/SAP-automation-samples`](https://github.com/Azure/SAP-automation-samples)
+as the owner of:
+
+- `Terraform/WORKSPACES` examples.
+- `SAP` application definitions.
+- `BOM` software bills of materials.
+- `Ansible` sample inputs.
+
+Copy only the required examples into the customer configuration repository.
+Review names, subscriptions, regions, networks, sizes, images, availability,
+credentials, and feature flags. Samples are not production approval.
+
+## Review gate
+
+Do not continue until architecture, security, networking, DNS, quota, cost,
+identity, configuration ownership, version pins, backup, and removal
+responsibilities have named approvers.
+
+## Next step
+
+[Prepare the local execution environment](02-00-prepare-execution-environment.md).

--- a/docs/local/01-00-prerequisites.md
+++ b/docs/local/01-00-prerequisites.md
@@ -28,6 +28,12 @@ Confirm the following requirements:
 - Permission to create role assignments when the configuration requires SDAF
   to assign Contributor, User Access Administrator, Key Vault, Storage, DNS,
   or other roles.
+- For the established control-plane path without MSI-only deployment, an
+  approved service-principal application ID, tenant ID, client secret, and
+  subscription ID. Provide them through the approved secure input method or
+  the `ARM_CLIENT_ID`, `ARM_TENANT_ID`, and `ARM_CLIENT_SECRET` environment
+  variables when the scripts require them. An interactive Azure user sign-in
+  does not replace these inputs for `set_secrets.sh`.
 - An approved management virtual network and subnet, or approved address
   spaces for SDAF to create them.
 - Name resolution and routing between the execution host, Azure Resource

--- a/docs/local/01-00-prerequisites.md
+++ b/docs/local/01-00-prerequisites.md
@@ -13,7 +13,10 @@ Run them on an operator-managed Linux host, including an SDAF deployer after
 it exists. The repository's
 [`configure_deployer.sh`](../../deploy/scripts/configure_deployer.sh) setup
 path recognizes Ubuntu, RHEL, and supported SLES releases. It rejects SLES 12
-and SLES 15.4 through 15.7.
+and SLES 15.4 through 15.7. This setup path requires an x86_64 or amd64 host
+because it downloads the Terraform `linux_amd64` archive. On ARM64, use a
+separately reviewed architecture-specific tool installation path instead of
+`configure_deployer.sh`.
 
 The source does not establish native Windows, Windows Subsystem for Linux, or
 macOS as supported deployment hosts. Do not infer host support from Bash

--- a/docs/local/01-00-prerequisites.md
+++ b/docs/local/01-00-prerequisites.md
@@ -45,13 +45,11 @@ Confirm the following requirements:
 
 Treat the SDAF commit and tool versions as one reviewed release unit.
 
-1. Record the approved SDAF commit.
+1. Identify the approved SDAF commit from your release guidance and record it
+   as `<SDAF_COMMIT>`.
 
-   ```bash
-   git -C "$SAP_AUTOMATION_REPO_PATH" rev-parse HEAD
-   ```
-
-   The command returns one commit identifier.
+   Verify this value with `git rev-parse HEAD` after checking out the repository
+   on the next page.
 
 2. Review each Terraform root module's `providers.tf` before installation.
 

--- a/docs/local/01-00-prerequisites.md
+++ b/docs/local/01-00-prerequisites.md
@@ -9,18 +9,18 @@ resources.
 ## Supported execution host
 
 The local entry points are Bash scripts that call Linux command-line tools.
-Run them on an operator-managed Linux host, including an SDAF deployer after
-it exists. The repository's
+They are designed to run in any environment that provides Bash and the
+required command-line dependencies. An operator-managed Linux host, including
+an SDAF deployer after it exists, provides the documented setup path. The
+repository's
 [`configure_deployer.sh`](../../deploy/scripts/configure_deployer.sh) setup
-path recognizes Ubuntu, RHEL, and supported SLES releases. It rejects SLES 12
-and SLES 15.4 through 15.7. This setup path requires an x86_64 or amd64 host
-because it downloads the Terraform `linux_amd64` archive. On ARM64, use a
-separately reviewed architecture-specific tool installation path instead of
-`configure_deployer.sh`.
+path accepts Ubuntu, RHEL, SLES 15.0 through 15.3, and SLES 15.8 or later.
+This setup path requires an x86_64 or amd64 host because it downloads the
+Terraform `linux_amd64` archive.
 
-The source does not establish native Windows, Windows Subsystem for Linux, or
-macOS as supported deployment hosts. Do not infer host support from Bash
-availability alone.
+On another Bash environment or on ARM64, install and validate the required
+tools through a separately reviewed process instead of
+`configure_deployer.sh`.
 
 ## Before you begin
 

--- a/docs/local/02-00-prepare-execution-environment.md
+++ b/docs/local/02-00-prepare-execution-environment.md
@@ -2,8 +2,9 @@
 
 ## Outcome
 
-The Linux execution host has pinned tools, an authenticated Azure identity,
-an SDAF checkout, a separate configuration root, and reviewed stage inputs.
+The Linux execution host has reviewed and recorded tool versions, an
+authenticated Azure identity, an SDAF checkout, a separate configuration
+root, and reviewed stage inputs.
 
 ## Before you begin
 
@@ -33,9 +34,13 @@ Later stages persist nonsecret environment metadata under
 ## What the automation does
 
 `configure_deployer.sh` prepares a Linux host with Terraform, Azure CLI,
-Ansible, required Python packages, and Ansible collections. It uses a Python
-virtual environment instead of changing the system Python environment. It
-also writes `/etc/profile.d/deploy_server.sh`.
+Ansible, required Python packages, Ansible collections, and .NET 9. It upgrades
+or patches distribution packages before installing the toolchain. Terraform is
+version-pinned, but Azure CLI, the Ansible patch release, .NET channel updates,
+several Python packages, and several collections can resolve newer versions.
+On RHEL and SLES, the script also installs `virtualenv` into system Python
+before creating the Python virtual environment under `/opt/ansible`. It writes
+`/etc/profile.d/deploy_server.sh`.
 
 The script does not create customer `WORKSPACES` configuration or approve an
 Azure deployment.
@@ -89,9 +94,16 @@ Azure deployment.
      "$SAP_AUTOMATION_REPO_PATH/deploy/scripts/configure_deployer.sh"
    ```
 
-   The script installs Terraform under `/opt/terraform`, Azure CLI, a Python
-   virtual environment under `/opt/ansible`, Ansible dependencies, and a
-   profile script under `/etc/profile.d`.
+   The script upgrades or patches operating-system packages, installs
+   Terraform under `/opt/terraform`, Azure CLI, .NET 9, Ansible dependencies,
+   and a profile script under `/etc/profile.d`. On RHEL and SLES, it installs
+   `virtualenv` into system Python before creating the environment under
+   `/opt/ansible`.
+
+   > [!WARNING]
+   > Run this step only in an approved maintenance window. Distribution package
+   > updates can affect software unrelated to SDAF and can require a host
+   > restart.
 
    If your organization manages these tools separately, install the approved
    versions through that process instead. The deployment scripts check that
@@ -111,6 +123,12 @@ Azure deployment.
    Terraform, Azure CLI, Ansible, and SDAF scripts are available on `PATH`.
    Re-exporting the reviewed values is required because the generated profile
    sets its current subscription and fixed default repository paths.
+
+   The generated profile also sets `ANSIBLE_HOST_KEY_CHECKING=False`. Before
+   running configuration, verify each target host key through an approved
+   out-of-band source. If your security policy requires strict checking,
+   populate the approved `known_hosts` file and export
+   `ANSIBLE_HOST_KEY_CHECKING=True` after loading the profile.
 
 7. Verify the tool versions.
 
@@ -181,9 +199,12 @@ Confirm that:
 
 ## Safe retry
 
-Host setup is repeatable, but `configure_deployer.sh` regenerates
-`/etc/profile.d/deploy_server.sh`. Preserve any approved local customization
-elsewhere before rerunning it.
+Do not treat a host-setup rerun as deterministic. It repeats the
+operating-system upgrade or patch and can resolve newer unpinned Azure CLI,
+Ansible patch, Python package, .NET channel, and collection versions. Obtain a
+new maintenance and version review, record the currently resolved versions,
+and preserve approved profile customization elsewhere before rerunning
+`configure_deployer.sh`.
 
 ## Next step
 

--- a/docs/local/02-00-prepare-execution-environment.md
+++ b/docs/local/02-00-prepare-execution-environment.md
@@ -47,7 +47,17 @@ Azure deployment.
 
 ## Prepare the host
 
-1. Clone the SDAF repository.
+1. Install Git through your organization's approved operating-system package
+   process, then verify it is available.
+
+   ```bash
+   command -v git
+   git --version
+   ```
+
+   Both commands complete successfully.
+
+2. Clone the SDAF repository.
 
    ```bash
    mkdir -p "$HOME/Azure_SAP_Automated_Deployment"
@@ -58,7 +68,7 @@ Azure deployment.
    The repository is created at the fixed checkout path used by
    `configure_deployer.sh`.
 
-2. Check out the approved commit.
+3. Check out the approved commit.
 
    ```bash
    cd "$HOME/Azure_SAP_Automated_Deployment/sap-automation"
@@ -69,7 +79,7 @@ Azure deployment.
    Git reports a detached HEAD at the approved commit unless the commit is on
    a local release branch, and `rev-parse` returns the recorded commit.
 
-3. Export the source and configuration paths.
+4. Export the source and configuration paths.
 
    ```bash
    export SAP_AUTOMATION_REPO_PATH="$(pwd)"
@@ -79,7 +89,7 @@ Azure deployment.
 
    Each variable resolves to a nonempty absolute path or subscription ID.
 
-4. Create the configuration root.
+5. Create the configuration root.
 
    ```bash
    mkdir -p "$CONFIG_REPO_PATH/WORKSPACES"
@@ -87,7 +97,7 @@ Azure deployment.
 
    The `WORKSPACES` directory exists outside the SDAF checkout.
 
-5. Install Azure CLI through your organization's approved process, then
+6. Install Azure CLI through your organization's approved process, then
    authenticate before host preparation.
 
    ```bash
@@ -107,7 +117,7 @@ Azure deployment.
    setup completes, so exporting a subscription ID without an authenticated
    session is not sufficient.
 
-6. Prepare the Linux toolchain.
+7. Prepare the Linux toolchain.
 
    ```bash
    TF_VERSION=1.14.6 \
@@ -134,7 +144,7 @@ Azure deployment.
    versions through that process instead. The deployment scripts check that
    Terraform and Azure CLI are available.
 
-7. Start a new shell or load the generated profile when present.
+8. Start a new shell or load the generated profile when present.
 
    ```bash
    if [ -f /etc/profile.d/deploy_server.sh ]; then
@@ -158,7 +168,7 @@ Azure deployment.
    approved `known_hosts` file and obtain a reviewed wrapper or execution path
    that does not override the setting.
 
-8. Verify the tool versions.
+9. Verify the tool versions.
 
    ```bash
    "$SAP_AUTOMATION_REPO_PATH/deploy/scripts/helpers/check_workstation.sh"
@@ -166,7 +176,7 @@ Azure deployment.
 
    The command prints a version for `az`, `terraform`, `ansible`, and `jq`.
 
-9. Verify the Azure context after host preparation.
+10. Verify the Azure context after host preparation.
 
    ```bash
    az account show --query '{subscription:id,tenant:tenantId,user:user.name}' \

--- a/docs/local/02-00-prepare-execution-environment.md
+++ b/docs/local/02-00-prepare-execution-environment.md
@@ -1,0 +1,181 @@
+# Prepare the local execution environment
+
+## Outcome
+
+The Linux execution host has pinned tools, an authenticated Azure identity,
+an SDAF checkout, a separate configuration root, and reviewed stage inputs.
+
+## Before you begin
+
+Complete [local execution prerequisites](01-00-prerequisites.md). Run these
+steps as a regular user with `sudo` permission. Do not run
+`configure_deployer.sh` as `root` or with `sudo`.
+
+## Inputs
+
+Define these placeholders:
+
+- `<SDAF_COMMIT>`: Approved `Azure/sap-automation` commit.
+- `<CONFIG_ROOT>`: Absolute path to the customer configuration root.
+- `<SUBSCRIPTION_ID>`: Initial target Azure subscription.
+- `<ABSOLUTE_PATH_TO_SAP_AUTOMATION_SAMPLES>`: Absolute path to the reviewed
+  `Azure/SAP-automation-samples` checkout.
+
+The scripts require:
+
+- `SAP_AUTOMATION_REPO_PATH`: SDAF checkout root.
+- `CONFIG_REPO_PATH`: Customer configuration root.
+- `ARM_SUBSCRIPTION_ID`: Current target subscription.
+
+Later stages persist nonsecret environment metadata under
+`$CONFIG_REPO_PATH/.sap_deployment_automation`.
+
+## What the automation does
+
+`configure_deployer.sh` prepares a Linux host with Terraform, Azure CLI,
+Ansible, required Python packages, and Ansible collections. It uses a Python
+virtual environment instead of changing the system Python environment. It
+also writes `/etc/profile.d/deploy_server.sh`.
+
+The script does not create customer `WORKSPACES` configuration or approve an
+Azure deployment.
+
+## Prepare the host
+
+1. Clone the SDAF repository.
+
+   ```bash
+   git clone https://github.com/Azure/sap-automation.git
+   ```
+
+   The `sap-automation` directory is created.
+
+2. Check out the approved commit.
+
+   ```bash
+   cd sap-automation
+   git checkout <SDAF_COMMIT>
+   ```
+
+   Git reports a detached HEAD at the approved commit unless the commit is on
+   a local release branch.
+
+3. Export the source and configuration paths.
+
+   ```bash
+   export SAP_AUTOMATION_REPO_PATH="$(pwd)"
+   export CONFIG_REPO_PATH="<CONFIG_ROOT>"
+   export ARM_SUBSCRIPTION_ID="<SUBSCRIPTION_ID>"
+   ```
+
+   Each variable resolves to a nonempty absolute path or subscription ID.
+
+4. Create the configuration root.
+
+   ```bash
+   mkdir -p "$CONFIG_REPO_PATH/WORKSPACES"
+   ```
+
+   The `WORKSPACES` directory exists outside the SDAF checkout.
+
+5. Prepare the Linux toolchain.
+
+   ```bash
+   TF_VERSION=1.14.6 \
+     "$SAP_AUTOMATION_REPO_PATH/deploy/scripts/configure_deployer.sh"
+   ```
+
+   The script installs Terraform under `/opt/terraform`, Azure CLI, a Python
+   virtual environment under `/opt/ansible`, Ansible dependencies, and a
+   profile script under `/etc/profile.d`.
+
+   If your organization manages these tools separately, install the approved
+   versions through that process instead. The deployment scripts check that
+   Terraform and Azure CLI are available.
+
+6. Start a new shell or load the generated profile when present.
+
+   ```bash
+   if [ -f /etc/profile.d/deploy_server.sh ]; then
+     source /etc/profile.d/deploy_server.sh
+   fi
+   ```
+
+   Terraform, Azure CLI, Ansible, and SDAF scripts are available on `PATH`.
+
+7. Verify the tool versions.
+
+   ```bash
+   "$SAP_AUTOMATION_REPO_PATH/deploy/scripts/helpers/check_workstation.sh"
+   ```
+
+   The command prints a version for `az`, `terraform`, `ansible`, and `jq`.
+
+8. Sign in to Azure.
+
+   ```bash
+   az login
+   az account set --subscription "$ARM_SUBSCRIPTION_ID"
+   az account show --query '{subscription:id,tenant:tenantId,user:user.name}' \
+     --output table
+   ```
+
+   The output identifies the intended subscription, tenant, and principal.
+   Use the approved service-principal or managed-identity sign-in instead when
+   that identity model applies.
+
+## Prepare configuration
+
+Local execution has no hosted stage-specific generator.
+
+1. Clone or browse
+   [`Azure/SAP-automation-samples`](https://github.com/Azure/SAP-automation-samples).
+2. Copy the required `Terraform/WORKSPACES` examples into
+   `$CONFIG_REPO_PATH/WORKSPACES`.
+3. Use the SDAF Web application where applicable to create, upload, edit, and
+   download workload-zone or SAP-system `.tfvars` files.
+4. Review direct edits in source control before execution.
+5. Preserve the directory and file naming relationship expected by the
+   scripts: each stage directory contains its same-named `.tfvars` file.
+
+The Web application assists with configuration. It does not replace local
+identity setup, plan review, or script execution.
+
+## Protect secrets and transient files
+
+- Store deployment credentials in the configured Azure Key Vault.
+- Keep `ARM_CLIENT_SECRET`, SAP credentials, private keys, and downloaded
+  software out of Git.
+- Exclude `.terraform/`, `.sap_deployment_automation/`, `terraform.tfstate`,
+  `*.tfplan`, `apply_output.*`, `plan_output.log`, `sshkey`, and generated
+  secret-bearing files from source control.
+- Restrict permissions on the execution host and configuration root.
+- Do not enable `DEBUG` when environment variables can contain secrets.
+
+## Review gate
+
+Review the exact commit, tool versions, Azure principal, subscription,
+configuration diff, ignored files, and outbound connectivity. Do not run a
+deployment command until the review is recorded.
+
+## Validate
+
+Confirm that:
+
+- The SDAF checkout is at the approved commit.
+- `SAP_AUTOMATION_REPO_PATH`, `CONFIG_REPO_PATH`, and
+  `ARM_SUBSCRIPTION_ID` have the expected values.
+- Azure CLI, Terraform, Ansible, and `jq` report the approved versions.
+- `az account show` reports the approved principal, tenant, and subscription.
+- The configuration root contains reviewed stage directories and no secrets
+  are tracked by source control.
+
+## Safe retry
+
+Host setup is repeatable, but `configure_deployer.sh` regenerates
+`/etc/profile.d/deploy_server.sh`. Preserve any approved local customization
+elsewhere before rerunning it.
+
+## Next step
+
+[Deploy the control plane](03-00-control-plane.md).

--- a/docs/local/02-00-prepare-execution-environment.md
+++ b/docs/local/02-00-prepare-execution-environment.md
@@ -62,7 +62,7 @@ Azure deployment.
 
    ```bash
    cd "$HOME/Azure_SAP_Automated_Deployment/sap-automation"
-   git checkout <SDAF_COMMIT>
+   git checkout "<SDAF_COMMIT>"
    git rev-parse HEAD
    ```
 

--- a/docs/local/02-00-prepare-execution-environment.md
+++ b/docs/local/02-00-prepare-execution-environment.md
@@ -45,20 +45,24 @@ Azure deployment.
 1. Clone the SDAF repository.
 
    ```bash
-   git clone https://github.com/Azure/sap-automation.git
+   mkdir -p "$HOME/Azure_SAP_Automated_Deployment"
+   git clone https://github.com/Azure/sap-automation.git \
+     "$HOME/Azure_SAP_Automated_Deployment/sap-automation"
    ```
 
-   The `sap-automation` directory is created.
+   The repository is created at the fixed checkout path used by
+   `configure_deployer.sh`.
 
 2. Check out the approved commit.
 
    ```bash
-   cd sap-automation
+   cd "$HOME/Azure_SAP_Automated_Deployment/sap-automation"
    git checkout <SDAF_COMMIT>
+   git rev-parse HEAD
    ```
 
    Git reports a detached HEAD at the approved commit unless the commit is on
-   a local release branch.
+   a local release branch, and `rev-parse` returns the recorded commit.
 
 3. Export the source and configuration paths.
 
@@ -99,9 +103,14 @@ Azure deployment.
    if [ -f /etc/profile.d/deploy_server.sh ]; then
      source /etc/profile.d/deploy_server.sh
    fi
+   export SAP_AUTOMATION_REPO_PATH="$HOME/Azure_SAP_Automated_Deployment/sap-automation"
+   export CONFIG_REPO_PATH="<CONFIG_ROOT>"
+   export ARM_SUBSCRIPTION_ID="<SUBSCRIPTION_ID>"
    ```
 
    Terraform, Azure CLI, Ansible, and SDAF scripts are available on `PATH`.
+   Re-exporting the reviewed values is required because the generated profile
+   sets its current subscription and fixed default repository paths.
 
 7. Verify the tool versions.
 

--- a/docs/local/02-00-prepare-execution-environment.md
+++ b/docs/local/02-00-prepare-execution-environment.md
@@ -159,6 +159,22 @@ Azure deployment.
    Re-exporting the reviewed values is required because the generated profile
    sets its current subscription and fixed default repository paths.
 
+   The generated profile can also export `ARM_USE_MSI=true` and an
+   `ARM_CLIENT_ID`, and can run `az login --identity`, when host setup detects
+   a user-assigned managed identity. After sourcing the profile, verify that
+   these variables still select the intended identity model:
+
+   - For Azure CLI user or service-principal execution, unset `ARM_USE_MSI`.
+     For service-principal execution, re-export the reviewed
+     `ARM_CLIENT_ID`, `ARM_CLIENT_SECRET`, `ARM_TENANT_ID`, and
+     `ARM_SUBSCRIPTION_ID` values.
+   - For managed-identity execution, verify that `ARM_USE_MSI=true` and that
+     `ARM_CLIENT_ID` identifies the approved user-assigned identity. Use the
+     reviewed system-assigned identity procedure when no client ID is needed.
+
+   Do not start deployment until `az account show` and the `ARM_*` variables
+   agree with the selected identity model and subscription.
+
    The generated profile also sets `ANSIBLE_HOST_KEY_CHECKING=False`. Before
    running configuration, verify each target host key through an approved
    out-of-band source. `configuration_menu.sh` also sets this value to `False`

--- a/docs/local/02-00-prepare-execution-environment.md
+++ b/docs/local/02-00-prepare-execution-environment.md
@@ -151,9 +151,12 @@ Azure deployment.
 
    The generated profile also sets `ANSIBLE_HOST_KEY_CHECKING=False`. Before
    running configuration, verify each target host key through an approved
-   out-of-band source. If your security policy requires strict checking,
-   populate the approved `known_hosts` file and export
-   `ANSIBLE_HOST_KEY_CHECKING=True` after loading the profile.
+   out-of-band source. `configuration_menu.sh` also sets this value to `False`
+   each time it starts, so exporting `ANSIBLE_HOST_KEY_CHECKING=True` before
+   using that wrapper does not enable strict checking. If your security policy
+   requires strict checking, do not use the wrapper unchanged. Populate the
+   approved `known_hosts` file and obtain a reviewed wrapper or execution path
+   that does not override the setting.
 
 8. Verify the tool versions.
 

--- a/docs/local/02-00-prepare-execution-environment.md
+++ b/docs/local/02-00-prepare-execution-environment.md
@@ -17,7 +17,7 @@ steps as a regular user with `sudo` permission. Do not run
 Define these placeholders:
 
 - `<SDAF_COMMIT>`: Approved `Azure/sap-automation` commit.
-- `<CONFIG_ROOT>`: Absolute path to the customer configuration root.
+- `<CONFIG_ROOT>`: Absolute path to the deployment configuration root.
 - `<SUBSCRIPTION_ID>`: Initial target Azure subscription.
 - `<ABSOLUTE_PATH_TO_SAP_AUTOMATION_SAMPLES>`: Absolute path to the reviewed
   `Azure/SAP-automation-samples` checkout.
@@ -25,7 +25,7 @@ Define these placeholders:
 The scripts require:
 
 - `SAP_AUTOMATION_REPO_PATH`: SDAF checkout root.
-- `CONFIG_REPO_PATH`: Customer configuration root.
+- `CONFIG_REPO_PATH`: Deployment configuration root.
 - `ARM_SUBSCRIPTION_ID`: Current target subscription.
 
 Later stages persist nonsecret environment metadata under
@@ -42,7 +42,7 @@ On RHEL and SLES, the script also installs `virtualenv` into system Python
 before creating the Python virtual environment under `/opt/ansible`. It writes
 `/etc/profile.d/deploy_server.sh`.
 
-The script does not create customer `WORKSPACES` configuration or approve an
+The script does not create deployment `WORKSPACES` configuration or approve an
 Azure deployment.
 
 ## Prepare the host

--- a/docs/local/02-00-prepare-execution-environment.md
+++ b/docs/local/02-00-prepare-execution-environment.md
@@ -87,7 +87,27 @@ Azure deployment.
 
    The `WORKSPACES` directory exists outside the SDAF checkout.
 
-5. Prepare the Linux toolchain.
+5. Install Azure CLI through your organization's approved process, then
+   authenticate before host preparation.
+
+   ```bash
+   command -v az
+   az login
+   az account set --subscription "$ARM_SUBSCRIPTION_ID"
+   az account show --query '{subscription:id,tenant:tenantId,user:user.name}' \
+     --output table
+   ```
+
+   The output identifies the intended subscription, tenant, and principal.
+   Use the approved service-principal sign-in instead when that identity model
+   applies. On an Azure host with managed identity, use the approved
+   `az login --identity` form.
+
+   `configure_deployer.sh` queries `az account show` before its own Azure CLI
+   setup completes, so exporting a subscription ID without an authenticated
+   session is not sufficient.
+
+6. Prepare the Linux toolchain.
 
    ```bash
    TF_VERSION=1.14.6 \
@@ -105,11 +125,16 @@ Azure deployment.
    > updates can affect software unrelated to SDAF and can require a host
    > restart.
 
+   The script ends by signing in with managed identity. Run it only on an Azure
+   host with an approved system-assigned or user-assigned managed identity. On
+   a workstation without managed identity, install the reviewed tools through
+   your organization's process instead.
+
    If your organization manages these tools separately, install the approved
    versions through that process instead. The deployment scripts check that
    Terraform and Azure CLI are available.
 
-6. Start a new shell or load the generated profile when present.
+7. Start a new shell or load the generated profile when present.
 
    ```bash
    if [ -f /etc/profile.d/deploy_server.sh ]; then
@@ -130,7 +155,7 @@ Azure deployment.
    populate the approved `known_hosts` file and export
    `ANSIBLE_HOST_KEY_CHECKING=True` after loading the profile.
 
-7. Verify the tool versions.
+8. Verify the tool versions.
 
    ```bash
    "$SAP_AUTOMATION_REPO_PATH/deploy/scripts/helpers/check_workstation.sh"
@@ -138,18 +163,15 @@ Azure deployment.
 
    The command prints a version for `az`, `terraform`, `ansible`, and `jq`.
 
-8. Sign in to Azure.
+9. Verify the Azure context after host preparation.
 
    ```bash
-   az login
-   az account set --subscription "$ARM_SUBSCRIPTION_ID"
    az account show --query '{subscription:id,tenant:tenantId,user:user.name}' \
      --output table
    ```
 
    The output identifies the intended subscription, tenant, and principal.
-   Use the approved service-principal or managed-identity sign-in instead when
-   that identity model applies.
+   Reauthenticate with the approved identity if the context changed.
 
 ## Prepare configuration
 

--- a/docs/local/03-00-control-plane.md
+++ b/docs/local/03-00-control-plane.md
@@ -1,0 +1,131 @@
+# Deploy the control plane locally
+
+## Outcome
+
+The SDAF deployer and SAP library are deployed. Terraform state is stored in
+the library state storage account, and local metadata identifies the control
+plane for later stages.
+
+## Before you begin
+
+- Complete [execution environment preparation](02-00-prepare-execution-environment.md).
+- Confirm the deployment identity can create the configured resources and
+  role assignments.
+- Confirm the management network, DNS, and state-storage design.
+- Back up the configuration repository.
+
+## Inputs
+
+Prepare and review:
+
+- `WORKSPACES/DEPLOYER/<CONTROL_PLANE>-INFRASTRUCTURE/<CONTROL_PLANE>-INFRASTRUCTURE.tfvars`
+- `WORKSPACES/LIBRARY/<ENVIRONMENT>-<LOCATION>-SAP_LIBRARY/<ENVIRONMENT>-<LOCATION>-SAP_LIBRARY.tfvars`
+
+Define `<CONTROL_PLANE>` as the first three hyphen-separated name segments
+used by the deployer configuration.
+
+Define `<ENVIRONMENT>` and `<LOCATION>` as the environment and location codes
+used by the library directory and parameter file.
+
+## Configuration preparation
+
+1. Copy deployer and library examples from
+   [`Azure/SAP-automation-samples/Terraform/WORKSPACES`](https://github.com/Azure/SAP-automation-samples/tree/main/Terraform/WORKSPACES).
+2. Review subscription IDs, resource groups, region, management networking,
+   DNS, Key Vault, storage, deployer VM, authentication, and optional Web
+   application settings.
+3. Confirm that deployer and library names describe the same environment and
+   location.
+4. Commit or otherwise record the approved customer configuration.
+
+## What the automation does
+
+[`deploy_controlplane.sh`](../../deploy/scripts/deploy_controlplane.sh):
+
+1. Validates the required exports and key parameters.
+2. Calls `install_deployer.sh` for the deployer.
+3. Calls `install_library.sh` for the SAP library.
+4. Uses bootstrap modules while remote state does not yet exist.
+5. Creates the state storage account through the library deployment.
+6. Migrates deployer and library state to the Azure Storage `tfstate`
+   container.
+7. Persists environment metadata under
+   `$CONFIG_REPO_PATH/.sap_deployment_automation`.
+8. Writes apply output and a Markdown control-plane summary.
+
+It can also invoke `installer.sh` for component migration steps required by
+the control-plane orchestration.
+
+`deploy_control_plane_v2.sh` implements the same lifecycle through sourced v2
+functions and has different option and environment-variable names. Use it only
+when selected by release guidance.
+
+## Review before execution
+
+Review the Terraform plan shown by each component. Pay particular attention to
+role assignments, network ranges, public endpoints, Key Vault access, storage
+replication, resource replacement, and monthly cost.
+
+Do not pass `--auto-approve` for an operator-reviewed local deployment.
+
+## Run
+
+1. Change to the configuration root.
+
+   ```bash
+   cd "$CONFIG_REPO_PATH/WORKSPACES"
+   ```
+
+   The current directory contains `DEPLOYER` and `LIBRARY`.
+
+2. Run the control-plane orchestrator.
+
+   ```bash
+   "$SAP_AUTOMATION_REPO_PATH/deploy/scripts/deploy_controlplane.sh" \
+     --deployer_parameter_file \
+     "DEPLOYER/<CONTROL_PLANE>-INFRASTRUCTURE/<CONTROL_PLANE>-INFRASTRUCTURE.tfvars" \
+     --library_parameter_file \
+     "LIBRARY/<ENVIRONMENT>-<LOCATION>-SAP_LIBRARY/<ENVIRONMENT>-<LOCATION>-SAP_LIBRARY.tfvars" \
+     --subscription "$ARM_SUBSCRIPTION_ID"
+   ```
+
+   Terraform displays plans and asks for approval before apply. A successful
+   run completes both deployer and library stages.
+
+Use `install_deployer.sh` and `install_library.sh` directly only when you need
+component-level execution and have reviewed their required working-directory
+and state handoff. `install_deployer.sh` must run from the deployer parameter
+directory. `install_library.sh` must run from the library parameter directory
+and requires the deployer state folder.
+
+## Validate
+
+1. Confirm that both Terraform applies completed successfully in the console.
+2. Confirm that `apply_output.log` exists in each component working directory,
+   unless automation output mode produced `apply_output.json`.
+3. Confirm that `$CONFIG_REPO_PATH/.sap_deployment_automation` contains the
+   environment metadata file.
+4. Confirm that the library output identifies the remote-state storage
+   account.
+5. Confirm that deployer and library state blobs exist in the `tfstate`
+   container.
+6. Confirm that the expected deployer and library resource groups exist.
+7. Confirm that the generated control-plane Markdown summary contains the
+   expected names.
+
+## Safe retry
+
+Rerun the same command with the same commit, parameter files, identity, and
+state. Terraform reconciles completed resources and plans remaining work.
+
+If the established control-plane orchestration was interrupted after a
+component completed, inspect the persisted `step` value and component state
+before using `--recover`. The script implements `--recover` specifically for
+its persisted control-plane step flow.
+
+Do not use `--force` as a general retry option. It changes how local Terraform
+metadata is considered and can trigger state migration or replacement paths.
+
+## Next step
+
+[Deploy a workload zone](04-00-workload-zone.md).

--- a/docs/local/03-00-control-plane.md
+++ b/docs/local/03-00-control-plane.md
@@ -83,9 +83,9 @@ Do not pass `--auto-approve` for an operator-reviewed local deployment.
    ```bash
    "$SAP_AUTOMATION_REPO_PATH/deploy/scripts/deploy_controlplane.sh" \
      --deployer_parameter_file \
-     "DEPLOYER/<CONTROL_PLANE>-INFRASTRUCTURE/<CONTROL_PLANE>-INFRASTRUCTURE.tfvars" \
+     "$CONFIG_REPO_PATH/WORKSPACES/DEPLOYER/<CONTROL_PLANE>-INFRASTRUCTURE/<CONTROL_PLANE>-INFRASTRUCTURE.tfvars" \
      --library_parameter_file \
-     "LIBRARY/<ENVIRONMENT>-<LOCATION>-SAP_LIBRARY/<ENVIRONMENT>-<LOCATION>-SAP_LIBRARY.tfvars" \
+     "$CONFIG_REPO_PATH/WORKSPACES/LIBRARY/<ENVIRONMENT>-<LOCATION>-SAP_LIBRARY/<ENVIRONMENT>-<LOCATION>-SAP_LIBRARY.tfvars" \
      --subscription "$ARM_SUBSCRIPTION_ID"
    ```
 

--- a/docs/local/03-00-control-plane.md
+++ b/docs/local/03-00-control-plane.md
@@ -36,7 +36,7 @@ used by the library directory and parameter file.
    application settings.
 3. Confirm that deployer and library names describe the same environment and
    location.
-4. Commit or otherwise record the approved customer configuration.
+4. Commit or otherwise record the approved deployment configuration.
 
 ## What the automation does
 
@@ -56,9 +56,11 @@ used by the library directory and parameter file.
 It can also invoke `installer.sh` for component migration steps required by
 the control-plane orchestration.
 
-`deploy_control_plane_v2.sh` implements the same lifecycle through sourced v2
-functions and has different option and environment-variable names. Use it only
-when selected by release guidance.
+`deploy_control_plane_v2.sh` implements the lifecycle through sourced v2
+functions and is designed to use Azure App Configuration as the central store
+for deployment metadata, including remote-state and Key Vault references. It
+has different option and environment-variable names. Use it only when selected
+by release guidance.
 
 ## Review before execution
 
@@ -124,8 +126,11 @@ component completed, inspect the persisted `step` value and component state
 before using `--recover`. The script implements `--recover` specifically for
 its persisted control-plane step flow.
 
-Do not use `--force` as a general retry option. It changes how local Terraform
-metadata is considered and can trigger state migration or replacement paths.
+> [!WARNING]
+> Do not use `--force` as a general retry option. It changes how local
+> Terraform metadata is considered and can trigger state migration or
+> replacement paths. Use it only with a reviewed state migration or recovery
+> plan.
 
 ## Next step
 

--- a/docs/local/03-00-control-plane.md
+++ b/docs/local/03-00-control-plane.md
@@ -101,8 +101,9 @@ and requires the deployer state folder.
 ## Validate
 
 1. Confirm that both Terraform applies completed successfully in the console.
-2. Confirm that `apply_output.log` exists in each component working directory,
-   unless automation output mode produced `apply_output.json`.
+2. Confirm that `apply_output.log` exists in each component working directory.
+   The documented interactive execution retains this log; automation mode uses
+   `apply_output.json` only as a transient processing artifact.
 3. Confirm that `$CONFIG_REPO_PATH/.sap_deployment_automation` contains the
    environment metadata file.
 4. Confirm that the library output identifies the remote-state storage

--- a/docs/local/04-00-workload-zone.md
+++ b/docs/local/04-00-workload-zone.md
@@ -29,6 +29,8 @@ Also identify:
 - `<STATE_STORAGE_ACCOUNT>`: Library output
   `remote_state_storage_account_name`.
 - `<STATE_SUBSCRIPTION_ID>`: Subscription containing the state account.
+- `<WORKLOAD_SUBSCRIPTION_ID>`: Subscription where workload-zone resources are
+  deployed.
 
 ## Configuration preparation
 
@@ -89,7 +91,8 @@ cross-subscription resources.
      --control_plane_name "<CONTROL_PLANE>" \
      --deployer_tfstate_key "<DEPLOYER_STATE_KEY>" \
      --storageaccountname "<STATE_STORAGE_ACCOUNT>" \
-     --state_subscription "<STATE_SUBSCRIPTION_ID>"
+     --state_subscription "<STATE_SUBSCRIPTION_ID>" \
+     --subscription "<WORKLOAD_SUBSCRIPTION_ID>"
    ```
 
    Terraform displays the plan and asks for approval before apply.

--- a/docs/local/04-00-workload-zone.md
+++ b/docs/local/04-00-workload-zone.md
@@ -97,7 +97,8 @@ cross-subscription resources.
 ## Validate
 
 1. Confirm that Terraform apply completed successfully.
-2. Confirm that `apply_output.log` or `apply_output.json` records the apply.
+2. Confirm that `apply_output.log` records the apply. Automation mode uses
+   `apply_output.json` only as a transient processing artifact.
 3. Confirm that the workload-zone resource group and configured shared
    services exist.
 4. Confirm that the workload-zone state blob is named
@@ -120,4 +121,3 @@ have a state migration or recovery plan.
 ## Next step
 
 [Deploy an SAP system](05-00-sap-system.md).
-

--- a/docs/local/04-00-workload-zone.md
+++ b/docs/local/04-00-workload-zone.md
@@ -118,8 +118,9 @@ cross-subscription resources.
 Rerun the same command after correcting the cause. Use the same commit,
 configuration, state account, state key, and identity. Review the new plan.
 
-Do not use `--force` unless you have reviewed its local-state handling and
-have a state migration or recovery plan.
+> [!WARNING]
+> Do not use `--force` unless you have reviewed its local-state handling and
+> have a state migration or recovery plan.
 
 ## Next step
 

--- a/docs/local/04-00-workload-zone.md
+++ b/docs/local/04-00-workload-zone.md
@@ -1,0 +1,123 @@
+# Deploy a workload zone locally
+
+## Outcome
+
+The workload-zone network, shared services, Key Vault, storage, and related
+resources defined by the landscape configuration are deployed and connected
+to the control-plane state.
+
+## Before you begin
+
+- Complete [control-plane deployment](03-00-control-plane.md).
+- Confirm the remote-state storage account and deployer state key.
+- Confirm workload subscription access, DNS ownership, network peering, and
+  quota.
+- Confirm the execution host can reach the control-plane Key Vault and state
+  storage account.
+
+## Inputs
+
+Prepare:
+
+`WORKSPACES/LANDSCAPE/<WORKLOAD_ZONE>-INFRASTRUCTURE/<WORKLOAD_ZONE>-INFRASTRUCTURE.tfvars`
+
+Also identify:
+
+- `<CONTROL_PLANE>`: Control-plane name.
+- `<DEPLOYER_STATE_KEY>`: Usually
+  `<CONTROL_PLANE>-INFRASTRUCTURE.terraform.tfstate`.
+- `<STATE_STORAGE_ACCOUNT>`: Library output
+  `remote_state_storage_account_name`.
+- `<STATE_SUBSCRIPTION_ID>`: Subscription containing the state account.
+
+## Configuration preparation
+
+1. Copy a landscape example from the shared samples repository or download a
+   reviewed workload-zone `.tfvars` file from the SDAF Web application.
+2. Review the workload subscription, virtual network, subnets, DNS, peering,
+   Key Vault, storage, NFS, witness, transport, and optional existing-resource
+   identifiers.
+3. Confirm that `<WORKLOAD_ZONE>` follows the environment, location, and
+   logical network naming used by the `.tfvars` file.
+4. Record approval of the final configuration.
+
+## What the automation does
+
+[`install_workloadzone.sh`](../../deploy/scripts/install_workloadzone.sh):
+
+- Loads control-plane metadata from
+  `$CONFIG_REPO_PATH/.sap_deployment_automation`.
+- Configures the `sap_landscape` Terraform root module.
+- Reads deployer remote state.
+- Runs Terraform plan with detailed exit codes.
+- Checks plan output for selected replacement and data-loss risks.
+- Applies the approved plan.
+- Persists workload-zone metadata.
+- Uploads the `.tfvars` file and local backend metadata to the state storage
+  account's `tfvars` container.
+- Writes `apply_output.log` or `apply_output.json` and a workload-zone
+  Markdown summary.
+
+## Review before execution
+
+Review the plan for address-space changes, subnet replacement, DNS-zone
+changes, storage replacement, Key Vault changes, role assignments, and
+cross-subscription resources.
+
+> [!WARNING]
+> Stop if the script reports that the environment uses older Terraform
+> templates or that the plan risks data loss. Review the complete plan and
+> migration path before continuing.
+
+## Run
+
+1. Change to the landscape parameter directory.
+
+   ```bash
+   cd \
+     "$CONFIG_REPO_PATH/WORKSPACES/LANDSCAPE/<WORKLOAD_ZONE>-INFRASTRUCTURE"
+   ```
+
+   The current directory contains
+   `<WORKLOAD_ZONE>-INFRASTRUCTURE.tfvars`.
+
+2. Run the workload-zone installer.
+
+   ```bash
+   "$SAP_AUTOMATION_REPO_PATH/deploy/scripts/install_workloadzone.sh" \
+     --parameterfile "<WORKLOAD_ZONE>-INFRASTRUCTURE.tfvars" \
+     --control_plane_name "<CONTROL_PLANE>" \
+     --deployer_tfstate_key "<DEPLOYER_STATE_KEY>" \
+     --storageaccountname "<STATE_STORAGE_ACCOUNT>" \
+     --state_subscription "<STATE_SUBSCRIPTION_ID>"
+   ```
+
+   Terraform displays the plan and asks for approval before apply.
+
+## Validate
+
+1. Confirm that Terraform apply completed successfully.
+2. Confirm that `apply_output.log` or `apply_output.json` records the apply.
+3. Confirm that the workload-zone resource group and configured shared
+   services exist.
+4. Confirm that the workload-zone state blob is named
+   `<WORKLOAD_ZONE>-INFRASTRUCTURE.terraform.tfstate`.
+5. Confirm that the `tfvars/LANDSCAPE` path contains the uploaded
+   configuration and backend metadata.
+6. Confirm that the workload-zone Markdown summary contains the expected
+   subscription, network, Key Vault, and storage details.
+7. Confirm connectivity and name resolution from the execution host or
+   deployer to the workload zone.
+
+## Safe retry
+
+Rerun the same command after correcting the cause. Use the same commit,
+configuration, state account, state key, and identity. Review the new plan.
+
+Do not use `--force` unless you have reviewed its local-state handling and
+have a state migration or recovery plan.
+
+## Next step
+
+[Deploy an SAP system](05-00-sap-system.md).
+

--- a/docs/local/04-00-workload-zone.md
+++ b/docs/local/04-00-workload-zone.md
@@ -50,7 +50,6 @@ Also identify:
 - Configures the `sap_landscape` Terraform root module.
 - Reads deployer remote state.
 - Runs Terraform plan with detailed exit codes.
-- Checks plan output for selected replacement and data-loss risks.
 - Applies the approved plan.
 - Persists workload-zone metadata.
 - Uploads the `.tfvars` file and local backend metadata to the state storage
@@ -65,9 +64,10 @@ changes, storage replacement, Key Vault changes, role assignments, and
 cross-subscription resources.
 
 > [!WARNING]
-> Stop if the script reports that the environment uses older Terraform
-> templates or that the plan risks data loss. Review the complete plan and
-> migration path before continuing.
+> Stop if the displayed plan shows older Terraform templates, replacement, or
+> data-loss risk. The fresh local execution path does not capture the current
+> plan for automated replacement checks, so operator review of the complete
+> plan and migration path is required.
 
 ## Run
 
@@ -106,7 +106,7 @@ cross-subscription resources.
 5. Confirm that the `tfvars/LANDSCAPE` path contains the uploaded
    configuration and backend metadata.
 6. Confirm that the workload-zone Markdown summary contains the expected
-   subscription, network, Key Vault, and storage details.
+   environment, location, and Key Vault name.
 7. Confirm connectivity and name resolution from the execution host or
    deployer to the workload zone.
 

--- a/docs/local/05-00-sap-system.md
+++ b/docs/local/05-00-sap-system.md
@@ -104,7 +104,8 @@ Do not pass `--auto-approve`.
 ## Validate
 
 1. Confirm that Terraform apply completed successfully.
-2. Confirm that `apply_output.log` or `apply_output.json` records the apply.
+2. Confirm that `apply_output.log` records the apply. Automation mode uses
+   `apply_output.json` only as a transient processing artifact.
 3. Confirm that the expected SAP-system resource group, VMs, disks, network
    interfaces, and load balancers exist.
 4. Confirm that the system state blob is named

--- a/docs/local/05-00-sap-system.md
+++ b/docs/local/05-00-sap-system.md
@@ -1,0 +1,131 @@
+# Deploy an SAP system locally
+
+## Outcome
+
+The SAP-system infrastructure is deployed in the workload zone. The system
+workspace contains generated Ansible inventory and SAP parameter files for
+software download and installation.
+
+## Before you begin
+
+- Complete [workload-zone deployment](04-00-workload-zone.md).
+- Confirm the workload-zone state key and remote-state account.
+- Confirm VM-family quota, image availability, storage performance, DNS,
+  load-balancer, availability-zone, and high-availability decisions.
+- Confirm the configured operating systems and database topology are
+  compatible with the intended SAP product.
+
+## Inputs
+
+Prepare:
+
+`WORKSPACES/SYSTEM/<SAP_SYSTEM>/<SAP_SYSTEM>.tfvars`
+
+Also identify:
+
+- `<SAP_SYSTEM>`: Same-named system directory and `.tfvars` base name.
+- `<CONTROL_PLANE>`: Control-plane name.
+- `<WORKLOAD_ZONE>`: Workload-zone name.
+- `<DEPLOYER_STATE_KEY>`: Deployer state blob name.
+- `<LANDSCAPE_STATE_KEY>`: Usually
+  `<WORKLOAD_ZONE>-INFRASTRUCTURE.terraform.tfstate`.
+- `<STATE_STORAGE_ACCOUNT>`: Remote-state storage account name.
+- `<STATE_SUBSCRIPTION_ID>`: Subscription containing that storage account.
+
+## Configuration preparation
+
+1. Copy a system example from the shared samples repository or download a
+   reviewed SAP-system `.tfvars` file from the SDAF Web application.
+2. Review the SAP SID, database SID, VM roles, VM sizes, disks, images,
+   availability, load balancers, accelerated networking, credentials,
+   existing-resource IDs, and optional services.
+3. Review every resource replacement that could affect database or SAP
+   application data.
+4. Record approval of the complete system topology and cost.
+
+## What the automation does
+
+[`installer.sh`](../../deploy/scripts/installer.sh) with
+`--type sap_system`:
+
+- Loads control-plane and workload-zone metadata.
+- Configures the `sap_system` Terraform root module.
+- Reads deployer and landscape remote state.
+- Runs Terraform plan with detailed exit codes.
+- Checks plan output for replacement of state storage, SAP library storage,
+  VMs, and managed disks.
+- Applies the approved plan.
+- Uploads configuration and metadata to the `tfvars` container.
+- Generates `<SID>_hosts.yaml`, `sap-parameters.yaml`, inventory summaries,
+  and other output files in the current system directory.
+- Writes `apply_output.log` or `apply_output.json`.
+
+[`installer_v2.sh`](../../deploy/scripts/installer_v2.sh) provides a v2
+implementation. It uses `--parameter_file` instead of `--parameterfile` and
+different state environment-variable names. Do not mix its options with the
+established command.
+
+## Review before execution
+
+Review the complete Terraform plan.
+
+> [!WARNING]
+> Stop if the plan replaces a database VM, application VM, SCS VM, Web
+> Dispatcher VM, managed data disk, SAP library storage account, or Terraform
+> state storage account. Replacement can cause downtime or data loss.
+
+Do not pass `--auto-approve`.
+
+## Run
+
+1. Change to the system parameter directory.
+
+   ```bash
+   cd "$CONFIG_REPO_PATH/WORKSPACES/SYSTEM/<SAP_SYSTEM>"
+   ```
+
+   The current directory contains `<SAP_SYSTEM>.tfvars`.
+
+2. Run the SAP-system installer.
+
+   ```bash
+   "$SAP_AUTOMATION_REPO_PATH/deploy/scripts/installer.sh" \
+     --type sap_system \
+     --parameterfile "<SAP_SYSTEM>.tfvars" \
+     --control_plane_name "<CONTROL_PLANE>" \
+     --deployer_tfstate_key "<DEPLOYER_STATE_KEY>" \
+     --landscape_tfstate_key "<LANDSCAPE_STATE_KEY>" \
+     --storageaccountname "<STATE_STORAGE_ACCOUNT>" \
+     --state_subscription "<STATE_SUBSCRIPTION_ID>"
+   ```
+
+   Terraform displays the plan and asks for approval before apply.
+
+## Validate
+
+1. Confirm that Terraform apply completed successfully.
+2. Confirm that `apply_output.log` or `apply_output.json` records the apply.
+3. Confirm that the expected SAP-system resource group, VMs, disks, network
+   interfaces, and load balancers exist.
+4. Confirm that the system state blob is named
+   `<SAP_SYSTEM>.terraform.tfstate`.
+5. Confirm that `<SID>_hosts.yaml` exists in the system directory.
+6. Confirm that `sap-parameters.yaml` exists in the system directory.
+7. Confirm that the generated inventory contains the expected host groups and
+   private addresses.
+8. Confirm that the `tfvars/SYSTEM` path contains the uploaded configuration
+   and generated files defined by the module.
+
+## Safe retry
+
+Rerun the same command with the same source, inputs, identity, and state after
+correcting the failure. Review the new plan before approval.
+
+If generated files are missing after a successful infrastructure apply,
+inspect Terraform output and local-file errors before running Ansible. Do not
+create an inventory manually unless it is reviewed against the module's
+generated structure.
+
+## Next step
+
+[Download SAP software and run configuration and installation](06-00-software-and-installation.md).

--- a/docs/local/05-00-sap-system.md
+++ b/docs/local/05-00-sap-system.md
@@ -31,6 +31,8 @@ Also identify:
   `<WORKLOAD_ZONE>-INFRASTRUCTURE.terraform.tfstate`.
 - `<STATE_STORAGE_ACCOUNT>`: Remote-state storage account name.
 - `<STATE_SUBSCRIPTION_ID>`: Subscription containing that storage account.
+- `<WORKLOAD_SUBSCRIPTION_ID>`: Subscription where the SAP-system resources
+  are deployed.
 
 ## Configuration preparation
 
@@ -89,6 +91,7 @@ Do not pass `--auto-approve`.
 2. Run the SAP-system installer.
 
    ```bash
+   ARM_SUBSCRIPTION_ID="<WORKLOAD_SUBSCRIPTION_ID>" \
    "$SAP_AUTOMATION_REPO_PATH/deploy/scripts/installer.sh" \
      --type sap_system \
      --parameterfile "<SAP_SYSTEM>.tfvars" \

--- a/docs/local/05-00-sap-system.md
+++ b/docs/local/05-00-sap-system.md
@@ -9,7 +9,7 @@ software download and installation.
 ## Before you begin
 
 - Complete [workload-zone deployment](04-00-workload-zone.md).
-- Confirm the workload-zone state key and remote-state account.
+- Confirm the workload-zone state blob name and remote-state account.
 - Confirm VM-family quota, image availability, storage performance, DNS,
   load-balancer, availability-zone, and high-availability decisions.
 - Confirm the configured operating systems and database topology are
@@ -27,7 +27,8 @@ Also identify:
 - `<CONTROL_PLANE>`: Control-plane name.
 - `<WORKLOAD_ZONE>`: Workload-zone name.
 - `<DEPLOYER_STATE_KEY>`: Deployer state blob name.
-- `<LANDSCAPE_STATE_KEY>`: Usually
+- `<LANDSCAPE_STATE_KEY>` (also called `<WORKLOAD_ZONE_STATE_KEY>`): Workload-zone
+  Terraform state blob name in the `tfstate` container, usually
   `<WORKLOAD_ZONE>-INFRASTRUCTURE.terraform.tfstate`.
 - `<STATE_STORAGE_ACCOUNT>`: Remote-state storage account name.
 - `<STATE_SUBSCRIPTION_ID>`: Subscription containing that storage account.
@@ -52,7 +53,7 @@ Also identify:
 
 - Loads control-plane and workload-zone metadata.
 - Configures the `sap_system` Terraform root module.
-- Reads deployer and landscape remote state.
+- Reads deployer and landscape (workload-zone) remote state.
 - Runs Terraform plan with detailed exit codes.
 - Checks plan output for replacement of state storage, SAP library storage,
   VMs, and managed disks.
@@ -62,10 +63,12 @@ Also identify:
   and other output files in the current system directory.
 - Writes `apply_output.log` or `apply_output.json`.
 
-[`installer_v2.sh`](../../deploy/scripts/installer_v2.sh) provides a v2
-implementation. It uses `--parameter_file` instead of `--parameterfile` and
-different state environment-variable names. Do not mix its options with the
-established command.
+[`installer_v2.sh`](../../deploy/scripts/installer_v2.sh) provides the v2
+implementation designed to retrieve shared deployment metadata from Azure App
+Configuration, including remote-state and Key Vault references. It uses
+`--parameter_file` instead of `--parameterfile` and different state
+environment-variable names. Do not mix its options with the established
+command.
 
 ## Review before execution
 

--- a/docs/local/06-00-software-and-installation.md
+++ b/docs/local/06-00-software-and-installation.md
@@ -1,0 +1,177 @@
+# Download software and install SAP locally
+
+## Outcome
+
+The approved SAP software is available in the SAP library, and the selected
+operating-system, database, high-availability, and SAP installation playbooks
+have completed against the generated inventory.
+
+## Before you begin
+
+- Complete [SAP-system infrastructure deployment](05-00-sap-system.md).
+- Confirm `sap-parameters.yaml` and `<SID>_hosts.yaml` exist in the system
+  directory.
+- Confirm SSH connectivity from the execution host to every inventory host.
+- Confirm the workload-zone Key Vault contains the generated credentials.
+- Confirm the SAP library has sufficient capacity.
+- Confirm SAP licenses and download credentials.
+- Back up the system and obtain a maintenance window before rerunning
+  installation playbooks on an existing system.
+
+## Inputs and BOM ownership
+
+Define `<SAP_SYSTEM>` as the same-named system directory and `.tfvars` base
+name. Define `<ABSOLUTE_PATH_TO_SAP_AUTOMATION_SAMPLES>` as the absolute path
+to the reviewed samples checkout.
+
+The
+[`Azure/SAP-automation-samples`](https://github.com/Azure/SAP-automation-samples)
+repository owns the `SAP` application definitions and `BOM` files.
+
+Set `BOM_CATALOG` to the root of a reviewed samples checkout that contains
+the `SAP/` and `BOM/` directories:
+
+```bash
+export BOM_CATALOG="<ABSOLUTE_PATH_TO_SAP_AUTOMATION_SAMPLES>"
+```
+
+`download_menu.sh` passes this value to Ansible as `BOM_directory`. The BOM
+utility searches below that root, including:
+
+- `SAP/<name>/<name>.yaml`
+- `BOM/<name>/<name>.yaml`
+- `archives/<name>/<name>.yaml`
+
+Do not set `BOM_CATALOG` to an individual BOM directory.
+
+The software-download wrapper reads these values from `sap-parameters.yaml`:
+
+- `application_bom_name`
+- `database_bom_name`
+- `sap_kernel_bom_name`
+- `save_bom_as`
+
+It passes the selected combination to
+[`playbook_bom_downloader.yaml`](../../deploy/ansible/playbook_bom_downloader.yaml).
+
+## Configuration preparation
+
+1. Review the application, database, and kernel BOMs in the samples checkout.
+2. Review all SAP download URLs, archive names, checksums, and target product
+   versions.
+3. Review `sap-parameters.yaml`, especially the BOM names, SAP SID, database
+   SID, Key Vault name, secret prefix, and installation options.
+4. Review `<SID>_hosts.yaml` for expected hosts and groups.
+5. Record approval of the software versions and installation scope.
+
+## What the automation does
+
+[`download_menu.sh`](../../deploy/ansible/download_menu.sh):
+
+- Requires `sap-parameters.yaml` in the current directory.
+- Requires `BOM_CATALOG` to identify the samples root.
+- Runs the BOM downloader playbook interactively.
+- Downloads and stages software according to the selected BOM definitions.
+
+[`configuration_menu.sh`](../../deploy/ansible/configuration_menu.sh):
+
+- Requires `sap-parameters.yaml` in the current directory.
+- Derives the inventory name from `sap_sid`.
+- Retrieves the system password from the workload-zone Key Vault.
+- Retrieves the SAP system SSH key from the workload-zone Key Vault through
+  `pb_get-sshkey.yaml`.
+- Runs selected numbered playbooks.
+- Runs customer pre- and post-playbooks from
+  `$CONFIG_REPO_PATH/ANSIBLE` when matching files exist.
+- Stops the selected sequence after a failed playbook.
+
+The menu exposes validation, OS configuration, SAP OS configuration, BOM
+processing, SCS, database, database load, database HA, PAS, application
+server, Web Dispatcher, ACSS, AMS, HCMT, post-installation, and grouped
+selections.
+
+## Review before execution
+
+Review SAP license terms, download destinations, credentials, disk capacity,
+inventory targets, playbook selection, maintenance windows, and custom
+pre/post playbooks.
+
+> [!WARNING]
+> Installation playbooks change operating systems, storage, clusters,
+> databases, and SAP instances. Do not select **All Playbooks** on an existing
+> system without reviewing idempotence, progress markers, and recovery for
+> every included playbook.
+
+## Download software
+
+1. Change to the SAP-system directory.
+
+   ```bash
+   cd "$CONFIG_REPO_PATH/WORKSPACES/SYSTEM/<SAP_SYSTEM>"
+   ```
+
+2. Confirm the BOM catalog root.
+
+   ```bash
+   test -d "$BOM_CATALOG/SAP"
+   test -d "$BOM_CATALOG/BOM"
+   ```
+
+   Both commands return successfully.
+
+3. Start the download menu.
+
+   ```bash
+   "$SAP_AUTOMATION_REPO_PATH/deploy/ansible/download_menu.sh"
+   ```
+
+4. Select **BOM Downloader**.
+
+   The playbook reports each selected archive and download result.
+
+## Run configuration and installation
+
+1. Start the configuration menu from the same system directory.
+
+   ```bash
+   "$SAP_AUTOMATION_REPO_PATH/deploy/ansible/configuration_menu.sh"
+   ```
+
+2. Select **Validate parameters** first.
+
+   The validation playbook confirms required parameters and host reachability.
+
+3. Select one reviewed playbook or grouped sequence.
+
+   The wrapper reports the current playbook and stops if it returns a nonzero
+   status.
+
+4. Repeat the menu for the next approved sequence.
+
+   Progress files under the workspace `.progress` directory provide evidence
+   for BOM and installation stages that implement markers.
+
+## Validate
+
+1. Confirm that the downloader reports success for every required archive.
+2. Confirm that the SAP library contains the expected software.
+3. Confirm that each selected playbook reports successful completion.
+4. Confirm expected `.progress` markers on the target workspace.
+5. Confirm operating-system, database, cluster, and SAP service health using
+   the product-specific operational checks.
+6. Retain Ansible console output and relevant target logs with the deployment
+   record.
+
+## Safe retry
+
+Correct the failed prerequisite or task, then rerun the smallest applicable
+playbook. The menu stops after a failure, so do not restart a grouped sequence
+without identifying the failed playbook and reviewing its progress marker and
+idempotence.
+
+Do not delete `.progress` markers merely to force a rerun. Review the role that
+owns the marker and the target system state first.
+
+## Next step
+
+[Operate, recover, and remove the deployment](07-00-operations.md).

--- a/docs/local/06-00-software-and-installation.md
+++ b/docs/local/06-00-software-and-installation.md
@@ -96,9 +96,9 @@ whitespace-delimited field instead of parsing YAML.
 - Retrieves the SAP system SSH key from the workload-zone Key Vault through
   `pb_get-sshkey.yaml`.
 - Runs selected numbered playbooks.
-- Runs customer pre- and post-playbooks from
+- Runs custom pre- and post-playbooks from
   `$CONFIG_REPO_PATH/ANSIBLE` when matching files exist.
-- Reports customer hook failures but continues to the numbered playbook or the
+- Reports custom hook failures but continues to the numbered playbook or the
   next selected playbook.
 - Stops the selected sequence after a failed numbered playbook.
 
@@ -117,7 +117,8 @@ pre/post playbooks.
 > Installation playbooks change operating systems, storage, clusters,
 > databases, and SAP instances. Do not select **All Playbooks** on an existing
 > system without reviewing idempotence, progress markers, and recovery for
-> every included playbook.
+> every included playbook. Some underlying Ansible modules or roles might not
+> be idempotent.
 
 ## Download software
 
@@ -161,7 +162,7 @@ pre/post playbooks.
 3. Select one reviewed playbook or grouped sequence.
 
    The wrapper reports the current playbook and stops if a numbered playbook
-   returns a nonzero status. Customer pre- and post-playbook failures are
+   returns a nonzero status. Custom pre- and post-playbook failures are
    reported but do not stop the sequence.
 
 4. After the menu exits, remove the retrieved private-key file immediately.
@@ -195,12 +196,13 @@ pre/post playbooks.
 
 Correct the failed prerequisite or task, then rerun the smallest applicable
 playbook. Before restarting a grouped sequence, identify any failed numbered
-playbook or customer hook and review its output, progress marker, and
+playbook or custom hook and review its output, progress marker, and
 idempotence. A failed pre-hook does not prevent the numbered playbook from
 running, and a failed post-hook does not stop the next selected playbook.
 
-Do not delete `.progress` markers merely to force a rerun. Review the role that
-owns the marker and the target system state first.
+> [!WARNING]
+> Do not delete `.progress` markers merely to force a rerun. Review the role
+> that owns the marker and the target system state first.
 
 ## Next step
 

--- a/docs/local/06-00-software-and-installation.md
+++ b/docs/local/06-00-software-and-installation.md
@@ -83,7 +83,9 @@ It passes the selected combination to
 - Runs selected numbered playbooks.
 - Runs customer pre- and post-playbooks from
   `$CONFIG_REPO_PATH/ANSIBLE` when matching files exist.
-- Stops the selected sequence after a failed playbook.
+- Reports customer hook failures but continues to the numbered playbook or the
+  next selected playbook.
+- Stops the selected sequence after a failed numbered playbook.
 
 The menu exposes validation, OS configuration, SAP OS configuration, BOM
 processing, SCS, database, database load, database HA, PAS, application
@@ -143,8 +145,9 @@ pre/post playbooks.
 
 3. Select one reviewed playbook or grouped sequence.
 
-   The wrapper reports the current playbook and stops if it returns a nonzero
-   status.
+   The wrapper reports the current playbook and stops if a numbered playbook
+   returns a nonzero status. Customer pre- and post-playbook failures are
+   reported but do not stop the sequence.
 
 4. Repeat the menu for the next approved sequence.
 
@@ -165,9 +168,10 @@ pre/post playbooks.
 ## Safe retry
 
 Correct the failed prerequisite or task, then rerun the smallest applicable
-playbook. The menu stops after a failure, so do not restart a grouped sequence
-without identifying the failed playbook and reviewing its progress marker and
-idempotence.
+playbook. Before restarting a grouped sequence, identify any failed numbered
+playbook or customer hook and review its output, progress marker, and
+idempotence. A failed pre-hook does not prevent the numbered playbook from
+running, and a failed post-hook does not stop the next selected playbook.
 
 Do not delete `.progress` markers merely to force a rerun. Review the role that
 owns the marker and the target system state first.

--- a/docs/local/06-00-software-and-installation.md
+++ b/docs/local/06-00-software-and-installation.md
@@ -44,15 +44,29 @@ utility searches below that root, including:
 
 Do not set `BOM_CATALOG` to an individual BOM directory.
 
-The software-download wrapper reads these values from `sap-parameters.yaml`:
+The Terraform-generated `sap-parameters.yaml` contains `bom_base_name`, but
+`download_menu.sh` does not preserve that value. The wrapper instead requires
+these component keys:
 
 - `application_bom_name`
 - `database_bom_name`
 - `sap_kernel_bom_name`
 - `save_bom_as`
 
-It passes the selected combination to
+Before using the download menu, add reviewed values for all four keys to
+`sap-parameters.yaml`:
+
+```yaml
+application_bom_name: "<APPLICATION_BOM>"
+database_bom_name: "<DATABASE_BOM>"
+sap_kernel_bom_name: "<KERNEL_BOM>"
+save_bom_as: "<COMBINED_BOM_NAME>"
+```
+
+The wrapper combines the four values and passes the result to
 [`playbook_bom_downloader.yaml`](../../deploy/ansible/playbook_bom_downloader.yaml).
+Without these keys, it overrides the generated BOM value with an invalid empty
+combination.
 
 ## Configuration preparation
 

--- a/docs/local/06-00-software-and-installation.md
+++ b/docs/local/06-00-software-and-installation.md
@@ -164,7 +164,18 @@ pre/post playbooks.
    returns a nonzero status. Customer pre- and post-playbook failures are
    reported but do not stop the sequence.
 
-4. Repeat the menu for the next approved sequence.
+4. After the menu exits, remove the retrieved private-key file immediately.
+
+   ```bash
+   rm -f -- "$PWD/sshkey"
+   test ! -e "$PWD/sshkey"
+   ```
+
+   The wrapper removes `sshkey` only when **Quit** is selected. A normal
+   playbook selection exits without removing it, including after a failed
+   numbered playbook.
+
+5. Repeat steps 1 through 4 for the next approved sequence.
 
    Progress files under the workspace `.progress` directory provide evidence
    for BOM and installation stages that implement markers.

--- a/docs/local/06-00-software-and-installation.md
+++ b/docs/local/06-00-software-and-installation.md
@@ -57,16 +57,17 @@ Before using the download menu, add reviewed values for all four keys to
 `sap-parameters.yaml`:
 
 ```yaml
-application_bom_name: "<APPLICATION_BOM>"
-database_bom_name: "<DATABASE_BOM>"
-sap_kernel_bom_name: "<KERNEL_BOM>"
-save_bom_as: "<COMBINED_BOM_NAME>"
+application_bom_name: <APPLICATION_BOM>
+database_bom_name: <DATABASE_BOM>
+sap_kernel_bom_name: <KERNEL_BOM>
+save_bom_as: <COMBINED_BOM_NAME>
 ```
 
 The wrapper combines the four values and passes the result to
 [`playbook_bom_downloader.yaml`](../../deploy/ansible/playbook_bom_downloader.yaml).
 Without these keys, it overrides the generated BOM value with an invalid empty
-combination.
+combination. Keep these values unquoted because the wrapper extracts the second
+whitespace-delimited field instead of parsing YAML.
 
 ## Configuration preparation
 

--- a/docs/local/07-00-operations.md
+++ b/docs/local/07-00-operations.md
@@ -1,0 +1,225 @@
+# Operate, recover, and remove a local deployment
+
+## Outcome
+
+You can apply reviewed changes, retain evidence, recover state deliberately,
+retry deterministically, and remove resources in dependency order.
+
+## Before you begin
+
+Keep the approved SDAF commit, configuration, remote-state account, state
+keys, `.sap_deployment_automation` metadata, generated inventory, and logs.
+Document any manual Azure changes.
+
+## Inputs
+
+For an operation, identify:
+
+- `<SAP_SYSTEM>`: Same-named SAP-system directory and `.tfvars` base name.
+- `<WORKLOAD_ZONE>`: Workload-zone name.
+- `<CONTROL_PLANE>`: Control-plane name.
+- `<ENVIRONMENT>` and `<LOCATION>`: Library environment and location codes.
+- `<DEPLOYER_STATE_KEY>`: Deployer state blob name.
+- `<LANDSCAPE_STATE_KEY>`: Workload-zone state blob name.
+- `<STATE_STORAGE_ACCOUNT>`: Remote-state storage account name.
+- `<STATE_SUBSCRIPTION_ID>`: Subscription containing the state account.
+- The matching deployment and removal script family.
+- The Azure identity and maintenance window.
+- Required backups, retained resources, and approvers.
+
+## Prepare an operational change
+
+1. Reconcile the customer configuration, remote state, and Azure resources.
+2. Record drift or manual Azure changes.
+3. Back up business data and state before a risky or destructive operation.
+4. Review dependencies on shared control-plane and workload-zone resources.
+5. Approve the exact command, expected plan, validation, and rollback path.
+
+## What the automation does
+
+The stage installers reinitialize the matching Terraform root module, read
+remote state, create a plan, apply approved changes, and refresh stage
+metadata. `remover.sh` runs Terraform destroy for a selected `sap_system` or
+`sap_landscape`. `remove_controlplane.sh` removes library and deployer
+resources. `advanced_state_management.sh` lists, imports, or removes Terraform
+state entries.
+
+## Review before execution
+
+Review state ownership, replacement or deletion, service downtime, backups,
+retained shared resources, role assignments, locks, and the reverse dependency
+order. Do not use `--auto-approve` for an operator-reviewed change or removal.
+
+## Apply an approved change
+
+1. Update one stage's customer configuration.
+2. Review the source-control diff.
+3. Confirm the same SDAF and tool versions used by the environment, or approve
+   an upgrade plan.
+4. Run the same stage command without `--auto-approve`.
+5. Review the complete Terraform plan.
+6. Approve only the intended changes.
+7. Validate Azure resources and dependent services.
+8. Retain the configuration revision and apply output.
+
+Apply stages in dependency order: control plane, workload zone, SAP system,
+then Ansible configuration.
+
+## Manage state safely
+
+Remote Terraform state is the authoritative infrastructure record after
+control-plane bootstrap. Local `.terraform/terraform.tfstate` files contain
+backend metadata and can be uploaded to the `tfvars` container by the scripts;
+they are not a substitute for the remote state blob.
+
+Use
+[`advanced_state_management.sh`](../../deploy/scripts/advanced_state_management.sh)
+only for a reviewed state operation. It supports `list`, `import`, and
+`remove` for `sap_deployer`, `sap_library`, `sap_landscape`, and `sap_system`.
+
+> [!WARNING]
+> `state rm` stops Terraform from managing a resource without deleting the
+> Azure resource. `import` changes the resource-to-state association. An
+> incorrect address or Azure resource ID can cause later replacement or
+> deletion. Back up state and obtain expert review before either operation.
+
+List state before changing it:
+
+```bash
+cd "$CONFIG_REPO_PATH/WORKSPACES/SYSTEM/<SAP_SYSTEM>"
+"$SAP_AUTOMATION_REPO_PATH/deploy/scripts/advanced_state_management.sh" \
+  --parameterfile "<SAP_SYSTEM>.tfvars" \
+  --type sap_system \
+  --operation list \
+  --subscription "<STATE_SUBSCRIPTION_ID>" \
+  --storage_account_name "<STATE_STORAGE_ACCOUNT>" \
+  --terraform_keyfile "<SAP_SYSTEM>.terraform.tfstate" \
+  --workload_zone_name "<WORKLOAD_ZONE>" \
+  --control_plane_name "<CONTROL_PLANE>"
+```
+
+The script initializes the matching root module and writes the listed
+resources to `resources.lst`.
+
+## Retain logs and evidence
+
+Retain:
+
+- The SDAF commit and installed tool versions.
+- The approved `.tfvars` revision.
+- Terraform plan and apply console output.
+- `apply_output.log` or `apply_output.json`.
+- Stage Markdown summaries.
+- Generated inventory and `sap-parameters.yaml`.
+- Ansible output and product logs.
+- State account, container, and blob names.
+
+`plan_output.log` is transient in several scripts and can be removed during
+execution. Capture the console or redirect a reviewed command at the operator
+shell when your audit policy requires a persistent plan record.
+
+Do not retain secrets in general-purpose logs. Debug mode prints environment
+variables and can expose credentials.
+
+## Retry deterministically
+
+1. Stop after the first failed state-changing command.
+2. Record the exit code and complete output.
+3. Confirm the current Azure resources and remote-state lock.
+4. Keep the same SDAF commit, tool versions, identity, parameter file, state
+   account, and state key.
+5. Correct only the identified cause.
+6. Rerun the same stage command.
+7. Review the new plan before approval.
+
+Use [Troubleshoot local execution](troubleshooting.md) for stage-specific
+diagnostics.
+
+## Remove resources
+
+Remove resources in reverse dependency order:
+
+1. Stop SAP and database services according to product procedures.
+2. Back up business data, configuration, keys, and required logs.
+3. Remove each SAP system.
+4. Remove workload-zone resources only after every dependent SAP system is
+   removed.
+5. Remove the control plane only after every dependent workload zone is
+   removed.
+6. Remove retained shared or external resources separately according to their
+   ownership.
+
+### Remove an SAP system
+
+> [!WARNING]
+> This command runs Terraform destroy for the selected SAP system. It can
+> permanently delete VMs, disks, network interfaces, and other resources.
+
+```bash
+cd "$CONFIG_REPO_PATH/WORKSPACES/SYSTEM/<SAP_SYSTEM>"
+"$SAP_AUTOMATION_REPO_PATH/deploy/scripts/remover.sh" \
+  --type sap_system \
+  --parameterfile "<SAP_SYSTEM>.tfvars" \
+  --control_plane_name "<CONTROL_PLANE>" \
+  --deployer_tfstate_key "<DEPLOYER_STATE_KEY>" \
+  --landscape_tfstate_key "<LANDSCAPE_STATE_KEY>" \
+  --storageaccountname "<STATE_STORAGE_ACCOUNT>" \
+  --state_subscription "<STATE_SUBSCRIPTION_ID>"
+```
+
+Review the destroy plan and confirm only after backups and approvals are
+complete.
+
+### Remove a workload zone
+
+> [!WARNING]
+> Do not continue while any SAP system depends on the workload-zone state or
+> resources.
+
+```bash
+cd \
+  "$CONFIG_REPO_PATH/WORKSPACES/LANDSCAPE/<WORKLOAD_ZONE>-INFRASTRUCTURE"
+"$SAP_AUTOMATION_REPO_PATH/deploy/scripts/remover.sh" \
+  --type sap_landscape \
+  --parameterfile "<WORKLOAD_ZONE>-INFRASTRUCTURE.tfvars" \
+  --control_plane_name "<CONTROL_PLANE>" \
+  --deployer_tfstate_key "<DEPLOYER_STATE_KEY>" \
+  --storageaccountname "<STATE_STORAGE_ACCOUNT>" \
+  --state_subscription "<STATE_SUBSCRIPTION_ID>"
+```
+
+Confirm that the workload-zone state and retained shared resources match the
+approved removal scope.
+
+### Remove the control plane
+
+> [!WARNING]
+> Control-plane removal can delete the deployer, SAP library, Key Vaults, and
+> the storage account that holds Terraform state and software. Export required
+> state, configuration, keys, and software before approval.
+
+```bash
+cd "$CONFIG_REPO_PATH/WORKSPACES"
+"$SAP_AUTOMATION_REPO_PATH/deploy/scripts/remove_controlplane.sh" \
+  --deployer_parameter_file \
+  "DEPLOYER/<CONTROL_PLANE>-INFRASTRUCTURE/<CONTROL_PLANE>-INFRASTRUCTURE.tfvars" \
+  --library_parameter_file \
+  "LIBRARY/<ENVIRONMENT>-<LOCATION>-SAP_LIBRARY/<ENVIRONMENT>-<LOCATION>-SAP_LIBRARY.tfvars"
+```
+
+Review each destroy operation. Use `--keep_agent` only when you have approved
+retention of the deployment agent resource and understand the resulting
+partial removal.
+
+## Validate removal
+
+1. Confirm each Terraform destroy reports success.
+2. Confirm no dependent resource remains unexpectedly.
+3. Confirm retained resources have an owner and documented state.
+4. Confirm state and metadata cleanup matches the approved retention policy.
+5. Confirm subscriptions have no unexpected continuing cost.
+
+## Next step
+
+Return to [Run SDAF locally](README.md) for another environment or use
+[Troubleshoot local execution](troubleshooting.md) for an incomplete removal.

--- a/docs/local/07-00-operations.md
+++ b/docs/local/07-00-operations.md
@@ -108,7 +108,8 @@ Retain:
 - The SDAF commit and installed tool versions.
 - The approved `.tfvars` revision.
 - Terraform plan and apply console output.
-- `apply_output.log` or `apply_output.json`.
+- `apply_output.log`. Automation mode removes its transient
+  `apply_output.json` after processing.
 - Stage Markdown summaries.
 - Generated inventory and `sap-parameters.yaml`.
 - Ansible output and product logs.

--- a/docs/local/07-00-operations.md
+++ b/docs/local/07-00-operations.md
@@ -23,6 +23,8 @@ For an operation, identify:
 - `<LANDSCAPE_STATE_KEY>`: Workload-zone state blob name.
 - `<STATE_STORAGE_ACCOUNT>`: Remote-state storage account name.
 - `<STATE_SUBSCRIPTION_ID>`: Subscription containing the state account.
+- `<WORKLOAD_SUBSCRIPTION_ID>`: Subscription containing the workload-zone and
+  SAP-system resources.
 - The matching deployment and removal script family.
 - The Azure identity and maintenance window.
 - Required backups, retained resources, and approvers.
@@ -151,6 +153,12 @@ variables and can expose credentials.
 7. Rerun the same stage command.
 8. Review the new plan before approval.
 
+Do not use the generic rerun step for an interrupted control-plane removal.
+After the library destroy, `remove_controlplane.sh` persists `step=1`, and a
+later invocation can exit successfully without removing the deployer. Follow
+[Removal is incomplete](troubleshooting.md#removal-is-incomplete) for a
+reviewed component-specific recovery.
+
 Use [Troubleshoot local execution](troubleshooting.md) for stage-specific
 diagnostics.
 
@@ -176,6 +184,7 @@ Remove resources in reverse dependency order:
 
 ```bash
 cd "$CONFIG_REPO_PATH/WORKSPACES/SYSTEM/<SAP_SYSTEM>"
+ARM_SUBSCRIPTION_ID="<WORKLOAD_SUBSCRIPTION_ID>" \
 "$SAP_AUTOMATION_REPO_PATH/deploy/scripts/remover.sh" \
   --type sap_system \
   --parameterfile "<SAP_SYSTEM>.tfvars" \
@@ -198,6 +207,7 @@ complete.
 ```bash
 cd \
   "$CONFIG_REPO_PATH/WORKSPACES/LANDSCAPE/<WORKLOAD_ZONE>-INFRASTRUCTURE"
+ARM_SUBSCRIPTION_ID="<WORKLOAD_SUBSCRIPTION_ID>" \
 "$SAP_AUTOMATION_REPO_PATH/deploy/scripts/remover.sh" \
   --type sap_landscape \
   --parameterfile "<WORKLOAD_ZONE>-INFRASTRUCTURE.tfvars" \

--- a/docs/local/07-00-operations.md
+++ b/docs/local/07-00-operations.md
@@ -31,7 +31,7 @@ For an operation, identify:
 
 ## Prepare an operational change
 
-1. Reconcile the customer configuration, remote state, and Azure resources.
+1. Reconcile the deployment configuration, remote state, and Azure resources.
 2. Record drift or manual Azure changes.
 3. Back up business data and state before a risky or destructive operation.
 4. Review dependencies on shared control-plane and workload-zone resources.
@@ -55,7 +55,7 @@ order. Do not use `--auto-approve` for an operator-reviewed change or removal.
 
 ## Apply an approved change
 
-1. Update one stage's customer configuration.
+1. Update one stage's deployment configuration.
 2. Review the source-control diff.
 3. Confirm the same SDAF and tool versions used by the environment, or approve
    an upgrade plan.

--- a/docs/local/07-00-operations.md
+++ b/docs/local/07-00-operations.md
@@ -42,7 +42,8 @@ remote state, create a plan, apply approved changes, and refresh stage
 metadata. `remover.sh` runs Terraform destroy for a selected `sap_system` or
 `sap_landscape`. `remove_controlplane.sh` removes library and deployer
 resources. `advanced_state_management.sh` lists, imports, or removes Terraform
-state entries.
+state entries. Before every operation, including `list`, it runs
+`terraform init -migrate-state -upgrade` against the supplied backend.
 
 ## Review before execution
 
@@ -83,7 +84,17 @@ only for a reviewed state operation. It supports `list`, `import`, and
 > incorrect address or Azure resource ID can cause later replacement or
 > deletion. Back up state and obtain expert review before either operation.
 
-List state before changing it:
+Before invoking the script, back up the target remote-state blob and the local
+`.terraform/terraform.tfstate` backend metadata. Confirm that the existing
+local metadata and the supplied subscription, storage account, container, and
+key identify the intended backend.
+
+> [!WARNING]
+> The `list` operation is not read-only during initialization. Reject any
+> unexpected prompt to copy or migrate state, reconcile the existing and target
+> backends, and rerun only after expert review.
+
+After completing these checks, list state:
 
 ```bash
 cd "$CONFIG_REPO_PATH/WORKSPACES/SYSTEM/<SAP_SYSTEM>"
@@ -98,8 +109,8 @@ cd "$CONFIG_REPO_PATH/WORKSPACES/SYSTEM/<SAP_SYSTEM>"
   --control_plane_name "<CONTROL_PLANE>"
 ```
 
-The script initializes the matching root module and writes the listed
-resources to `resources.lst`.
+The script initializes the matching root module with migration and provider
+upgrade options, then writes the listed resources to `resources.lst`.
 
 ## Retain logs and evidence
 

--- a/docs/local/07-00-operations.md
+++ b/docs/local/07-00-operations.md
@@ -139,10 +139,17 @@ variables and can expose credentials.
 2. Record the exit code and complete output.
 3. Confirm the current Azure resources and remote-state lock.
 4. Keep the same SDAF commit, tool versions, identity, parameter file, state
-   account, and state key.
-5. Correct only the identified cause.
-6. Rerun the same stage command.
-7. Review the new plan before approval.
+   account, state key, and provider selections. Preserve the generated
+   `.terraform.lock.hcl` for every root module involved in the stage and
+   compare it during the retry.
+5. Treat any provider lock change as an upgrade that requires review and a
+   new plan. The stage installers run `terraform init -upgrade`, and some root
+   provider requirements, including `hashicorp/random`, don't constrain a
+   version. The same SDAF commit and Terraform version therefore don't
+   guarantee the same provider resolution.
+6. Correct only the identified cause.
+7. Rerun the same stage command.
+8. Review the new plan before approval.
 
 Use [Troubleshoot local execution](troubleshooting.md) for stage-specific
 diagnostics.

--- a/docs/local/07-00-operations.md
+++ b/docs/local/07-00-operations.md
@@ -214,9 +214,9 @@ approved removal scope.
 cd "$CONFIG_REPO_PATH/WORKSPACES"
 "$SAP_AUTOMATION_REPO_PATH/deploy/scripts/remove_controlplane.sh" \
   --deployer_parameter_file \
-  "DEPLOYER/<CONTROL_PLANE>-INFRASTRUCTURE/<CONTROL_PLANE>-INFRASTRUCTURE.tfvars" \
+  "$CONFIG_REPO_PATH/WORKSPACES/DEPLOYER/<CONTROL_PLANE>-INFRASTRUCTURE/<CONTROL_PLANE>-INFRASTRUCTURE.tfvars" \
   --library_parameter_file \
-  "LIBRARY/<ENVIRONMENT>-<LOCATION>-SAP_LIBRARY/<ENVIRONMENT>-<LOCATION>-SAP_LIBRARY.tfvars"
+  "$CONFIG_REPO_PATH/WORKSPACES/LIBRARY/<ENVIRONMENT>-<LOCATION>-SAP_LIBRARY/<ENVIRONMENT>-<LOCATION>-SAP_LIBRARY.tfvars"
 ```
 
 Review each destroy operation. Use `--keep_agent` only when you have approved

--- a/docs/local/README.md
+++ b/docs/local/README.md
@@ -1,0 +1,101 @@
+# Run SDAF locally
+
+Use this journey to run the SAP Deployment Automation Framework (SDAF)
+directly from an operator-managed host. Local execution is an equal execution
+model to GitHub Actions and Azure DevOps. It uses the same Terraform modules,
+Ansible playbooks, configuration model, and remote state.
+
+Local execution does not include a hosted stage generator. Prepare and review
+configuration from the
+[`Azure/SAP-automation-samples`](https://github.com/Azure/SAP-automation-samples)
+repository, the SDAF Web application where applicable, or direct editing.
+
+## Complete the journey
+
+1. [Review prerequisites](01-00-prerequisites.md).
+2. [Prepare the execution environment](02-00-prepare-execution-environment.md).
+3. [Deploy the control plane](03-00-control-plane.md).
+4. [Deploy a workload zone](04-00-workload-zone.md).
+5. [Deploy an SAP system](05-00-sap-system.md).
+6. [Download software and run installation](06-00-software-and-installation.md).
+7. [Operate, recover, and remove the deployment](07-00-operations.md).
+
+Use [Troubleshoot local execution](troubleshooting.md) when a command stops or
+the observed state differs from the expected state.
+
+## Understand the local automation boundary
+
+The operator owns:
+
+- The execution host and installed tools.
+- The checked-out SDAF version.
+- The configuration repository or working directory.
+- Azure sign-in and access controls.
+- Review and approval before each state-changing command.
+- Retention of configuration, state metadata, and logs.
+
+SDAF automation owns:
+
+- Terraform initialization, planning, application, and output generation.
+- Control-plane state bootstrap and migration to Azure Storage.
+- Workload-zone and SAP-system access to remote state.
+- Generation of Ansible inventory and `sap-parameters.yaml`.
+- BOM-driven software download and numbered Ansible playbook execution.
+
+## Select a script family
+
+This release contains established and v2 implementations. The repository does
+not identify either family as preferred, recommended, or legacy. Select the
+family named by your release guidance, validate its `--help` output against
+the checked-out version, and use that family consistently for deployment and
+removal.
+
+| Outcome | Established entry point | v2 entry point | Source-backed distinction |
+| --- | --- | --- | --- |
+| Deploy the complete control plane | [`deploy_controlplane.sh`](../../deploy/scripts/deploy_controlplane.sh) | [`deploy_control_plane_v2.sh`](../../deploy/scripts/deploy_control_plane_v2.sh) | Both orchestrate deployer and library deployment. The established script invokes standalone scripts. The v2 script sources v2 functions. |
+| Deploy only the deployer | [`install_deployer.sh`](../../deploy/scripts/install_deployer.sh) | [`install_deployer_v2.sh`](../../deploy/scripts/install_deployer_v2.sh) | Component-level control-plane entry points. |
+| Deploy only the library | [`install_library.sh`](../../deploy/scripts/install_library.sh) | [`install_library_v2.sh`](../../deploy/scripts/install_library_v2.sh) | Component-level control-plane entry points. |
+| Deploy a workload zone | [`install_workloadzone.sh`](../../deploy/scripts/install_workloadzone.sh) | No separate v2-named workload-zone entry point | The v2 installer accepts `--type sap_landscape`, but do not substitute it unless release guidance selects that path. |
+| Deploy an SAP system | [`installer.sh`](../../deploy/scripts/installer.sh) | [`installer_v2.sh`](../../deploy/scripts/installer_v2.sh) | Both accept a deployment type and a parameter file. Their option names and state variables differ. |
+| Remove an SAP system or workload zone | [`remover.sh`](../../deploy/scripts/remover.sh) | [`remover_v2.sh`](../../deploy/scripts/remover_v2.sh) | Use the matching family and deployment type. |
+| Remove the control plane | [`remove_controlplane.sh`](../../deploy/scripts/remove_controlplane.sh) | [`remove_control_plane_v2.sh`](../../deploy/scripts/remove_control_plane_v2.sh) | Both remove library and deployer resources. |
+
+The procedural commands in this journey show the established family because
+its stage-specific entry points are explicit. If your release guidance selects
+the v2 family, use the v2 `--help` output and do not copy established-family
+options unchanged.
+
+## Configuration and state layout
+
+Keep customer configuration outside the SDAF source checkout. A typical
+configuration root contains:
+
+```text
+WORKSPACES/
+├── DEPLOYER/<control-plane>-INFRASTRUCTURE/
+├── LIBRARY/<environment>-<location>-SAP_LIBRARY/
+├── LANDSCAPE/<workload-zone>-INFRASTRUCTURE/
+└── SYSTEM/<SAP-system>/
+```
+
+Each leaf directory contains its same-named `.tfvars` file. Scripts also
+create or update:
+
+- `.terraform/` beside the parameter file for Terraform working data and
+  backend metadata.
+- `.sap_deployment_automation/` under `CONFIG_REPO_PATH` for persisted
+  environment metadata.
+- `apply_output.log` or `apply_output.json` in the current stage directory.
+- Stage summaries and generated Ansible files where the source module defines
+  them.
+
+Do not commit secrets, private keys, Terraform state, `.terraform/`, or
+`.sap_deployment_automation/` to source control.
+
+## Source validation baseline
+
+This journey was validated against `Azure/sap-automation` commit
+`fe6a307d1c9d0dee81d1dfc486265276aed3b03a` on
+`release/july-2026`. Revalidate commands and capability statements before you
+use another release.
+

--- a/docs/local/README.md
+++ b/docs/local/README.md
@@ -67,7 +67,7 @@ options unchanged.
 
 ## Configuration and state layout
 
-Keep customer configuration outside the SDAF source checkout. A typical
+Keep deployment configuration outside the SDAF source checkout. A typical
 configuration root contains:
 
 ```text
@@ -98,4 +98,3 @@ This journey was validated against `Azure/sap-automation` commit
 `fe6a307d1c9d0dee81d1dfc486265276aed3b03a` on
 `release/july-2026`. Revalidate commands and capability statements before you
 use another release.
-

--- a/docs/local/troubleshooting.md
+++ b/docs/local/troubleshooting.md
@@ -99,8 +99,10 @@ Stop before approval. Compare:
 - The previous successful plan or apply record.
 
 SAP-system automation checks selected VM, disk, SAP library, and state storage
-replacements. Workload-zone automation also writes risk information to its
-environment `.err` file for selected migration conditions.
+replacements. Workload-zone automation reports selected migration risks in the
+console during local interactive execution. Its environment `.err` artifact is
+written only when the script runs through Azure DevOps, so local operators must
+retain the console output.
 
 ## A control-plane run stopped partway through
 
@@ -190,4 +192,3 @@ Include:
 - Whether a retry, recovery, state operation, or manual Azure change occurred.
 
 Return to [Run SDAF locally](README.md).
-

--- a/docs/local/troubleshooting.md
+++ b/docs/local/troubleshooting.md
@@ -171,7 +171,17 @@ Do not remove the remote-state account or edit state to hide the failure.
 3. Confirm that workload zones were removed before the control plane.
 4. Compare remaining Azure resources with the Terraform state list.
 5. Resolve locks, permissions, policies, and delete protections.
-6. Rerun the same removal command and review the destroy plan.
+6. For an SAP-system or workload-zone removal, rerun the same command and
+   review the destroy plan.
+
+For an interrupted control-plane removal, inspect the environment file under
+`$CONFIG_REPO_PATH/.sap_deployment_automation`, its persisted `step`, the
+library destroy result, and the remaining deployer state and resources. After
+the library destroy, `remove_controlplane.sh` saves `step=1`; a later invocation
+can exit successfully without destroying the deployer. Do not treat that exit
+as completion or edit the step to bypass the guard. Obtain expert review for a
+component-specific deployer recovery path, including state backup and destroy
+plan review.
 
 Use `advanced_state_management.sh` only when an Azure resource and its
 Terraform address require an explicitly reviewed `list`, `import`, or

--- a/docs/local/troubleshooting.md
+++ b/docs/local/troubleshooting.md
@@ -1,0 +1,193 @@
+# Troubleshoot local execution
+
+Use the first applicable section. Preserve the original error, command,
+working directory, SDAF commit, tool versions, configuration revision, state
+key, and Azure principal.
+
+## A required export is missing
+
+The infrastructure scripts validate:
+
+- `SAP_AUTOMATION_REPO_PATH`
+- `CONFIG_REPO_PATH`
+- `ARM_SUBSCRIPTION_ID`
+
+Run:
+
+```bash
+printf 'SAP_AUTOMATION_REPO_PATH=%s\n' "$SAP_AUTOMATION_REPO_PATH"
+printf 'CONFIG_REPO_PATH=%s\n' "$CONFIG_REPO_PATH"
+printf 'ARM_SUBSCRIPTION_ID=%s\n' "$ARM_SUBSCRIPTION_ID"
+```
+
+Each value must be nonempty and identify the intended source, configuration,
+or subscription.
+
+## A parameter file is not found
+
+`install_deployer.sh`, `install_library.sh`, `install_workloadzone.sh`, and
+`installer.sh` enforce working-directory rules. Run a stage-specific script
+from the directory that contains its parameter file and pass the basename,
+not a path with another directory component.
+
+Run:
+
+```bash
+pwd
+ls -l ./*.tfvars
+```
+
+Confirm the expected file is in the current directory.
+
+## Terraform or Azure CLI is not found
+
+Run:
+
+```bash
+"$SAP_AUTOMATION_REPO_PATH/deploy/scripts/helpers/check_workstation.sh"
+```
+
+If a tool is missing, load `/etc/profile.d/deploy_server.sh` when it was
+created by `configure_deployer.sh`, or repair the approved tool installation.
+
+## Azure authentication or authorization fails
+
+Run:
+
+```bash
+az account show --output table
+az account get-access-token --query expiresOn --output tsv
+```
+
+Confirm the intended principal, tenant, subscription, and unexpired token.
+Check access to the target subscription, state storage, Key Vault, network,
+DNS, and role-assignment scopes.
+
+Do not grant broad permanent roles only to bypass an error. Identify the
+specific operation and approved scope.
+
+## The execution host cannot reach Key Vault or Storage
+
+Check:
+
+- DNS resolution for the public or private endpoint.
+- Routes, peering, firewalls, proxies, and network security controls.
+- Private DNS zone links.
+- Storage and Key Vault network rules.
+- Whether the script detected the correct execution-host public IP.
+
+Retry only after connectivity is stable. A changing egress IP can invalidate
+temporary network rules.
+
+## Terraform reports a state lock
+
+Confirm no other workflow, pipeline, operator, or process is using the same
+state blob. Preserve the lock details. Remove a lock only after proving the
+owning operation is no longer running and obtaining state-owner approval.
+
+Do not run two execution models concurrently against the same state.
+
+## Terraform proposes unexpected replacement
+
+Stop before approval. Compare:
+
+- The current `.tfvars` revision.
+- The SDAF commit and provider lock data.
+- Remote-state keys and control-plane or workload-zone names.
+- Existing-resource IDs.
+- Azure changes made outside Terraform.
+- The previous successful plan or apply record.
+
+SAP-system automation checks selected VM, disk, SAP library, and state storage
+replacements. Workload-zone automation also writes risk information to its
+environment `.err` file for selected migration conditions.
+
+## A control-plane run stopped partway through
+
+Inspect:
+
+- Deployer and library state blobs.
+- The environment metadata file under
+  `$CONFIG_REPO_PATH/.sap_deployment_automation`.
+- Its persisted `step` value.
+- Deployer and library `apply_output.*`.
+- Azure resource groups and the state storage account.
+
+Rerun the identical command after correcting the cause. Use the established
+script's `--recover` option only after the persisted step and component state
+agree with the recovery path. Do not combine `--recover` and `--force` without
+a reviewed state plan.
+
+## Generated Ansible files are missing
+
+Confirm the SAP-system Terraform apply completed in the system directory.
+The output-files module writes `<SID>_hosts.yaml` and
+`sap-parameters.yaml` to the current Terraform working directory and uploads
+defined artifacts to the `tfvars` container.
+
+Inspect `apply_output.*` and Terraform local-file errors. Rerun the same
+SAP-system command and review the plan.
+
+## BOM files are not found
+
+Run:
+
+```bash
+printf 'BOM_CATALOG=%s\n' "$BOM_CATALOG"
+test -d "$BOM_CATALOG/SAP"
+test -d "$BOM_CATALOG/BOM"
+```
+
+`BOM_CATALOG` must identify the samples repository root. `download_menu.sh`
+passes it as `BOM_directory`; the BOM utility searches its `SAP`, `BOM`, and
+`archives` children.
+
+Confirm the BOM names in `sap-parameters.yaml` match directories and YAML
+files in the reviewed samples revision.
+
+## An Ansible playbook fails
+
+Record the first failed task and target host. Check:
+
+- Inventory address and remote user.
+- Retrieved SSH key and Key Vault password.
+- Host reachability and privilege escalation.
+- Operating-system repositories and package access.
+- SAP media availability and disk space.
+- The playbook's `.progress` marker.
+- Product logs on the target host.
+
+Correct the cause and rerun the smallest applicable playbook. Do not delete
+progress markers until you have reviewed the owning role.
+
+## Removal is incomplete
+
+Do not remove the remote-state account or edit state to hide the failure.
+
+1. Preserve the destroy output.
+2. Confirm that dependent SAP systems were removed before the workload zone.
+3. Confirm that workload zones were removed before the control plane.
+4. Compare remaining Azure resources with the Terraform state list.
+5. Resolve locks, permissions, policies, and delete protections.
+6. Rerun the same removal command and review the destroy plan.
+
+Use `advanced_state_management.sh` only when an Azure resource and its
+Terraform address require an explicitly reviewed `list`, `import`, or
+`remove` operation.
+
+## Collect information for support
+
+Include:
+
+- Execution model: local.
+- SDAF commit and script family.
+- Host operating system and tool versions.
+- Stage and exact entry point.
+- Sanitized command and working directory.
+- Sanitized configuration path and state key.
+- Azure subscription and region.
+- Exit code and relevant output.
+- Whether a retry, recovery, state operation, or manual Azure change occurred.
+
+Return to [Run SDAF locally](README.md).
+


### PR DESCRIPTION
## Problem

Local scripted execution is a first-class SDAF deployment model, but the central repository did not provide an end-to-end journey equivalent to the GitHub Actions and Azure DevOps paths.

## Solution

- Add an ordered local-execution journey covering prerequisites, host preparation, control plane, workload zone, SAP system, software and installation, operations, and troubleshooting.
- Document established and v2 script families without assigning an unsupported preference.
- Explain configuration ownership, Terraform state, validation evidence, retry behavior, and destructive-operation safeguards at each stage.
- Add the journey to the central documentation index and deployment-options page.

## Tests

- Validated all relative Markdown links and heading anchors in the changed documentation.
- Validated referenced repository paths and script entry points against the `release/july-2026` source baseline.
- Ran `git diff --check`.
- Confirmed the change set contains documentation only.

## Notes

This is phase 2 of the repository documentation modernization. It follows merged PR #1205 and does not change scripts, Terraform, Ansible, pipelines, support policy, or Microsoft Learn content.