### PR TITLE
Add OIDC authentication to deployment pipelines

### DIFF
--- a/deploy/pipelines/01-deploy-control-plane.yaml
+++ b/deploy/pipelines/01-deploy-control-plane.yaml
@@ -152,11 +152,15 @@ stages:
           - template:                             templates\download.yaml
             parameters:
               getLatestFromBranch:                true
-          - task:                                 Bash@3
+          - task:                                 AzureCLI@2
             inputs:
-              targetType:                         'filePath'
-              filePath:                           "$(System.DefaultWorkingDirectory)/sap-automation/deploy/scripts/pipeline_scripts/00-store-secrets-in-keyvault.sh"
-              failOnStderr:                       false
+              azureSubscription:                  ${{parameters.connection_name}}
+              scriptType:                         bash
+              scriptLocation:                     'scriptPath'
+              scriptPath:                         "$(System.DefaultWorkingDirectory)/sap-automation/deploy/scripts/pipeline_scripts/00-store-secrets-in-keyvault.sh"
+              addSpnToEnvironment:                true
+              visibleAzLogin:                     false
+              failOnStandardError:                false
               workingDirectory:                   "$(System.DefaultWorkingDirectory)"
             name:                                 StoreSecrets
             displayName:                          Store deployment credentials in Key Vault
@@ -207,11 +211,15 @@ stages:
             displayName:                          Install Terraform
             inputs:
               terraformVersion:                   $(tf_version)
-          - task:                                 Bash@3
+          - task:                                 AzureCLI@2
             inputs:
-              targetType:                         'filePath'
-              filePath:                           "$(System.DefaultWorkingDirectory)/sap-automation/deploy/scripts/pipeline_scripts/01-control-plane-deploy.sh"
-              failOnStderr:                       false
+              azureSubscription:                  ${{parameters.connection_name}}
+              scriptType:                         bash
+              scriptLocation:                     'scriptPath'
+              scriptPath:                         "$(System.DefaultWorkingDirectory)/sap-automation/deploy/scripts/pipeline_scripts/01-control-plane-deploy.sh"
+              addSpnToEnvironment:                true
+              visibleAzLogin:                     false
+              failOnStandardError:                false
               workingDirectory:                   "$(System.DefaultWorkingDirectory)"
             displayName:                          Deploy control plane Part 2
             env:

--- a/deploy/pipelines/02-sap-workload-zone.yaml
+++ b/deploy/pipelines/02-sap-workload-zone.yaml
@@ -133,11 +133,15 @@ stages:
             parameters:
               getLatestFromBranch:                true
 
-          - task:                                 Bash@3
+          - task:                                 AzureCLI@2
             inputs:
-              targetType:                         'filePath'
-              filePath:                           "$(System.DefaultWorkingDirectory)/sap-automation/deploy/scripts/pipeline_scripts/00-store-secrets-in-keyvault.sh"
-              failOnStderr:                       false
+              azureSubscription:                  $(AZURE_CONNECTION_NAME)
+              scriptType:                         bash
+              scriptLocation:                     'scriptPath'
+              scriptPath:                         "$(System.DefaultWorkingDirectory)/sap-automation/deploy/scripts/pipeline_scripts/00-store-secrets-in-keyvault.sh"
+              addSpnToEnvironment:                true
+              visibleAzLogin:                     false
+              failOnStandardError:                false
               workingDirectory:                   "$(System.DefaultWorkingDirectory)"
             name:                                 StoreSecrets
             displayName:                          Store deployment credentials in Key Vault
@@ -181,11 +185,15 @@ stages:
             displayName:                          Install Terraform
             inputs:
               terraformVersion:                   $(tf_version)
-          - task:                                 Bash@3
+          - task:                                 AzureCLI@2
             inputs:
-              targetType:                         'filePath'
-              filePath:                           "$(System.DefaultWorkingDirectory)/sap-automation/deploy/scripts/pipeline_scripts/02-sap-workload-zone.sh"
-              failOnStderr:                       false
+              azureSubscription:                  $(AZURE_CONNECTION_NAME)
+              scriptType:                         bash
+              scriptLocation:                     'scriptPath'
+              scriptPath:                         "$(System.DefaultWorkingDirectory)/sap-automation/deploy/scripts/pipeline_scripts/02-sap-workload-zone.sh"
+              addSpnToEnvironment:                true
+              visibleAzLogin:                     false
+              failOnStandardError:                false
               workingDirectory:                   "$(System.DefaultWorkingDirectory)"
             displayName:                          Deploy SAP Workload Zone
             env:

--- a/deploy/pipelines/03-sap-system-deployment.yaml
+++ b/deploy/pipelines/03-sap-system-deployment.yaml
@@ -52,11 +52,15 @@ stages:
             displayName:                          Install Terraform
             inputs:
               terraformVersion:                   $(tf_version)
-          - task:                                 Bash@3
+          - task:                                 AzureCLI@2
             inputs:
-              targetType:                         'filePath'
-              filePath:                           "$(System.DefaultWorkingDirectory)/sap-automation/deploy/scripts/pipeline_scripts/03-sap-system-deployment.sh"
-              failOnStderr:                       false
+              azureSubscription:                  $(AZURE_CONNECTION_NAME)
+              scriptType:                         bash
+              scriptLocation:                     'scriptPath'
+              scriptPath:                         "$(System.DefaultWorkingDirectory)/sap-automation/deploy/scripts/pipeline_scripts/03-sap-system-deployment.sh"
+              addSpnToEnvironment:                true
+              visibleAzLogin:                     false
+              failOnStandardError:                false
               workingDirectory:                   "$(System.DefaultWorkingDirectory)"
             displayName:                          Deploy_SAP_infrastructure
             env:

--- a/deploy/pipelines/04-sap-software-download.yaml
+++ b/deploy/pipelines/04-sap-software-download.yaml
@@ -77,11 +77,15 @@ stages:
             name:                                 AnsibleInstallation
             displayName:                          Install Ansible
 
-          - task:                                 Bash@3
+          - task:                                 AzureCLI@2
             inputs:
-              targetType:                         'filePath'
-              filePath:                           "$(System.DefaultWorkingDirectory)/sap-automation/deploy/scripts/pipeline_scripts/04-sap-software-download-prepare.sh"
-              failOnStderr:                       false
+              azureSubscription:                  $(AZURE_CONNECTION_NAME)
+              scriptType:                         bash
+              scriptLocation:                     'scriptPath'
+              scriptPath:                         "$(System.DefaultWorkingDirectory)/sap-automation/deploy/scripts/pipeline_scripts/04-sap-software-download-prepare.sh"
+              addSpnToEnvironment:                true
+              visibleAzLogin:                     false
+              failOnStandardError:                false
               workingDirectory:                   "$(System.DefaultWorkingDirectory)"
             displayName:                          Prepare download
             name:                                 Preparation
@@ -125,11 +129,15 @@ stages:
             displayName:                          Install Terraform
             inputs:
               terraformVersion:                   $(tf_version)
-          - task:                                 Bash@3
+          - task:                                 AzureCLI@2
             inputs:
-              targetType:                         'filePath'
-              filePath:                           "$(System.DefaultWorkingDirectory)/sap-automation/deploy/scripts/pipeline_scripts/04-sap-software-download.sh"
-              failOnStderr:                       false
+              azureSubscription:                  $(AZURE_CONNECTION_NAME)
+              scriptType:                         bash
+              scriptLocation:                     'scriptPath'
+              scriptPath:                         "$(System.DefaultWorkingDirectory)/sap-automation/deploy/scripts/pipeline_scripts/04-sap-software-download.sh"
+              addSpnToEnvironment:                true
+              visibleAzLogin:                     false
+              failOnStandardError:                false
               workingDirectory:                   "$(System.DefaultWorkingDirectory)"
             displayName:                          Download
             name:                                 download

--- a/deploy/pipelines/05-DB-and-SAP-installation.yaml
+++ b/deploy/pipelines/05-DB-and-SAP-installation.yaml
@@ -164,11 +164,15 @@ stages:
             inputs:
               terraformVersion:                   $(tf_version)
 
-          - task:                                 Bash@3
+          - task:                                 AzureCLI@2
             inputs:
-              targetType:                         'filePath'
-              filePath:                           "$(System.DefaultWorkingDirectory)/sap-automation/deploy/scripts/pipeline_scripts/05-DB-and-SAP-installation-prepare.sh"
-              failOnStderr:                       false
+              azureSubscription:                  $(AZURE_CONNECTION_NAME)
+              scriptType:                         bash
+              scriptLocation:                     'scriptPath'
+              scriptPath:                         "$(System.DefaultWorkingDirectory)/sap-automation/deploy/scripts/pipeline_scripts/05-DB-and-SAP-installation-prepare.sh"
+              addSpnToEnvironment:                true
+              visibleAzLogin:                     false
+              failOnStandardError:                false
               workingDirectory:                   "$(System.DefaultWorkingDirectory)"
             name:                                 Preparation
             displayName:                          Preparation for Ansible

--- a/deploy/pipelines/10-remover-terraform.yaml
+++ b/deploy/pipelines/10-remover-terraform.yaml
@@ -78,11 +78,15 @@ stages:
             displayName:                          Install Terraform
             inputs:
               terraformVersion:                   $(tf_version)
-          - task:                                 Bash@3
+          - task:                                 AzureCLI@2
             inputs:
-              targetType:                         'filePath'
-              filePath:                           "$(System.DefaultWorkingDirectory)/sap-automation/deploy/scripts/pipeline_scripts/10-remover-terraform-system.sh"
-              failOnStderr:                       false
+              azureSubscription:                  $(AZURE_CONNECTION_NAME)
+              scriptType:                         bash
+              scriptLocation:                     'scriptPath'
+              scriptPath:                         "$(System.DefaultWorkingDirectory)/sap-automation/deploy/scripts/pipeline_scripts/10-remover-terraform-system.sh"
+              addSpnToEnvironment:                true
+              visibleAzLogin:                     false
+              failOnStandardError:                false
               workingDirectory:                   "$(System.DefaultWorkingDirectory)"
 
             displayName:                          "Remove SAP system"
@@ -128,11 +132,15 @@ stages:
             displayName:                          Install Terraform
             inputs:
               terraformVersion:                   $(tf_version)
-          - task:                                 Bash@3
+          - task:                                 AzureCLI@2
             inputs:
-              targetType:                         'filePath'
-              filePath:                           "$(System.DefaultWorkingDirectory)/sap-automation/deploy/scripts/pipeline_scripts/10-remover-terraform-workload-zone.sh"
-              failOnStderr:                       false
+              azureSubscription:                  $(AZURE_CONNECTION_NAME)
+              scriptType:                         bash
+              scriptLocation:                     'scriptPath'
+              scriptPath:                         "$(System.DefaultWorkingDirectory)/sap-automation/deploy/scripts/pipeline_scripts/10-remover-terraform-workload-zone.sh"
+              addSpnToEnvironment:                true
+              visibleAzLogin:                     false
+              failOnStandardError:                false
               workingDirectory:                   "$(System.DefaultWorkingDirectory)"
             displayName:                          Remove SAP workload_zone
             env:

--- a/deploy/pipelines/12-remove-control-plane.yaml
+++ b/deploy/pipelines/12-remove-control-plane.yaml
@@ -67,11 +67,15 @@ stages:
             displayName:                          Install Terraform
             inputs:
               terraformVersion:                   $(tf_version)
-          - task:                                 Bash@3
+          - task:                                 AzureCLI@2
             inputs:
-              targetType:                         'filePath'
-              filePath:                           "$(System.DefaultWorkingDirectory)/sap-automation/deploy/scripts/pipeline_scripts/12-remove-control-plane.sh"
-              failOnStderr:                       false
+              azureSubscription:                  ${{parameters.connection_name}}
+              scriptType:                         bash
+              scriptLocation:                     'scriptPath'
+              scriptPath:                         "$(System.DefaultWorkingDirectory)/sap-automation/deploy/scripts/pipeline_scripts/12-remove-control-plane.sh"
+              addSpnToEnvironment:                true
+              visibleAzLogin:                     false
+              failOnStandardError:                false
               workingDirectory:                   "$(System.DefaultWorkingDirectory)"
             displayName:                          Remove control plane
             env:

--- a/deploy/pipelines/templates/run-ansible.yaml
+++ b/deploy/pipelines/templates/run-ansible.yaml
@@ -27,13 +27,17 @@ parameters:
   workloadZoneName: ''
 
 steps:
-- task:                              Bash@3
+- task:                              AzureCLI@2
   name:                              ${{ parameters.name }}
   displayName:                       ${{ parameters.displayName }}
   inputs:
-    targetType:                      'filePath'
-    filePath:                        "$(System.DefaultWorkingDirectory)/sap-automation/deploy/scripts/pipeline_scripts/05-run-ansible.sh"
-    failOnStderr:                    false
+    azureSubscription:               $(AZURE_CONNECTION_NAME)
+    scriptType:                      bash
+    scriptLocation:                  'scriptPath'
+    scriptPath:                      "$(System.DefaultWorkingDirectory)/sap-automation/deploy/scripts/pipeline_scripts/05-run-ansible.sh"
+    addSpnToEnvironment:             true
+    visibleAzLogin:                  false
+    failOnStandardError:             false
     workingDirectory:                "$(System.DefaultWorkingDirectory)"
   env:
     ANSIBLE_COLLECTIONS_PATH:        ~/.ansible/collections:/opt/ansible/collections

--- a/deploy/scripts/deploy_controlplane.sh
+++ b/deploy/scripts/deploy_controlplane.sh
@@ -51,7 +51,7 @@ if  [[ ${SYSTEM_DEBUG:-False} = True ]] || \
       set -x                                                                    # Enable debug mode
       export DEBUG=True
       echo "Environment variables:"
-      printenv | sort
+      printenv | grep -Ev '^(ARM_CLIENT_SECRET|ARM_OIDC_TOKEN|idToken|servicePrincipalKey|SYSTEM_ACCESSTOKEN|AZURE_DEVOPS_EXT_PAT)=' | sort
 else
       export DEBUG=False
 fi
@@ -638,7 +638,7 @@ if [ 0 != "$step" ]; then
             allParameters+=(--tenant_id "${tenant_id:-$ARM_TENANT_ID}")
             allParameters+=(--spn_id "${client_id:-$ARM_CLIENT_ID}")
             # ss
-            if [ "$deploy_using_msi_only" -eq 0 ]; then
+            if [ "$deploy_using_msi_only" -eq 0 ] && [ "${ARM_USE_OIDC:-false}" != "true" ]; then
                 allParameters+=(--spn_secret "${client_secret:-$ARM_CLIENT_SECRET}")
             else
                 allParameters+=(--msi)

--- a/deploy/scripts/pipeline_scripts/00-store-secrets-in-keyvault.sh
+++ b/deploy/scripts/pipeline_scripts/00-store-secrets-in-keyvault.sh
@@ -34,7 +34,7 @@ if  [[ ${SYSTEM_DEBUG:-False} = True ]] || \
       set -x                                                                    # Enable debug mode
       export DEBUG=True
       echo "Environment variables:"
-      printenv | sort
+      printenv | grep -Ev '^(ARM_CLIENT_SECRET|ARM_OIDC_TOKEN|idToken|servicePrincipalKey|SYSTEM_ACCESSTOKEN|AZURE_DEVOPS_EXT_PAT)=' | sort
 else
       export DEBUG=False
 fi

--- a/deploy/scripts/pipeline_scripts/00-validate-credentials.sh
+++ b/deploy/scripts/pipeline_scripts/00-validate-credentials.sh
@@ -25,7 +25,7 @@ if [ "${SYSTEM_DEBUG:-False}" == "True" ]; then
 	set -x
 	DEBUG=True
 	echo "Environment variables:"
-	printenv | sort
+	printenv | grep -Ev '^(ARM_CLIENT_SECRET|ARM_OIDC_TOKEN|idToken|servicePrincipalKey|SYSTEM_ACCESSTOKEN|AZURE_DEVOPS_EXT_PAT)=' | sort
 
 fi
 export DEBUG

--- a/deploy/scripts/pipeline_scripts/01-control-plane-deploy.sh
+++ b/deploy/scripts/pipeline_scripts/01-control-plane-deploy.sh
@@ -34,7 +34,7 @@ if  [[ ${SYSTEM_DEBUG:-False} = True ]] || \
       set -x                                                                    # Enable debug mode
       export DEBUG=True
       echo "Environment variables:"
-      printenv | sort
+      printenv | grep -Ev '^(ARM_CLIENT_SECRET|ARM_OIDC_TOKEN|idToken|servicePrincipalKey|SYSTEM_ACCESSTOKEN|AZURE_DEVOPS_EXT_PAT)=' | sort
 else
       export DEBUG=False
 fi

--- a/deploy/scripts/pipeline_scripts/01-control-plane-prepare.sh
+++ b/deploy/scripts/pipeline_scripts/01-control-plane-prepare.sh
@@ -34,7 +34,7 @@ if  [[ ${SYSTEM_DEBUG:-False} = True ]] || \
       set -x                                                                    # Enable debug mode
       export DEBUG=True
       echo "Environment variables:"
-      printenv | sort
+      printenv | grep -Ev '^(ARM_CLIENT_SECRET|ARM_OIDC_TOKEN|idToken|servicePrincipalKey|SYSTEM_ACCESSTOKEN|AZURE_DEVOPS_EXT_PAT)=' | sort
 else
       export DEBUG=False
 fi

--- a/deploy/scripts/pipeline_scripts/01-webapp-configuration.sh
+++ b/deploy/scripts/pipeline_scripts/01-webapp-configuration.sh
@@ -34,7 +34,7 @@ if  [[ ${SYSTEM_DEBUG:-False} = True ]] || \
       set -x                                                                    # Enable debug mode
       export DEBUG=True
       echo "Environment variables:"
-      printenv | sort
+      printenv | grep -Ev '^(ARM_CLIENT_SECRET|ARM_OIDC_TOKEN|idToken|servicePrincipalKey|SYSTEM_ACCESSTOKEN|AZURE_DEVOPS_EXT_PAT)=' | sort
 else
       export DEBUG=False
 fi

--- a/deploy/scripts/pipeline_scripts/11-remover-arm-fallback-control-plane.sh
+++ b/deploy/scripts/pipeline_scripts/11-remover-arm-fallback-control-plane.sh
@@ -18,7 +18,7 @@ if [ "${SYSTEM_DEBUG:-False}" == "True" ]; then
 	set -x
 	debug=true
 	export debug
-	printenv | sort
+	printenv | grep -Ev '^(ARM_CLIENT_SECRET|ARM_OIDC_TOKEN|idToken|servicePrincipalKey|SYSTEM_ACCESSTOKEN|AZURE_DEVOPS_EXT_PAT)=' | sort
 fi
 
 if [ "${#PAT}" -gt 0 ]; then

--- a/deploy/scripts/pipeline_scripts/helper.sh
+++ b/deploy/scripts/pipeline_scripts/helper.sh
@@ -198,18 +198,76 @@ function configureNonDeployer() {
     fi
 }
 
+function configure_service_connection_authentication() {
+    local restore_xtrace=false
+    if [[ $- == *x* ]]; then
+        set +x
+        restore_xtrace=true
+    fi
+
+    if [ "${USE_MSI:-false}" == "true" ]; then
+        unset ARM_CLIENT_SECRET ARM_OIDC_TOKEN ARM_USE_OIDC
+    else
+        if [ -n "${servicePrincipalId:-}" ]; then
+            ARM_CLIENT_ID="$servicePrincipalId"
+            export ARM_CLIENT_ID
+        fi
+
+        if [ -n "${tenantId:-}" ]; then
+            ARM_TENANT_ID="$tenantId"
+            export ARM_TENANT_ID
+        fi
+
+        if [ -n "${idToken:-}" ]; then
+            ARM_OIDC_TOKEN="$idToken"
+            ARM_USE_OIDC=true
+            ARM_USE_AZUREAD=true
+            export ARM_OIDC_TOKEN ARM_USE_OIDC ARM_USE_AZUREAD
+            unset ARM_CLIENT_SECRET
+        elif [ -n "${servicePrincipalKey:-}" ]; then
+            ARM_CLIENT_SECRET="$servicePrincipalKey"
+            export ARM_CLIENT_SECRET
+            unset ARM_OIDC_TOKEN ARM_USE_OIDC
+        fi
+    fi
+
+    if [ "$restore_xtrace" == "true" ]; then
+        set -x
+    fi
+}
+
 function LogonToAzure() {
     local useMSI=$1
     local subscriptionId=$ARM_SUBSCRIPTION_ID
+
+    configure_service_connection_authentication
+
     if [ "$useMSI" != "true" ]; then
         echo "Deployment credentials:              Service Principal"
         echo "Deployment credential ID (SPN):      $ARM_CLIENT_ID"
         unset ARM_USE_MSI
+        if [ "${ARM_USE_OIDC:-false}" == "true" ]; then
+            if ! az account show >/dev/null 2>&1; then
+                local restore_xtrace=false
+                if [[ $- == *x* ]]; then
+                    set +x
+                    restore_xtrace=true
+                fi
+                az login --service-principal --username "$ARM_CLIENT_ID" --federated-token "$ARM_OIDC_TOKEN" --tenant "$ARM_TENANT_ID" --output none
+                if [ "$restore_xtrace" == "true" ]; then
+                    set -x
+                fi
+            fi
+        elif [ -n "${ARM_CLIENT_SECRET:-}" ]; then
         # <BEGIN> MKD 20260217
         # AZ CLI 2.83 - syntax for --service-principal user --username NOT --client-id
         # az login --service-principal --client-id "$ARM_CLIENT_ID" --password="$ARM_CLIENT_SECRET" --tenant "$ARM_TENANT_ID" --output none
         az login --service-principal --username "$ARM_CLIENT_ID" --password="$ARM_CLIENT_SECRET" --tenant "$ARM_TENANT_ID" --output none
         # <END>   MKD 20260217
+        else
+            echo "##vso[task.logissue type=error]No service principal authentication credential was provided."
+            return 2
+        fi
         echo "Logged on as:"
         az account show --query user --output yaml
         TF_VAR_use_spn=true
@@ -223,11 +281,7 @@ function LogonToAzure() {
 						ARM_CLIENT_ID=$(az identity show --ids "$MSI_ID" --query clientId -o tsv)
 						if [ -n "$ARM_CLIENT_ID" ]; then
 							export ARM_CLIENT_ID
-							if az account show > /dev/null 2>&1; then
-								echo "Already logged in with MSI, skipping az login."
-							else
-								az login --identity --allow-no-subscriptions --resource-id "$MSI_ID" --output none
-							fi
+							az login --identity --allow-no-subscriptions --resource-id "$MSI_ID" --output none
 						else
 							echo "##vso[task.logissue type=error]Unable to retrieve client ID for the provided MSI_ID: $MSI_ID."
 						fi

--- a/deploy/scripts/pipeline_scripts/v1/00-store-secrets-in-keyvault.sh
+++ b/deploy/scripts/pipeline_scripts/v1/00-store-secrets-in-keyvault.sh
@@ -34,7 +34,7 @@ if  [[ ${SYSTEM_DEBUG:-False} = True ]] || \
       set -x                                                                    # Enable debug mode
       export DEBUG=True
       echo "Environment variables:"
-      printenv | sort
+      printenv | grep -Ev '^(ARM_CLIENT_SECRET|ARM_OIDC_TOKEN|idToken|servicePrincipalKey|SYSTEM_ACCESSTOKEN|AZURE_DEVOPS_EXT_PAT)=' | sort
 else
       export DEBUG=False
 fi
@@ -86,6 +86,8 @@ if [[ ! -f /etc/profile.d/deploy_server.sh ]]; then
 fi
 
 echo -e "$green--- Validations ---$reset"
+configure_service_connection_authentication
+
 if [ "$USE_MSI" != "true" ]; then
 
 	if ! printenv ARM_SUBSCRIPTION_ID; then
@@ -94,7 +96,7 @@ if [ "$USE_MSI" != "true" ]; then
 		exit 2
 	fi
 
-	if ! printenv ARM_CLIENT_SECRET; then
+	if [ "${ARM_USE_OIDC:-false}" != "true" ] && ! printenv ARM_CLIENT_SECRET; then
 		echo "##vso[task.logissue type=error]Variable ARM_CLIENT_SECRET was not defined in the $VARIABLE_GROUP variable group."
 		print_banner "$banner_title" "Variable ARM_CLIENT_SECRET was not defined in the $VARIABLE_GROUP variable group" "error"
 		exit 2
@@ -204,9 +206,13 @@ keyvault_subscription_id=$(az graph query -q                                    
 															--output tsv)
 
 if [ "$USE_MSI" != "true" ]; then
+	allParameters=(--prefix "${ZONE}" --key_vault "${DEPLOYER_KEYVAULT}" --keyvault_subscription "$keyvault_subscription_id")
+	allParameters+=(--subscription "$ARM_SUBSCRIPTION_ID" --client_id "$ARM_CLIENT_ID" --client_tenant_id "$ARM_TENANT_ID" --ado)
+	if [ "${ARM_USE_OIDC:-false}" != "true" ]; then
+		allParameters+=(--client_secret "$ARM_CLIENT_SECRET")
+	fi
 
-	if "$SAP_AUTOMATION_REPO_PATH/deploy/scripts/set_secrets_v2.sh" --prefix "${ZONE}" --key_vault "${DEPLOYER_KEYVAULT}" --keyvault_subscription "$keyvault_subscription_id" \
-		--subscription "$ARM_SUBSCRIPTION_ID" --client_id "$ARM_CLIENT_ID" --client_secret "$ARM_CLIENT_SECRET" --client_tenant_id "$ARM_TENANT_ID" --ado; then
+	if "$SAP_AUTOMATION_REPO_PATH/deploy/scripts/set_secrets_v2.sh" "${allParameters[@]}"; then
 		return_code=$?
 	else
 		return_code=$?

--- a/deploy/scripts/pipeline_scripts/v1/01-control-plane-deploy.sh
+++ b/deploy/scripts/pipeline_scripts/v1/01-control-plane-deploy.sh
@@ -34,7 +34,7 @@ if  [[ ${SYSTEM_DEBUG:-False} = True ]] || \
       set -x                                                                    # Enable debug mode
       export DEBUG=True
       echo "Environment variables:"
-      printenv | sort
+      printenv | grep -Ev '^(ARM_CLIENT_SECRET|ARM_OIDC_TOKEN|idToken|servicePrincipalKey|SYSTEM_ACCESSTOKEN|AZURE_DEVOPS_EXT_PAT)=' | sort
 else
       export DEBUG=False
 fi
@@ -117,6 +117,8 @@ if [[ ! -f /etc/profile.d/deploy_server.sh ]]; then
 fi
 
 echo -e "$green--- Validations ---$reset"
+configure_service_connection_authentication
+
 if [ "$USE_MSI" != "true" ]; then
 
     if ! printenv ARM_SUBSCRIPTION_ID; then
@@ -125,7 +127,7 @@ if [ "$USE_MSI" != "true" ]; then
         exit 2
     fi
 
-    if ! printenv ARM_CLIENT_SECRET; then
+    if [ "${ARM_USE_OIDC:-false}" != "true" ] && ! printenv ARM_CLIENT_SECRET; then
         echo "##vso[task.logissue type=error]Variable ARM_CLIENT_SECRET was not defined in the $VARIABLE_GROUP variable group."
         print_banner "$banner_title" "Variable ARM_CLIENT_SECRET was not defined in the $VARIABLE_GROUP variable group" "error"
         exit 2
@@ -375,14 +377,20 @@ if [ "$USE_MSI" != "true" ]; then
 
     export TF_VAR_use_spn=true
 
+    allParameters=(
+        --deployer_parameter_file "${deployer_tfvars_file_name}"
+        --library_parameter_file "${library_tfvars_file_name}"
+        --subscription "$ARM_SUBSCRIPTION_ID"
+        --tenant_id "$ARM_TENANT_ID"
+        --auto-approve
+        --ado
+    )
+    if [ "${ARM_USE_OIDC:-false}" != "true" ]; then
+        allParameters+=(--spn_secret "$ARM_CLIENT_SECRET")
+    fi
+
     if "$SAP_AUTOMATION_REPO_PATH/deploy/scripts/deploy_controlplane.sh" \
-    --deployer_parameter_file "${deployer_tfvars_file_name}" \
-    --library_parameter_file "${library_tfvars_file_name}" \
-    --subscription "$ARM_SUBSCRIPTION_ID" \
-    --spn_secret "$ARM_CLIENT_SECRET" \
-    --tenant_id "$ARM_TENANT_ID" \
-    --auto-approve --ado \
-    "${storage_account_parameter}" "${keyvault_parameter}"; then
+        "${allParameters[@]}" "${storage_account_parameter}" "${keyvault_parameter}"; then
         return_code=$?
         if [ -f "${CONFIG_REPO_PATH}/DEPLOYER/$DEPLOYER_FOLDERNAME/exports.sh" ]; then
             source "${CONFIG_REPO_PATH}/DEPLOYER/$DEPLOYER_FOLDERNAME/exports.sh"

--- a/deploy/scripts/pipeline_scripts/v1/01-control-plane-prepare.sh
+++ b/deploy/scripts/pipeline_scripts/v1/01-control-plane-prepare.sh
@@ -34,7 +34,7 @@ if  [[ ${SYSTEM_DEBUG:-False} = True ]] || \
       set -x                                                                    # Enable debug mode
       export DEBUG=True
       echo "Environment variables:"
-      printenv | sort
+      printenv | grep -Ev '^(ARM_CLIENT_SECRET|ARM_OIDC_TOKEN|idToken|servicePrincipalKey|SYSTEM_ACCESSTOKEN|AZURE_DEVOPS_EXT_PAT)=' | sort
 else
       export DEBUG=False
 fi
@@ -108,29 +108,9 @@ else
 
 fi
 
-if [ -v servicePrincipalId ]; then
-	ARM_CLIENT_ID="$servicePrincipalId"
-	export ARM_CLIENT_ID
-	TF_VAR_spn_id=$ARM_CLIENT_ID
-	export TF_VAR_spn_id
-fi
-
-if [ -v servicePrincipalKey ]; then
-	unset ARM_OIDC_TOKEN
-	ARM_CLIENT_SECRET="$servicePrincipalKey"
-	export ARM_CLIENT_SECRET
-else
-	ARM_OIDC_TOKEN="$idToken"
-	export ARM_OIDC_TOKEN
-	ARM_USE_OIDC=true
-	export ARM_USE_OIDC
-	unset ARM_CLIENT_SECRET
-fi
-
-if [ -v tenantId ]; then
-	ARM_TENANT_ID="$tenantId"
-	export ARM_TENANT_ID
-fi
+configure_service_connection_authentication
+TF_VAR_spn_id=$ARM_CLIENT_ID
+export TF_VAR_spn_id
 
 if az account show --query name; then
 	echo -e "$green--- Already logged in to Azure ---$reset"

--- a/deploy/scripts/pipeline_scripts/v1/01-webapp-configuration.sh
+++ b/deploy/scripts/pipeline_scripts/v1/01-webapp-configuration.sh
@@ -34,7 +34,7 @@ if  [[ ${SYSTEM_DEBUG:-False} = True ]] || \
       set -x                                                                    # Enable debug mode
       export DEBUG=True
       echo "Environment variables:"
-      printenv | sort
+      printenv | grep -Ev '^(ARM_CLIENT_SECRET|ARM_OIDC_TOKEN|idToken|servicePrincipalKey|SYSTEM_ACCESSTOKEN|AZURE_DEVOPS_EXT_PAT)=' | sort
 else
       export DEBUG=False
 fi
@@ -108,4 +108,3 @@ return_code=0
 echo -e "\n${cyan}Exiting script:  ${BASH_SOURCE[0]}${reset}"
 echo -e   "${cyan}   Return code:  ${return_code}${reset}"
 exit $return_code
-

--- a/deploy/scripts/pipeline_scripts/v1/02-sap-workload-zone.sh
+++ b/deploy/scripts/pipeline_scripts/v1/02-sap-workload-zone.sh
@@ -31,7 +31,7 @@ if [ "${SYSTEM_DEBUG:-False}" == "True" ]; then
 	set -x
 	DEBUG=True
 	echo "Environment variables:"
-	printenv | sort
+	printenv | grep -Ev '^(ARM_CLIENT_SECRET|ARM_OIDC_TOKEN|idToken|servicePrincipalKey|SYSTEM_ACCESSTOKEN|AZURE_DEVOPS_EXT_PAT)=' | sort
 
 fi
 export DEBUG

--- a/deploy/scripts/pipeline_scripts/v1/03-sap-system-deployment.sh
+++ b/deploy/scripts/pipeline_scripts/v1/03-sap-system-deployment.sh
@@ -32,7 +32,7 @@ if [ "${SYSTEM_DEBUG:-False}" == "True" ]; then
 	set -x
 	DEBUG=True
 	echo "Environment variables:"
-	printenv | sort
+	printenv | grep -Ev '^(ARM_CLIENT_SECRET|ARM_OIDC_TOKEN|idToken|servicePrincipalKey|SYSTEM_ACCESSTOKEN|AZURE_DEVOPS_EXT_PAT)=' | sort
 
 fi
 export DEBUG

--- a/deploy/scripts/pipeline_scripts/v1/04-sap-software-download-prepare.sh
+++ b/deploy/scripts/pipeline_scripts/v1/04-sap-software-download-prepare.sh
@@ -32,7 +32,7 @@ if [ "${SYSTEM_DEBUG:-False}" == "True" ]; then
 	set -x
 	DEBUG=True
 	echo "Environment variables:"
-	printenv | sort
+	printenv | grep -Ev '^(ARM_CLIENT_SECRET|ARM_OIDC_TOKEN|idToken|servicePrincipalKey|SYSTEM_ACCESSTOKEN|AZURE_DEVOPS_EXT_PAT)=' | sort
 
 fi
 export DEBUG
@@ -50,6 +50,8 @@ if [[ ! -f /etc/profile.d/deploy_server.sh ]]; then
 fi
 
 echo -e "$green--- Validations ---$reset"
+configure_service_connection_authentication
+
 if [ "$USE_MSI" != "true" ]; then
 
 	if ! printenv ARM_SUBSCRIPTION_ID; then
@@ -58,7 +60,7 @@ if [ "$USE_MSI" != "true" ]; then
 		exit 2
 	fi
 
-	if ! printenv ARM_CLIENT_SECRET; then
+	if [ "${ARM_USE_OIDC:-false}" != "true" ] && ! printenv ARM_CLIENT_SECRET; then
 		echo "##vso[task.logissue type=error]Variable ARM_CLIENT_SECRET was not defined in the $VARIABLE_GROUP variable group."
 		print_banner "$banner_title" "Variable ARM_CLIENT_SECRET was not defined in the $VARIABLE_GROUP variable group" "error"
 		exit 2

--- a/deploy/scripts/pipeline_scripts/v1/04-sap-software-download.sh
+++ b/deploy/scripts/pipeline_scripts/v1/04-sap-software-download.sh
@@ -30,7 +30,7 @@ if [ "$SYSTEM_DEBUG" = True ]; then
   set -x
   DEBUG=True
 	echo "Environment variables:"
-	printenv | sort
+	printenv | grep -Ev '^(ARM_CLIENT_SECRET|ARM_OIDC_TOKEN|idToken|servicePrincipalKey|SYSTEM_ACCESSTOKEN|AZURE_DEVOPS_EXT_PAT)=' | sort
 
 fi
 export DEBUG
@@ -38,13 +38,15 @@ set -eu
 
 cd "$CONFIG_REPO_PATH" || exit
 
+configure_service_connection_authentication
+
 if [ "$USE_MSI" != "true" ]; then
   if [ -z "$ARM_CLIENT_ID" ]; then
     echo "##vso[task.logissue type=error]Variable ARM_CLIENT_ID was not defined."
     exit 2
   fi
 
-  if [ -z "$ARM_CLIENT_SECRET" ]; then
+  if [ "${ARM_USE_OIDC:-false}" != "true" ] && [ -z "${ARM_CLIENT_SECRET:-}" ]; then
     echo "##vso[task.logissue type=error]Variable ARM_CLIENT_SECRET was not defined."
     exit 2
   fi

--- a/deploy/scripts/pipeline_scripts/v1/05-DB-and-SAP-installation-prepare.sh
+++ b/deploy/scripts/pipeline_scripts/v1/05-DB-and-SAP-installation-prepare.sh
@@ -29,7 +29,7 @@ if [ "${SYSTEM_DEBUG:-False}" == "True" ]; then
 	set -x
 	DEBUG=true
 	echo "Environment variables:"
-	printenv | sort
+	printenv | grep -Ev '^(ARM_CLIENT_SECRET|ARM_OIDC_TOKEN|idToken|servicePrincipalKey|SYSTEM_ACCESSTOKEN|AZURE_DEVOPS_EXT_PAT)=' | sort
 
 fi
 export DEBUG

--- a/deploy/scripts/pipeline_scripts/v1/05-run-ansible.sh
+++ b/deploy/scripts/pipeline_scripts/v1/05-run-ansible.sh
@@ -37,7 +37,7 @@ if [ "${SYSTEM_DEBUG:-False}" == "True" ]; then
 	set -x
 	DEBUG=True
 	echo "Environment variables:"
-	printenv | sort
+	printenv | grep -Ev '^(ARM_CLIENT_SECRET|ARM_OIDC_TOKEN|idToken|servicePrincipalKey|SYSTEM_ACCESSTOKEN|AZURE_DEVOPS_EXT_PAT)=' | sort
 
 fi
 export DEBUG

--- a/deploy/scripts/pipeline_scripts/v1/10-remover-terraform-system.sh
+++ b/deploy/scripts/pipeline_scripts/v1/10-remover-terraform-system.sh
@@ -32,7 +32,7 @@ if [ "${SYSTEM_DEBUG:-False}" == "True" ]; then
 	set -x
 	DEBUG=True
 	echo "Environment variables:"
-	printenv | sort
+	printenv | grep -Ev '^(ARM_CLIENT_SECRET|ARM_OIDC_TOKEN|idToken|servicePrincipalKey|SYSTEM_ACCESSTOKEN|AZURE_DEVOPS_EXT_PAT)=' | sort
 
 fi
 export DEBUG

--- a/deploy/scripts/pipeline_scripts/v1/10-remover-terraform-workload-zone.sh
+++ b/deploy/scripts/pipeline_scripts/v1/10-remover-terraform-workload-zone.sh
@@ -31,7 +31,7 @@ if [ "${SYSTEM_DEBUG:-False}" == "True" ]; then
 	set -x
 	DEBUG=True
 	echo "Environment variables:"
-	printenv | sort
+	printenv | grep -Ev '^(ARM_CLIENT_SECRET|ARM_OIDC_TOKEN|idToken|servicePrincipalKey|SYSTEM_ACCESSTOKEN|AZURE_DEVOPS_EXT_PAT)=' | sort
 
 fi
 export DEBUG

--- a/deploy/scripts/pipeline_scripts/v1/12-remove-control-plane-finalize.sh
+++ b/deploy/scripts/pipeline_scripts/v1/12-remove-control-plane-finalize.sh
@@ -34,26 +34,9 @@ if [[ ! -f /etc/profile.d/deploy_server.sh ]]; then
 
 	configureNonDeployer "$TF_VERSION"
 
-	ARM_CLIENT_ID="$servicePrincipalId"
-	export ARM_CLIENT_ID
+	configure_service_connection_authentication
 	TF_VAR_spn_id=$ARM_CLIENT_ID
 	export TF_VAR_spn_id
-
-	if printenv servicePrincipalKey; then
-		unset ARM_OIDC_TOKEN
-		ARM_CLIENT_SECRET="$servicePrincipalKey"
-		export ARM_CLIENT_SECRET
-
-	else
-		ARM_OIDC_TOKEN="$idToken"
-		export ARM_OIDC_TOKEN
-		ARM_USE_OIDC=true
-		export ARM_USE_OIDC
-		unset ARM_CLIENT_SECRET
-	fi
-
-	ARM_TENANT_ID="$tenantId"
-	export ARM_TENANT_ID
 
 	ARM_USE_AZUREAD=true
 	export ARM_USE_AZUREAD

--- a/deploy/scripts/pipeline_scripts/v1/12-remove-control-plane.sh
+++ b/deploy/scripts/pipeline_scripts/v1/12-remove-control-plane.sh
@@ -26,7 +26,7 @@ if [ "${SYSTEM_DEBUG:-False}" == "True" ]; then
 	set -o errexit
 	DEBUG=True
 	echo "Environment variables:"
-	printenv | sort
+	printenv | grep -Ev '^(ARM_CLIENT_SECRET|ARM_OIDC_TOKEN|idToken|servicePrincipalKey|SYSTEM_ACCESSTOKEN|AZURE_DEVOPS_EXT_PAT)=' | sort
 
 fi
 

--- a/deploy/scripts/pipeline_scripts/v2/00-store-secrets-in-keyvault.sh
+++ b/deploy/scripts/pipeline_scripts/v2/00-store-secrets-in-keyvault.sh
@@ -23,7 +23,7 @@ if [ "$PLATFORM" == "devops" ]; then
 		set -x
 		DEBUG=true
 		echo "Environment variables:"
-		printenv | sort
+		printenv | grep -Ev '^(ARM_CLIENT_SECRET|ARM_OIDC_TOKEN|idToken|servicePrincipalKey|SYSTEM_ACCESSTOKEN|AZURE_DEVOPS_EXT_PAT)=' | sort
 	fi
 fi
 
@@ -48,6 +48,8 @@ elif [ "$PLATFORM" == "github" ]; then
 fi
 
 echo -e "$green--- Validations ---$reset"
+configure_service_connection_authentication
+
 if [ "$USE_MSI" != "true" ]; then
 	print_banner "$banner_title" "Using Service Principals for deployment" "info"
 
@@ -61,7 +63,7 @@ if [ "$USE_MSI" != "true" ]; then
 		exit 2
 	fi
 
-	if ! printenv ARM_CLIENT_SECRET; then
+	if [ "${ARM_USE_OIDC:-false}" != "true" ] && ! printenv ARM_CLIENT_SECRET; then
 		echo "##vso[task.logissue type=error]Variable ARM_CLIENT_SECRET was not defined in the $VARIABLE_GROUP variable group."
 		exit 2
 	fi
@@ -191,8 +193,10 @@ fi
 
 if [ "$USE_MSI" != "true" ]; then
 	allParameters+=(--client_id "$ARM_CLIENT_ID")
-	allParameters+=(--client_secret "$ARM_CLIENT_SECRET")
 	allParameters+=(--client_tenant_id "$ARM_TENANT_ID")
+	if [ "${ARM_USE_OIDC:-false}" != "true" ]; then
+		allParameters+=(--client_secret "$ARM_CLIENT_SECRET")
+	fi
 fi
 
 source "$SAP_AUTOMATION_REPO_PATH/deploy/scripts/set_secrets_v2.sh"

--- a/deploy/scripts/pipeline_scripts/v2/01-control-plane-deploy.sh
+++ b/deploy/scripts/pipeline_scripts/v2/01-control-plane-deploy.sh
@@ -21,7 +21,7 @@ if [ "$PLATFORM" == "devops" ]; then
         export TF_LOG
 
         echo "Environment variables:"
-        printenv | sort
+        printenv | grep -Ev '^(ARM_CLIENT_SECRET|ARM_OIDC_TOKEN|idToken|servicePrincipalKey|SYSTEM_ACCESSTOKEN|AZURE_DEVOPS_EXT_PAT)=' | sort
     fi
 fi
 
@@ -381,7 +381,7 @@ fi
 
 if [ "${DEBUG:-false}" == "true" ]; then
     echo "ARM Environment variables:"
-    printenv | grep ARM_
+    printenv | grep '^ARM_' | grep -Ev '^(ARM_CLIENT_SECRET|ARM_OIDC_TOKEN)='
 fi
 echo -e "$green--- Control Plane deployment---$reset_formatting"
 

--- a/deploy/scripts/pipeline_scripts/v2/01-control-plane-prepare.sh
+++ b/deploy/scripts/pipeline_scripts/v2/01-control-plane-prepare.sh
@@ -22,7 +22,7 @@ if [ "$PLATFORM" == "devops" ]; then
 		set -x
 		DEBUG=true
 		echo "Environment variables:"
-		printenv | sort
+		printenv | grep -Ev '^(ARM_CLIENT_SECRET|ARM_OIDC_TOKEN|idToken|servicePrincipalKey|SYSTEM_ACCESSTOKEN|AZURE_DEVOPS_EXT_PAT)=' | sort
 	else
 		DEBUG=false
 	fi
@@ -174,29 +174,14 @@ echo "Deployer subscription:               $ARM_SUBSCRIPTION_ID"
 if [[ ! -f /etc/profile.d/deploy_server.sh ]]; then
 	configureNonDeployer "$TF_VERSION"
 
-	ARM_CLIENT_ID="${servicePrincipalId:-$ARM_CLIENT_ID}"
-	export ARM_CLIENT_ID
+	configure_service_connection_authentication
 	TF_VAR_spn_id=$ARM_CLIENT_ID
 	export TF_VAR_spn_id
 
-	if [ "$PLATFORM" == "devops" ]; then
-		# Azure DevOps specific authentication logic
-		if printenv servicePrincipalKey; then
-			unset ARM_OIDC_TOKEN
-			ARM_CLIENT_SECRET="$servicePrincipalKey"
-			export ARM_CLIENT_SECRET
-		else
-			ARM_OIDC_TOKEN="$idToken"
-			export ARM_OIDC_TOKEN
-			ARM_USE_OIDC=true
-			export ARM_USE_OIDC
-			unset ARM_CLIENT_SECRET
-		fi
-	elif [ "$PLATFORM" == "github" ]; then
+	if [ "$PLATFORM" == "github" ]; then
 		# GitHub Actions uses standard ARM_CLIENT_SECRET
 		echo "Using standard Azure authentication for GitHub Actions"
 	fi
-	ARM_TENANT_ID="${tenantId:-$ARM_TENANT_ID}"
 
 	if [ -z "${ARM_TENANT_ID:-}" ]; then
 		ARM_TENANT_ID=$(az account show --query tenantId -o tsv)
@@ -370,7 +355,7 @@ fi
 
 if [ "${DEBUG:-false}" == true ]; then
 	echo "ARM Environment variables:"
-	printenv | grep ARM_
+	printenv | grep '^ARM_' | grep -Ev '^(ARM_CLIENT_SECRET|ARM_OIDC_TOKEN)='
 fi
 echo -e "$green--- Control Plane deployment---$reset_formatting"
 

--- a/deploy/scripts/pipeline_scripts/v2/01-webapp-configuration.sh
+++ b/deploy/scripts/pipeline_scripts/v2/01-webapp-configuration.sh
@@ -34,7 +34,7 @@ if  [[ ${SYSTEM_DEBUG:-False} = True ]] || \
       set -x                                                                    # Enable debug mode
       export DEBUG=True
       echo "Environment variables:"
-      printenv | sort
+      printenv | grep -Ev '^(ARM_CLIENT_SECRET|ARM_OIDC_TOKEN|idToken|servicePrincipalKey|SYSTEM_ACCESSTOKEN|AZURE_DEVOPS_EXT_PAT)=' | sort
 else
       export DEBUG=False
 fi
@@ -118,4 +118,3 @@ return_code=0
 echo -e "\n${cyan}Exiting script:  ${BASH_SOURCE[0]}${reset}"
 echo -e   "${cyan}   Return code:  ${return_code}${reset}"
 exit $return_code
-

--- a/deploy/scripts/pipeline_scripts/v2/04-sap-software-download-prepare.sh
+++ b/deploy/scripts/pipeline_scripts/v2/04-sap-software-download-prepare.sh
@@ -35,7 +35,7 @@ if [ "$PLATFORM" == "devops" ]; then
         set -x
         DEBUG=True
         echo "Environment variables:"
-        printenv | sort
+        printenv | grep -Ev '^(ARM_CLIENT_SECRET|ARM_OIDC_TOKEN|idToken|servicePrincipalKey|SYSTEM_ACCESSTOKEN|AZURE_DEVOPS_EXT_PAT)=' | sort
     fi
     export DEBUG
     AZURE_DEVOPS_EXT_PAT=$SYSTEM_ACCESSTOKEN

--- a/deploy/scripts/pipeline_scripts/v2/04-sap-software-download.sh
+++ b/deploy/scripts/pipeline_scripts/v2/04-sap-software-download.sh
@@ -34,7 +34,7 @@ if [ "${SYSTEM_DEBUG:-False}" = True ]; then
     set -x
     DEBUG=True
     echo "Environment variables:"
-    printenv | sort
+    printenv | grep -Ev '^(ARM_CLIENT_SECRET|ARM_OIDC_TOKEN|idToken|servicePrincipalKey|SYSTEM_ACCESSTOKEN|AZURE_DEVOPS_EXT_PAT)=' | sort
 
 fi
 export DEBUG

--- a/deploy/scripts/pipeline_scripts/v2/05-DB-and-SAP-installation-prepare.sh
+++ b/deploy/scripts/pipeline_scripts/v2/05-DB-and-SAP-installation-prepare.sh
@@ -40,7 +40,7 @@ if [ "$PLATFORM" == "devops" ]; then
 		set -x
 		DEBUG=True
 		echo "Environment variables:"
-		printenv | sort
+		printenv | grep -Ev '^(ARM_CLIENT_SECRET|ARM_OIDC_TOKEN|idToken|servicePrincipalKey|SYSTEM_ACCESSTOKEN|AZURE_DEVOPS_EXT_PAT)=' | sort
 
 	fi
 	export DEBUG

--- a/deploy/scripts/pipeline_scripts/v2/05-run-ansible.sh
+++ b/deploy/scripts/pipeline_scripts/v2/05-run-ansible.sh
@@ -42,7 +42,7 @@ if [ "$PLATFORM" == "devops" ]; then
 		set -x
 		DEBUG=True
 		echo "Environment variables:"
-		printenv | sort
+		printenv | grep -Ev '^(ARM_CLIENT_SECRET|ARM_OIDC_TOKEN|idToken|servicePrincipalKey|SYSTEM_ACCESSTOKEN|AZURE_DEVOPS_EXT_PAT)=' | sort
 
 	fi
 	export DEBUG

--- a/deploy/scripts/pipeline_scripts/v2/10-remover-terraform-system.sh
+++ b/deploy/scripts/pipeline_scripts/v2/10-remover-terraform-system.sh
@@ -18,7 +18,7 @@ if [ "$PLATFORM" == "devops" ]; then
         set -x
         DEBUG=true
         echo "Environment variables:"
-        printenv | sort
+        printenv | grep -Ev '^(ARM_CLIENT_SECRET|ARM_OIDC_TOKEN|idToken|servicePrincipalKey|SYSTEM_ACCESSTOKEN|AZURE_DEVOPS_EXT_PAT)=' | sort
     fi
 fi
 

--- a/deploy/scripts/pipeline_scripts/v2/10-remover-terraform-workload-zone.sh
+++ b/deploy/scripts/pipeline_scripts/v2/10-remover-terraform-workload-zone.sh
@@ -18,7 +18,7 @@ if [ "$PLATFORM" == "devops" ]; then
 		set -x
 		DEBUG=true
 		echo "Environment variables:"
-		printenv | sort
+		printenv | grep -Ev '^(ARM_CLIENT_SECRET|ARM_OIDC_TOKEN|idToken|servicePrincipalKey|SYSTEM_ACCESSTOKEN|AZURE_DEVOPS_EXT_PAT)=' | sort
 	fi
 fi
 

--- a/deploy/scripts/pipeline_scripts/v2/12-remove-control-plane-finalize.sh
+++ b/deploy/scripts/pipeline_scripts/v2/12-remove-control-plane-finalize.sh
@@ -133,34 +133,16 @@ echo "Deployer subscription:               $ARM_SUBSCRIPTION_ID"
 if [[ ! -f /etc/profile.d/deploy_server.sh ]]; then
     configureNonDeployer "${tf_version:-1.15.7}"
 
-    if [ "$PLATFORM" == "devops" ]; then
-        ARM_CLIENT_ID="${servicePrincipalId:-$ARM_CLIENT_ID}"
-        export ARM_CLIENT_ID
-        TF_VAR_spn_id=$ARM_CLIENT_ID
-        export TF_VAR_spn_id
+    configure_service_connection_authentication
+    TF_VAR_spn_id=$ARM_CLIENT_ID
+    export TF_VAR_spn_id
 
-        # Azure DevOps specific authentication logic
-        if printenv servicePrincipalKey; then
-            unset ARM_OIDC_TOKEN
-            ARM_CLIENT_SECRET="$servicePrincipalKey"
-            export ARM_CLIENT_SECRET
-        else
-            ARM_OIDC_TOKEN="$idToken"
-            export ARM_OIDC_TOKEN
-            ARM_USE_OIDC=true
-            export ARM_USE_OIDC
-            unset ARM_CLIENT_SECRET
-        fi
-        elif [ "$PLATFORM" == "github" ]; then
+    if [ "$PLATFORM" == "github" ]; then
         # GitHub Actions uses standard ARM_CLIENT_SECRET
         echo "Using standard Azure authentication for GitHub Actions"
     fi
 
-    if [ -v tenantId ]; then
-        # If tenantId is set, use it
-        ARM_TENANT_ID="${tenantId}"
-    else
-        # Otherwise, use the default ARM_TENANT_ID
+    if [ -z "${ARM_TENANT_ID:-}" ]; then
         ARM_TENANT_ID=$(az account show --query tenantId -o tsv)
     fi
     export ARM_TENANT_ID
@@ -267,7 +249,7 @@ fi
 
 if [ "${DEBUG:-false}" == true ]; then
     echo "ARM Environment variables:"
-    printenv | grep ARM_
+    printenv | grep '^ARM_' | grep -Ev '^(ARM_CLIENT_SECRET|ARM_OIDC_TOKEN)='
 fi
 echo -e "$green--- Control Plane deployment---$reset_formatting"
 

--- a/deploy/scripts/pipeline_scripts/v2/shared_platform_config.sh
+++ b/deploy/scripts/pipeline_scripts/v2/shared_platform_config.sh
@@ -9,8 +9,7 @@ if [[ "${SYSTEM_DEBUG:-False}" == 'True' || "${RUNNER_DEBUG:-0}" == "1" ]]; then
 	set -x
 	# Exit on error
 	set -o errexit
-	echo "Environment variables:"
-	printenv | sort
+	echo "Debug logging enabled"
 	DEBUG=true
 else
 	DEBUG=false

--- a/deploy/scripts/set_secrets.sh
+++ b/deploy/scripts/set_secrets.sh
@@ -34,7 +34,7 @@ if  [[ ${SYSTEM_DEBUG:-False} = True ]] || \
       set -x                                                                    # Enable debug mode
       export DEBUG=True
       echo "Environment variables:"
-      printenv | sort
+      printenv | grep -Ev '^(ARM_CLIENT_SECRET|ARM_OIDC_TOKEN|idToken|servicePrincipalKey|SYSTEM_ACCESSTOKEN|AZURE_DEVOPS_EXT_PAT)=' | sort
 else
       export DEBUG=False
 fi
@@ -311,7 +311,7 @@ if [ $deploy_using_msi_only = 0 ]; then
 fi
 
 
-if [ 0 = "${deploy_using_msi_only:-}" ]; then
+if [ 0 = "${deploy_using_msi_only:-}" ] && [ "${ARM_USE_OIDC:-false}" != "true" ]; then
 
 	if [ -z "$client_secret" ]; then
 		#do not output the secret to screen
@@ -372,7 +372,7 @@ else
 	exit 20
 fi
 
-if [ 0 = "${deploy_using_msi_only:-}" ]; then
+if [ 0 = "${deploy_using_msi_only:-}" ] && [ "${ARM_USE_OIDC:-false}" != "true" ]; then
 
 	secret_name="${ZONE_NAME}"-client-secret
 	if setSecretValue "${keyvault}" "${STATE_SUBSCRIPTION}" "${secret_name}" "${client_secret}" "secret"; then

--- a/deploy/scripts/set_secrets_v2.sh
+++ b/deploy/scripts/set_secrets_v2.sh
@@ -34,7 +34,7 @@ if  [[ ${SYSTEM_DEBUG:-False} = True ]] || \
       set -x                                                                    # Enable debug mode
       export DEBUG=True
       echo "Environment variables:"
-      printenv | sort
+      printenv | grep -Ev '^(ARM_CLIENT_SECRET|ARM_OIDC_TOKEN|idToken|servicePrincipalKey|SYSTEM_ACCESSTOKEN|AZURE_DEVOPS_EXT_PAT)=' | sort
 else
       export DEBUG=False
 fi
@@ -502,11 +502,6 @@ function parse_arguments() {
 			fi
 		fi
 
-		[[ -z "$client_secret" ]] && {
-			print_banner "$banner_title" "client_secret is required" "error"
-			return 10
-		}
-
 		if [ -z "$tenant_id" ]; then
 			print_banner "$banner_title" "correct tenant_id is required" "error"
 			return 10
@@ -515,6 +510,13 @@ function parse_arguments() {
 				print_banner "$banner_title" "correct tenant_id is required" "error"
 				return 10
 			fi
+		fi
+
+		if [ "${ARM_USE_OIDC:-false}" != "true" ]; then
+			[[ -z "$client_secret" ]] && {
+				print_banner "$banner_title" "client_secret is required" "error"
+				return 10
+			}
 		fi
 
 	fi
@@ -639,7 +641,7 @@ function set_all_secrets() {
 		return 20
 	fi
 
-  if [ "$USE_MSI" != "true" ]; then
+  if [ "$USE_MSI" != "true" ] && [ "${ARM_USE_OIDC:-false}" != "true" ]; then
 		secret_name="${prefix}"-client-secret
 		if setSecretValue "${keyvault}" "${STATE_SUBSCRIPTION}" "${secret_name}" "$ARM_CLIENT_SECRET" "secret" >/dev/null; then
 			print_banner "$banner_title" "Secret ${secret_name} set in keyvault ${keyvault}" "success"


### PR DESCRIPTION
## Problem
This pull request updates the deployment pipelines and associated scripts to improve security and standardization. The most significant changes are the migration from `Bash@3` to `AzureCLI@2` tasks in Azure DevOps pipelines and the masking of sensitive environment variables from debug output. These changes enhance the security posture of the deployment process and ensure consistent authentication with Azure.

**Pipeline Task Standardization and Security:**

* Replaced all uses of the `Bash@3` task with `AzureCLI@2` in pipeline YAML files (such as `01-deploy-control-plane.yaml`, `02-sap-workload-zone.yaml`, `03-sap-system-deployment.yaml`, `04-sap-software-download.yaml`, `05-DB-and-SAP-installation.yaml`, `10-remover-terraform.yaml`, `12-remove-control-plane.yaml`, and the `run-ansible.yaml` template). This change ensures that scripts are run within an authenticated Azure context, using service principal credentials securely injected into the environment. [[1]](diffhunk://#diff-0efae0d203b4f2d6d06d8be3be83cd9dfa7ad9c5a7cf5dd1b61abcdf2dcdffb0L155-R163) [[2]](diffhunk://#diff-0efae0d203b4f2d6d06d8be3be83cd9dfa7ad9c5a7cf5dd1b61abcdf2dcdffb0L210-R222) [[3]](diffhunk://#diff-6035095a066a918fb6db37ab0eb04e702e8c2147dea6d8a4fbb30579299f1339L136-R144) [[4]](diffhunk://#diff-6035095a066a918fb6db37ab0eb04e702e8c2147dea6d8a4fbb30579299f1339L184-R196) [[5]](diffhunk://#diff-2574b1f74ab9dbe22ce61386ec5383dcc9907861337ae9a8e2d99ba95b6011acL55-R63) [[6]](diffhunk://#diff-d08b759c3be1e8985ac0354640e8b6eff15dfa049aa2e920d21e1c13bffc32f0L80-R88) [[7]](diffhunk://#diff-d08b759c3be1e8985ac0354640e8b6eff15dfa049aa2e920d21e1c13bffc32f0L128-R140) [[8]](diffhunk://#diff-7764570e485df8c61fda31b3ce2a17ff2a5e66a7efe96b18ce399087691626cdL167-R175) [[9]](diffhunk://#diff-755b16fb115db252f5b921c1db3f15dc70740a3d5ffb5df97f261d882c8d552eL81-R89) [[10]](diffhunk://#diff-755b16fb115db252f5b921c1db3f15dc70740a3d5ffb5df97f261d882c8d552eL131-R143) [[11]](diffhunk://#diff-1522f43b29a2791178c27df29f8a485a5550edeada57e21b4b243c3bbf76ccacL70-R78) [[12]](diffhunk://#diff-1ebbfe9fa954bec2571db0c00c8a96e43c1fbcc5519adde9c39eec596109a5d1L30-R40)

**Sensitive Data Masking in Debug Output:**

* Updated all scripts to filter out sensitive environment variables (`ARM_CLIENT_SECRET`, `ARM_OIDC_TOKEN`, `idToken`, `servicePrincipalKey`, `SYSTEM_ACCESSTOKEN`, `AZURE_DEVOPS_EXT_PAT`) from debug output, preventing accidental exposure in logs. This affects scripts such as `deploy_controlplane.sh`, `00-store-secrets-in-keyvault.sh`, `00-validate-credentials.sh`, `01-control-plane-deploy.sh`, `01-control-plane-prepare.sh`, `01-webapp-configuration.sh`, and `11-remover-arm-fallback-control-plane.sh`. [[1]](diffhunk://#diff-aa5e71e36577202e27195f8b428d8bdba70a6d047e42bd88a7b992aba42a9945L54-R54) [[2]](diffhunk://#diff-ac9f69b489265862bd0c1a44d666c6393340f81b9379559c35ea968e0bc2240aL37-R37) [[3]](diffhunk://#diff-1d0ba24350e267287e0e45794b2812db3d97f3992039b24d44f9c19eed7296ffL28-R28) [[4]](diffhunk://#diff-228240f2a6f381b1c08c20b095a9f363a2fb46e81dc75c45a889f26f5146ed0bL37-R37) [[5]](diffhunk://#diff-085d19d7e03da64311178d125fc95f8c44b00bdac8d2984cc480e71d7337dcf8L37-R37) [[6]](diffhunk://#diff-a7aaaec5c94753f74d65ba8340508768bac51537804af9c13fc1564cfaaf69b6L21-R21)

**Conditional Service Principal Secret Usage:**

* Modified logic in `deploy_controlplane.sh` to only include the service principal secret parameter if not using managed identity or OIDC, further strengthening credential handling.

These updates collectively improve the security, reliability, and maintainability of the deployment automation.
<Please describe what problem this PR is trying to resolve>

## Solution
<Please elaborate the solution for the problem>

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>