### PR TITLE
fix: use --subscription in sync_deployer.sh help example

### DIFF
--- a/deploy/scripts/sync_deployer.sh
+++ b/deploy/scripts/sync_deployer.sh
@@ -27,7 +27,7 @@ function showhelp {
 	echo "#                                                                                       #"
 	echo "#   [REPO-ROOT]deploy/scripts/sync_deployer.sh \                                        #"
 	echo "#      --storageaccountname mgmtweeutfstate### \                                        #"
-	echo "#      --state_subscription xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx                        #"
+	echo "#      --subscription xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx                              #"
 	echo "#                                                                                       #"
 	echo "#########################################################################################"
 }


### PR DESCRIPTION
## Summary
- Align the `sync_deployer.sh` help example with the flags that `getopt` actually accepts
- Replace `--state_subscription` with `--subscription` in the example block

Fixes #1061

## Test plan
- [ ] Run `deploy/scripts/sync_deployer.sh --help` and confirm the example shows `--subscription`
- [ ] Confirm `-s` / `--subscription` still parse as before