### PR TITLE
Fix RHEL HANA HA/DR provider configuration and SBD prerequisites

### DIFF
--- a/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.1.1-iSCSI.yml
+++ b/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.1.1-iSCSI.yml
@@ -7,29 +7,19 @@
 # +------------------------------------4--------------------------------------*/
 # https://learn.microsoft.com/en-us/azure/sap/workloads/high-availability-guide-suse-pacemaker#set-up-the-iscsi-target-server-sbd-device
 
-
-- name:                                "1.17.1 iSCSI packages (SUSE)"
+- name:                                "1.17.1 iSCSI transport package (SUSE)"
   when:                                (ansible_os_family | upper) == "SUSE"
   become:                              true
-  become_user:                         root
   community.general.zypper:
-    name:                              "{{ item }}"
+    name:                              open-iscsi
     state:                             present
-  loop:
-    - open-iscsi
-    - sbd
 
-- name:                                "1.17.1 iSCSI packages (REDHAT)"
+- name:                                "1.17.1 iSCSI transport package (REDHAT)"
   when:                                (ansible_os_family | upper) == "REDHAT"
   become:                              true
-  become_user:                         root
   ansible.builtin.dnf:
-    name:                              "{{ item }}"
+    name:                              iscsi-initiator-utils
     state:                             present
-  loop:
-    - iscsi-initiator-utils
-    - sbd
-    - fence-agents-sbd
 
 - name:                                "1.17.1 iSCSI packages"
   become:                              true

--- a/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.1.1-sbd-prerequisites.yaml
+++ b/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.1.1-sbd-prerequisites.yaml
@@ -1,0 +1,20 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+---
+
+- name:                                "1.17.1 SBD prerequisites (SUSE)"
+  when:                                (ansible_os_family | upper) == "SUSE"
+  become:                              true
+  community.general.zypper:
+    name:                              sbd
+    state:                             present
+
+- name:                                "1.17.1 SBD prerequisites (REDHAT)"
+  when:                                (ansible_os_family | upper) == "REDHAT"
+  become:                              true
+  ansible.builtin.dnf:
+    name:
+      - sbd
+      - fence-agents-sbd
+    state:                             present

--- a/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/main.yml
+++ b/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/main.yml
@@ -11,21 +11,23 @@
 - name:                                     "1.17 Generic Pacemaker - Run pre-checks"
   ansible.builtin.import_tasks:             1.17.1-pre_checks.yml
 
-- name:                                     "1.17 Generic Pacemaker - Set Runtime Facts"
+- name:                                     "1.17 Generic Pacemaker - Install SBD prerequisites"
+  ansible.builtin.import_tasks:             1.17.1.1-sbd-prerequisites.yaml
+  when:
+                                            - scs_cluster_type in ['ASD', 'ISCSI'] or
+                                              database_cluster_type in ['ASD', 'ISCSI']
+
+- name:                                     "1.17 Generic Pacemaker - Configure iSCSI transport"
   ansible.builtin.import_tasks:             1.17.1.1-iSCSI.yml
   when:
-                                            - ansible_os_family | upper == "SUSE" and
-                                              (scs_cluster_type == 'ISCSI') or
-                                              (database_cluster_type == 'ISCSI')
+                                            - scs_cluster_type == 'ISCSI' or
+                                              database_cluster_type == 'ISCSI'
 
 - name:                                     "1.17 Generic Pacemaker - SBD Devices"
   ansible.builtin.import_tasks:             1.17.1.2-sbd.yaml
   when:
-                                            - ansible_os_family | upper == "SUSE" and
-                                              (database_cluster_type == "ASD")   or
-                                              (database_cluster_type == "ISCSI") or
-                                              (scs_cluster_type      == "ASD")   or
-                                              (scs_cluster_type      == "ISCSI")
+                                            - scs_cluster_type in ['ASD', 'ISCSI'] or
+                                              database_cluster_type in ['ASD', 'ISCSI']
 
 # Import this task only if the cluster is not yet created
 - name:                                     "1.17 Generic Pacemaker - Provision"

--- a/deploy/ansible/roles-sap/5.5-hanadb-pacemaker/tasks/5.5.3-SAPHanaSR.yml
+++ b/deploy/ansible/roles-sap/5.5-hanadb-pacemaker/tasks/5.5.3-SAPHanaSR.yml
@@ -104,6 +104,11 @@
       ansible.builtin.set_fact:
         saphanasr_provider_path:       /usr/share/SAPHanaSR
 
+    - name:                            "5.5.3 HANA Pacemaker - Set SAPHanaSR provider path for RHEL"
+      when:                            ansible_os_family | upper == "REDHAT"
+      ansible.builtin.set_fact:
+        saphanasr_provider_path:       /usr/share/SAPHanaSR/srHook
+
     - name:                            "5.5.3 HANA Pacemaker - Adjust global.ini on each cluster node (RHEL)"
       when:
         - ansible_os_family | upper == "REDHAT"
@@ -112,12 +117,12 @@
         block: |
                                        [ha_dr_provider_SAPHanaSR]
                                        provider = SAPHanaSR
-                                       path = /hana/shared/myHooks
+                                       path = {{ saphanasr_provider_path }}
                                        execution_order = 1
 
                                        [ha_dr_provider_chksrv]
                                        provider = ChkSrv
-                                       path = /hana/shared/myHooks
+                                       path = {{ saphanasr_provider_path }}
                                        execution_order = 2
                                        action_on_lost = kill
 
@@ -480,7 +485,7 @@
                                        provider = ChkSrv
                                        path = /usr/share/sap-hana-ha/
                                        execution_order = 2
-                                       action_on_lost = stop
+                                       action_on_lost = fence
 
                                        [trace]
                                        ha_dr_hanasr = info

--- a/deploy/ansible/roles-sap/5.8-hanadb-scaleout-pacemaker/tasks/5.8.3-SAPHanaSRMultiTarget-RedHat.yml
+++ b/deploy/ansible/roles-sap/5.8-hanadb-scaleout-pacemaker/tasks/5.8.3-SAPHanaSRMultiTarget-RedHat.yml
@@ -21,6 +21,10 @@
     - name:                            "5.8 HANA Pacemaker Scale-out - Generate list of deployed packages on current host"
       ansible.builtin.package_facts:
 
+    - name:                            "5.8 HANA Pacemaker Scale-out - Set SAPHanaSR provider path for RHEL"
+      ansible.builtin.set_fact:
+        saphanasr_provider_path:       /usr/share/SAPHanaSR-ScaleOut
+
     # for RHEL, ensure resource-agents-sap-hana-Scale-out is installed
 
     - name:                            "5.8 HANA Pacemaker Scale-out - Ensure resource-agents-sap-hana is absent (REDHAT)"
@@ -141,12 +145,12 @@
             block: |
                                        [ha_dr_provider_SAPHanaSR]
                                        provider = SAPHanaSR
-                                       path = /hana/shared/myHooks
+                                       path = {{ saphanasr_provider_path }}
                                        execution_order = 1
 
                                        [ha_dr_provider_chksrv]
                                        provider = ChkSrv
-                                       path = /hana/shared/myHooks
+                                       path = {{ saphanasr_provider_path }}
                                        execution_order = 2
                                        action_on_lost = kill
 
@@ -324,7 +328,7 @@
                                        provider = ChkSrv
                                        path = /usr/share/sap-hana-ha/
                                        execution_order = 2
-                                       action_on_lost = stop
+                                       action_on_lost = fence
 
                                        [trace]
                                        ha_dr_hanasr = info


### PR DESCRIPTION
## Summary
- Correct classic RHEL SAP HANA HA/DR provider paths and use the OS-aware provider-path variable.
- Align RHEL ANGI ChkSrv with `action_on_lost = fence`.
- Refactor iSCSI/SBD task configuration and add SBD prerequisites for SUSE and RHEL.

## Validation
- Parsed the updated HANA Pacemaker task files as YAML.
- Verified classic and ANGI provider paths, names, execution order, and ChkSrv action values locally.
- Ran `git diff --check`.