### PR TITLE
Enhance mount logic for SLES and RHEL in Terraform configurations

### DIFF
--- a/deploy/ansible/roles-os/1.13-MOTD/tasks/main.yaml
+++ b/deploy/ansible/roles-os/1.13-MOTD/tasks/main.yaml
@@ -85,6 +85,13 @@
     group:                             root
   become:                              true
 
+- name:                                "1.13 MOTD - Check for a distribution sshd_config"
+  ansible.builtin.stat:
+    path:                              /etc/ssh/sshd_config
+  become:                              true
+  register:                            motd_sshd_config
+
+# SLES 16 ships no /etc/ssh/sshd_config; its vendor /usr/etc copy already includes the drop-in directory.
 - name:                                "1.13 MOTD - Ensure SSH drop-in loader is configured"
   ansible.builtin.lineinfile:
     path:                              /etc/ssh/sshd_config
@@ -93,6 +100,7 @@
     insertbefore:                       BOF
     validate:                           '/usr/sbin/sshd -t -f %s'
   become:                              true
+  when:                                motd_sshd_config.stat.exists
   notify:
     - "1.13 MOTD - Restart sshd service"
 

--- a/deploy/ansible/roles-os/1.13-MOTD/tasks/main.yaml
+++ b/deploy/ansible/roles-os/1.13-MOTD/tasks/main.yaml
@@ -96,9 +96,17 @@
   notify:
     - "1.13 MOTD - Restart sshd service"
 
+- name:                                "1.13 MOTD - Remove obsolete late-loading drop-in"
+  ansible.builtin.file:
+    path:                              /etc/ssh/sshd_config.d/99-sap-motd.conf
+    state:                             absent
+  become:                              true
+  notify:
+    - "1.13 MOTD - Restart sshd service"
+
 - name:                                "1.13 MOTD - Update PrintMotd and Banner via drop-in"
   ansible.builtin.copy:
-    dest:                              /etc/ssh/sshd_config.d/99-sap-motd.conf
+    dest:                              /etc/ssh/sshd_config.d/00-sap-motd.conf
     mode:                              '0600'
     owner:                             root
     group:                             root

--- a/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.2.0-cluster-Suse.yml
+++ b/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.2.0-cluster-Suse.yml
@@ -449,7 +449,7 @@
           ansible.builtin.shell: |
                                        crm configure primitive health-azure-events ocf:heartbeat:azure-events-az \
                                        meta allow-unhealthy-nodes=true failure-timeout=120s \
-                                       op start start-delay=90s \
+                                       op start start-delay=60s \
                                        op monitor interval=10s
           register:                    crm_configure_result
           failed_when:
@@ -468,7 +468,7 @@
           ansible.builtin.shell: |
                                        crm configure primitive health-azure-events ocf:heartbeat:azure-events-az \
                                        meta failure-timeout=120s \
-                                       op start start-delay=90s \
+                                       op start start-delay=60s \
                                        op monitor interval=10s
           register:                    crm_configure_result
           failed_when:

--- a/deploy/ansible/roles-os/1.18-scaleout-pacemaker/tasks/1.18.2.0-cluster-Suse.yml
+++ b/deploy/ansible/roles-os/1.18-scaleout-pacemaker/tasks/1.18.2.0-cluster-Suse.yml
@@ -352,7 +352,7 @@
           ansible.builtin.shell: |
                                        crm configure primitive health-azure-events ocf:heartbeat:azure-events-az \
                                        meta allow-unhealthy-nodes=true failure-timeout=120s \
-                                       op start start-delay=90s \
+                                       op start start-delay=60s \
                                        op monitor interval=10s
           register:                    crm_configure_result
           failed_when:
@@ -371,7 +371,7 @@
           ansible.builtin.shell: |
                                        crm configure primitive health-azure-events ocf:heartbeat:azure-events-az \
                                        meta failure-timeout=120s \
-                                       op start start-delay=90s \
+                                       op start start-delay=60s \
                                        op monitor interval=10s
           register:                    crm_configure_result
           failed_when:

--- a/deploy/ansible/roles-sap/5.5-hanadb-pacemaker/tasks/5.5.1-set_runtime_facts.yml
+++ b/deploy/ansible/roles-sap/5.5-hanadb-pacemaker/tasks/5.5.1-set_runtime_facts.yml
@@ -163,6 +163,19 @@
         - use_hanasr_angi | default(false)
         - ansible_os_family | upper == 'REDHAT'
       block:
+        # The sap-hana-ha (ANGI) package declares a Conflicts against the classic
+        # resource-agents-sap-hana package, which is installed unconditionally by
+        # roles-os/1.4-packages and roles-os/1.17-generic-pacemaker. It must be
+        # removed first or dnf fails with a depsolve conflict.
+        # TODO: remove this task once 1.4-packages and 1.17-generic-pacemaker
+        # skip resource-agents-sap-hana when use_hanasr_angi is true.
+        - name:                        "5.5.1 HANA Pacemaker - Remove conflicting resource-agents-sap-hana [RHEL ANGI]"
+          ansible.builtin.dnf:
+            name:                      resource-agents-sap-hana
+            state:                     absent
+          when:
+                                       - ansible_facts.packages['resource-agents-sap-hana'] is defined
+
         - name:                        "5.5.1 HANA Pacemaker - Install sap-hana-ha package"
           ansible.builtin.dnf:
             name:                      "sap-hana-ha"
@@ -174,6 +187,7 @@
 
         - name:                        "5.5.1 HANA Pacemaker - Update package versions after sap-hana-ha install"
           ansible.builtin.set_fact:
+            saphanaSR_version:         "{{ ansible_facts.packages['resource-agents-sap-hana'][0].version if 'resource-agents-sap-hana' in ansible_facts.packages else '0.0.0' }}"
             saphanaSR_angi_version:    "{{ ansible_facts.packages['sap-hana-ha'][0].version if 'sap-hana-ha' in ansible_facts.packages else '0.0.0' }}"
 
     - name:                            "5.5.1 HANA Pacemaker - Capture the Hana DB version"

--- a/deploy/ansible/roles-sap/5.6-scsers-pacemaker/tasks/5.6.4.0-cluster-RedHat.yml
+++ b/deploy/ansible/roles-sap/5.6-scsers-pacemaker/tasks/5.6.4.0-cluster-RedHat.yml
@@ -46,7 +46,7 @@
                                        directory='{{ profile_directory }}' fstype="{{ nfs_fs_type }}" fast_stop=no force_unmount=safe options={{ clus_nfs_options }} \
                                        op start interval=0 timeout=60 \
                                        op stop interval=0 timeout=120 \
-                                       op monitor interval=20 timeout={{ clus_fs_mon_timeout | int }} \
+                                       op monitor interval=200 timeout={{ clus_fs_mon_timeout | int }} \
                                        --group g-{{ sap_sid | upper }}_{{ instance_type | upper }}
       register:                        ascs_fs_resource
       failed_when:                     ascs_fs_resource.rc > 1
@@ -210,7 +210,7 @@
                                        directory='/usr/sap/{{ sap_sid | upper }}/ERS{{ ers_instance_number }}' fstype="{{ nfs_fs_type }}" fast_stop=no force_unmount=safe options={{ clus_nfs_options }} \
                                        op start interval=0 timeout=60 \
                                        op stop interval=0 timeout=120 \
-                                       op monitor interval=20 timeout={{ clus_fs_mon_timeout | int }} \
+                                       op monitor interval=200 timeout={{ clus_fs_mon_timeout | int }} \
                                        --group g-{{ sap_sid | upper }}_ERS
       register:                        ers_fs_resource
       failed_when:                     ers_fs_resource.rc > 1

--- a/deploy/terraform/run/sap_system/tests/output_params.tftest.hcl
+++ b/deploy/terraform/run/sap_system/tests/output_params.tftest.hcl
@@ -687,3 +687,164 @@ run "params_subnet_cidr_client_present_when_admin_subnet_exists" {
   }
 }
 
+run "params_simple_mount_enabled_automatically_for_sles_16" {
+  command = apply
+
+  variables {
+    scs_high_availability = true
+    use_simple_mount      = false
+    scs_server_image = {
+      os_type         = "LINUX"
+      source_image_id = ""
+      publisher       = "SUSE"
+      offer           = "sles-sap-16"
+      sku             = "gen2"
+      version         = "latest"
+      type            = "marketplace"
+    }
+  }
+
+  assert {
+    condition     = strcontains(output.sap_parameters_content, "use_simple_mount:              true")
+    error_message = "SLES 16 HA systems must enable simple mount automatically."
+  }
+}
+
+run "params_simple_mount_enabled_for_supported_sles_15" {
+  command = apply
+
+  variables {
+    scs_high_availability = true
+    use_simple_mount      = true
+    scs_server_image = {
+      os_type         = "LINUX"
+      source_image_id = ""
+      publisher       = "SUSE"
+      offer           = "sles-sap-15-sp7"
+      sku             = "gen2"
+      version         = "latest"
+      type            = "marketplace"
+    }
+  }
+
+  assert {
+    condition     = strcontains(output.sap_parameters_content, "use_simple_mount:              true")
+    error_message = "Supported SLES 15 HA systems must honor use_simple_mount=true."
+  }
+}
+
+run "params_simple_mount_disabled_for_supported_sles_15_when_not_requested" {
+  command = apply
+
+  variables {
+    scs_high_availability = true
+    use_simple_mount      = false
+    scs_server_image = {
+      os_type         = "LINUX"
+      source_image_id = ""
+      publisher       = "SUSE"
+      offer           = "sles-sap-15-sp7"
+      sku             = "gen2"
+      version         = "latest"
+      type            = "marketplace"
+    }
+  }
+
+  assert {
+    condition     = strcontains(output.sap_parameters_content, "use_simple_mount:              false")
+    error_message = "Supported SLES 15 HA systems must honor use_simple_mount=false."
+  }
+}
+
+run "params_simple_mount_enabled_for_rhel_9" {
+  command = apply
+
+  variables {
+    scs_high_availability = true
+    use_simple_mount      = true
+    scs_server_image = {
+      os_type         = "LINUX"
+      source_image_id = ""
+      publisher       = "redhat"
+      offer           = "RHEL-SAP-HA"
+      sku             = "96sapha-gen2"
+      version         = "latest"
+      type            = "marketplace"
+    }
+  }
+
+  assert {
+    condition     = strcontains(output.sap_parameters_content, "use_simple_mount:              true")
+    error_message = "RHEL 9 HA systems must honor use_simple_mount=true."
+  }
+}
+
+run "params_simple_mount_enabled_for_rhel_10" {
+  command = apply
+
+  variables {
+    scs_high_availability = true
+    use_simple_mount      = true
+    scs_server_image = {
+      os_type         = "LINUX"
+      source_image_id = ""
+      publisher       = "redhat"
+      offer           = "rhel_test_offers"
+      sku             = "10_0_sap_ha-gen2"
+      version         = "latest"
+      type            = "marketplace_with_plan"
+    }
+  }
+
+  assert {
+    condition     = strcontains(output.sap_parameters_content, "use_simple_mount:              true")
+    error_message = "RHEL 10 HA systems must honor use_simple_mount=true."
+  }
+}
+
+run "params_simple_mount_disabled_for_rhel_8" {
+  command = apply
+
+  variables {
+    scs_high_availability = true
+    use_simple_mount      = true
+    scs_server_image = {
+      os_type         = "LINUX"
+      source_image_id = ""
+      publisher       = "redhat"
+      offer           = "RHEL-SAP-HA"
+      sku             = "84sapha-gen2"
+      version         = "latest"
+      type            = "marketplace"
+    }
+  }
+
+  assert {
+    condition     = strcontains(output.sap_parameters_content, "use_simple_mount:              false")
+    error_message = "RHEL 8 systems must not enable simple mount."
+  }
+}
+
+run "params_simple_mount_disabled_without_scs_ha" {
+  command = apply
+
+  variables {
+    scs_high_availability = false
+    use_simple_mount      = true
+    scs_server_image = {
+      os_type         = "LINUX"
+      source_image_id = ""
+      publisher       = "redhat"
+      offer           = "rhel_test_offers"
+      sku             = "10_0_sap_ha-gen2"
+      version         = "latest"
+      type            = "marketplace_with_plan"
+    }
+  }
+
+  assert {
+    condition     = strcontains(output.sap_parameters_content, "use_simple_mount:              false")
+    error_message = "Simple mount must remain disabled when SCS is not highly available."
+  }
+}
+

--- a/deploy/terraform/run/sap_system/tests/output_params.tftest.hcl
+++ b/deploy/terraform/run/sap_system/tests/output_params.tftest.hcl
@@ -692,6 +692,7 @@ run "params_simple_mount_enabled_automatically_for_sles_16" {
 
   variables {
     scs_high_availability = true
+    NFS_provider          = "AFS"
     use_simple_mount      = false
     scs_server_image = {
       os_type         = "LINUX"
@@ -715,6 +716,7 @@ run "params_simple_mount_enabled_for_supported_sles_15" {
 
   variables {
     scs_high_availability = true
+    NFS_provider          = "AFS"
     use_simple_mount      = true
     scs_server_image = {
       os_type         = "LINUX"
@@ -738,6 +740,7 @@ run "params_simple_mount_disabled_for_supported_sles_15_when_not_requested" {
 
   variables {
     scs_high_availability = true
+    NFS_provider          = "AFS"
     use_simple_mount      = false
     scs_server_image = {
       os_type         = "LINUX"
@@ -761,6 +764,7 @@ run "params_simple_mount_enabled_for_rhel_9" {
 
   variables {
     scs_high_availability = true
+    NFS_provider          = "AFS"
     use_simple_mount      = true
     scs_server_image = {
       os_type         = "LINUX"
@@ -784,6 +788,7 @@ run "params_simple_mount_enabled_for_rhel_10" {
 
   variables {
     scs_high_availability = true
+    NFS_provider          = "AFS"
     use_simple_mount      = true
     scs_server_image = {
       os_type         = "LINUX"
@@ -807,6 +812,7 @@ run "params_simple_mount_disabled_for_rhel_8" {
 
   variables {
     scs_high_availability = true
+    NFS_provider          = "AFS"
     use_simple_mount      = true
     scs_server_image = {
       os_type         = "LINUX"

--- a/deploy/terraform/run/sap_system/tests/shard-manifest.json
+++ b/deploy/terraform/run/sap_system/tests/shard-manifest.json
@@ -2,11 +2,11 @@
   "module": "deploy/terraform/run/sap_system",
   "shards": [
     { "file": "output_hosts.tftest.hcl", "runs": 10 },
-    { "file": "output_params.tftest.hcl", "runs": 21 },
+    { "file": "output_params.tftest.hcl", "runs": 28 },
     { "file": "output_cross_sub.tftest.hcl", "runs": 6 },
     { "file": "plan_shape_core.tftest.hcl", "runs": 27 },
     { "file": "plan_shape_advanced.tftest.hcl", "runs": 22 },
     { "file": "validation.tftest.hcl", "runs": 35 }
   ],
-  "total_runs": 121
+  "total_runs": 128
 }

--- a/deploy/terraform/run/sap_system/transform.tf
+++ b/deploy/terraform/run/sap_system/transform.tf
@@ -336,18 +336,14 @@ locals {
 
   scs_os_specified                  = (length(local.scs_os.source_image_id) + length(local.scs_os.publisher)) > 0
 
-  validated_use_simple_mount        = (
-                                        upper(local.scs_os.publisher) == "SUSE" && var.scs_high_availability
-                                      ) ? (
-                                        startswith(local.scs_os.offer, "sles-sap-16") ? (
-                                          true) : (
-                                          var.use_simple_mount && contains(["sles-sap-15-sp3", "sles-sap-15-sp4", "sles-sap-15-sp5", "sles-sap-15-sp6", "sles-sap-15-sp7"], local.scs_os.offer) ? (
-                                            true) : (
-                                            false
+  validated_use_simple_mount        = var.scs_high_availability && (
+                                        upper(local.scs_os.publisher) == "SUSE" ? (
+                                          startswith(local.scs_os.offer, "sles-sap-16") || (
+                                            var.use_simple_mount && contains(["sles-sap-15-sp3", "sles-sap-15-sp4", "sles-sap-15-sp5", "sles-sap-15-sp6", "sles-sap-15-sp7"], local.scs_os.offer)
                                           )
+                                        ) : (
+                                          upper(local.scs_os.publisher) == "REDHAT" && var.use_simple_mount && !startswith(local.scs_os.sku, "7") && !startswith(local.scs_os.sku, "8")
                                         )
-                                      ) : (
-                                        false
                                       )
 
   web_os                            = {


### PR DESCRIPTION
This pull request introduces significant improvements to how the `use_simple_mount` parameter is validated and tested for SAP high-availability (HA) systems across different Linux distributions and versions. The main change is a refactor of the logic that determines when `simple mount` should be enabled, with more granular control for SUSE and Red Hat systems. Additionally, comprehensive test cases are added to ensure correct behavior, and the test manifest is updated accordingly. There are also minor adjustments to NFS monitoring intervals in Ansible cluster configuration.

**Validation Logic Improvements:**

* Refactored the `validated_use_simple_mount` logic in `transform.tf` to enable `simple mount` automatically for SLES 16 HA, honor user preference for supported SLES 15 and RHEL 9/10 HA, and ensure it remains disabled for RHEL 7/8 and when HA is not enabled. This provides more accurate and maintainable control over the parameter across supported platforms.

**Test Coverage Enhancements:**

* Added multiple test cases in `output_params.tftest.hcl` to verify `use_simple_mount` behavior for SLES 16, SLES 15 (various service packs), RHEL 8, 9, and 10, both when HA is enabled and disabled, and when the user requests enabling or disabling simple mount. These tests ensure the new logic works as intended in all scenarios.
* Updated the test shard manifest in `shard-manifest.json` to include the new tests, increasing the total number of test runs from 121 to 128.

**Cluster Configuration Adjustments:**

* Increased the NFS filesystem resource monitor interval from 20 to 200 seconds in the Ansible Pacemaker cluster tasks for both ASCS and ERS resources, reducing monitoring overhead and potential false positives. [[1]](diffhunk://#diff-d7c60b1f53fa52bfad5db8de117e53fdf11f16a64ca9d8a2d8f4a22807f97c0aL49-R49) [[2]](diffhunk://#diff-d7c60b1f53fa52bfad5db8de117e53fdf11f16a64ca9d8a2d8f4a22807f97c0aL213-R213)