### PR TITLE
Add skills for deployment, readiness checks, and quality assurance

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,16 @@
+{
+    "name": "sap-automation",
+    "description": "Microsoft's SAP Deployment Automation Framework (SDAF) AI-skills marketplace: the hub plugin plus references to the surface-specific bootstrap plugins for Azure DevOps and GitHub Actions.",
+    "owner": {
+        "name": "Microsoft",
+        "url": "https://github.com/Azure"
+    },
+    "plugins": [
+        {
+            "name": "azure-sap-automation",
+            "source": ".",
+            "description": "AI skills for the SAP Deployment Automation Framework (SDAF): orient, pre-flight readiness, deploy the control plane / workload zone / SAP system, choose a BOM, lay out WORKSPACES/tfvars, and triage failed runs. Documented behaviour only.",
+            "version": "0.1.0"
+        }
+    ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
     "name": "sap-automation",
-    "description": "Microsoft's SAP Deployment Automation Framework (SDAF) AI-skills marketplace: the hub plugin plus references to the surface-specific bootstrap plugins for Azure DevOps and GitHub Actions.",
+    "description": "Microsoft's SAP Deployment Automation Framework (SDAF) AI-skills marketplace: the 18-skill documented-only hub plugin plus references to the Azure DevOps and GitHub Actions surface bootstrap plugins.",
     "owner": {
         "name": "Microsoft",
         "url": "https://github.com/Azure"
@@ -9,7 +9,7 @@
         {
             "name": "azure-sap-automation",
             "source": ".",
-            "description": "AI skills for the SAP Deployment Automation Framework (SDAF): orient, pre-flight readiness, deploy the control plane / workload zone / SAP system, choose a BOM, lay out WORKSPACES/tfvars, and triage failed runs. Documented behaviour only.",
+            "description": "18 documented-only hub skills for the SAP Deployment Automation Framework (SDAF): orientation, readiness, workspaces/tfvars, BOM/media, plan/test semantics, control plane / workload zone / SAP system deployment, installation, QA, HA, state, safe removal, failure triage, and sovereign-cloud deltas.",
             "version": "0.1.0"
         }
     ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-sap-automation",
-    "description": "AI skills for the SAP Deployment Automation Framework (SDAF): orient, pre-flight readiness, deploy the control plane / workload zone / SAP system, choose a BOM, lay out WORKSPACES/tfvars, and triage failed runs. Documented behaviour only.",
+    "description": "18 documented-only hub skills for the SAP Deployment Automation Framework (SDAF): orientation, readiness, workspaces/tfvars, BOM/media, plan/test semantics, control plane / workload zone / SAP system deployment, installation, QA, HA, state, safe removal, failure triage, and sovereign-cloud deltas.",
     "version": "0.1.0",
     "author": {
         "name": "Microsoft",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+    "name": "azure-sap-automation",
+    "description": "AI skills for the SAP Deployment Automation Framework (SDAF): orient, pre-flight readiness, deploy the control plane / workload zone / SAP system, choose a BOM, lay out WORKSPACES/tfvars, and triage failed runs. Documented behaviour only.",
+    "version": "0.1.0",
+    "author": {
+        "name": "Microsoft",
+        "url": "https://github.com/Azure"
+    },
+    "homepage": "https://github.com/Azure/sap-automation",
+    "repository": "https://github.com/Azure/sap-automation",
+    "license": "MIT",
+    "keywords": [
+        "sap",
+        "sdaf",
+        "azure",
+        "terraform",
+        "ansible"
+    ]
+}

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -1,0 +1,16 @@
+{
+    "name": "sap-automation",
+    "description": "Microsoft's SAP Deployment Automation Framework (SDAF) AI-skills marketplace: the hub plugin plus references to the surface-specific bootstrap plugins for Azure DevOps and GitHub Actions.",
+    "owner": {
+        "name": "Microsoft",
+        "url": "https://github.com/Azure"
+    },
+    "plugins": [
+        {
+            "name": "azure-sap-automation",
+            "source": ".",
+            "description": "AI skills for the SAP Deployment Automation Framework (SDAF): orient, pre-flight readiness, deploy the control plane / workload zone / SAP system, choose a BOM, lay out WORKSPACES/tfvars, and triage failed runs. Documented behaviour only.",
+            "version": "0.1.0"
+        }
+    ]
+}

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
     "name": "sap-automation",
-    "description": "Microsoft's SAP Deployment Automation Framework (SDAF) AI-skills marketplace: the hub plugin plus references to the surface-specific bootstrap plugins for Azure DevOps and GitHub Actions.",
+    "description": "Microsoft's SAP Deployment Automation Framework (SDAF) AI-skills marketplace: the 18-skill documented-only hub plugin plus references to the Azure DevOps and GitHub Actions surface bootstrap plugins.",
     "owner": {
         "name": "Microsoft",
         "url": "https://github.com/Azure"
@@ -9,7 +9,7 @@
         {
             "name": "azure-sap-automation",
             "source": ".",
-            "description": "AI skills for the SAP Deployment Automation Framework (SDAF): orient, pre-flight readiness, deploy the control plane / workload zone / SAP system, choose a BOM, lay out WORKSPACES/tfvars, and triage failed runs. Documented behaviour only.",
+            "description": "18 documented-only hub skills for the SAP Deployment Automation Framework (SDAF): orientation, readiness, workspaces/tfvars, BOM/media, plan/test semantics, control plane / workload zone / SAP system deployment, installation, QA, HA, state, safe removal, failure triage, and sovereign-cloud deltas.",
             "version": "0.1.0"
         }
     ]

--- a/.github/plugin/plugin.json
+++ b/.github/plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+    "name": "azure-sap-automation",
+    "description": "AI skills for the SAP Deployment Automation Framework (SDAF): orient, pre-flight readiness, deploy the control plane / workload zone / SAP system, choose a BOM, lay out WORKSPACES/tfvars, and triage failed runs. Documented behaviour only.",
+    "version": "0.1.0",
+    "author": {
+        "name": "Microsoft",
+        "url": "https://github.com/Azure"
+    },
+    "homepage": "https://github.com/Azure/sap-automation",
+    "repository": "https://github.com/Azure/sap-automation",
+    "license": "MIT",
+    "keywords": [
+        "sap",
+        "sdaf",
+        "azure",
+        "terraform",
+        "ansible"
+    ]
+}

--- a/.github/plugin/plugin.json
+++ b/.github/plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-sap-automation",
-    "description": "AI skills for the SAP Deployment Automation Framework (SDAF): orient, pre-flight readiness, deploy the control plane / workload zone / SAP system, choose a BOM, lay out WORKSPACES/tfvars, and triage failed runs. Documented behaviour only.",
+    "description": "18 documented-only hub skills for the SAP Deployment Automation Framework (SDAF): orientation, readiness, workspaces/tfvars, BOM/media, plan/test semantics, control plane / workload zone / SAP system deployment, installation, QA, HA, state, safe removal, failure triage, and sovereign-cloud deltas.",
     "version": "0.1.0",
     "author": {
         "name": "Microsoft",
@@ -9,6 +9,7 @@
     "homepage": "https://github.com/Azure/sap-automation",
     "repository": "https://github.com/Azure/sap-automation",
     "license": "MIT",
+    "skills": "skills/",
     "keywords": [
         "sap",
         "sdaf",

--- a/.github/workflows/skill-validation.yml
+++ b/.github/workflows/skill-validation.yml
@@ -13,6 +13,19 @@ on:
       - "requirements-test.txt"
       - "skills/**"
       - "evals/evals.py"
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+    paths:
+      - ".claude-plugin/**"
+      - ".github/plugin/**"
+      - ".github/workflows/skill-validation.yml"
+      - "CLAUDE.md"
+      - "evals/evals.json"
+      - "GEMINI.md"
+      - "gemini-extension.json"
+      - "requirements-test.txt"
+      - "skills/**"
+      - "evals/evals.py"
   push:
     branches: [main]
     paths:
@@ -135,10 +148,17 @@ jobs:
           test -f "$path/$REQUIRED_SKILL"
 
   prepare:
-    name: Prepare behavioral-eval matrix
+    name: Prepare routing-eval matrix
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'pull_request'
+      (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name == github.repository
+      ) ||
+      (
+        github.event_name == 'pull_request_target' &&
+        github.event.pull_request.head.repo.full_name != github.repository
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:

--- a/.github/workflows/skill-validation.yml
+++ b/.github/workflows/skill-validation.yml
@@ -223,7 +223,7 @@ jobs:
       - name: Run with-skill and baseline comparison
         env:
           CASE_ID: ${{ matrix.case }}
-          GITHUB_TOKEN: ${{ github.token }}
+          COPILOT_GITHUB_TOKEN: ${{ github.token }}
         run: >-
           python evals/evals.py
           --content-root "$PWD/content"

--- a/.github/workflows/skill-validation.yml
+++ b/.github/workflows/skill-validation.yml
@@ -43,7 +43,6 @@ on:
 
 permissions:
   contents: read
-  copilot-requests: write
   pull-requests: read
 
 env:
@@ -167,6 +166,9 @@ jobs:
       head_sha: ${{ steps.pr.outputs.head_sha }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          persist-credentials: false
 
       - name: Resolve content revision
         id: pr
@@ -213,6 +215,9 @@ jobs:
     needs: prepare
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      copilot-requests: write
     strategy:
       fail-fast: false
       max-parallel: 4
@@ -221,6 +226,9 @@ jobs:
     steps:
       - name: Checkout trusted runner
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          persist-credentials: false
 
       - name: Checkout skill content as data
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/skill-validation.yml
+++ b/.github/workflows/skill-validation.yml
@@ -6,6 +6,7 @@ on:
       - ".claude-plugin/**"
       - ".github/plugin/**"
       - ".github/workflows/skill-validation.yml"
+      - "CLAUDE.md"
       - "evals/evals.json"
       - "GEMINI.md"
       - "gemini-extension.json"
@@ -14,6 +15,17 @@ on:
       - "evals/evals.py"
   pull_request_target:
     types: [opened, reopened, synchronize]
+    paths:
+      - ".claude-plugin/**"
+      - ".github/plugin/**"
+      - ".github/workflows/skill-validation.yml"
+      - "CLAUDE.md"
+      - "evals/evals.json"
+      - "GEMINI.md"
+      - "gemini-extension.json"
+      - "requirements-test.txt"
+      - "skills/**"
+      - "evals/evals.py"
   pull_request_review:
     types: [submitted]
   push:
@@ -22,6 +34,7 @@ on:
       - ".claude-plugin/**"
       - ".github/plugin/**"
       - ".github/workflows/skill-validation.yml"
+      - "CLAUDE.md"
       - "evals/evals.json"
       - "GEMINI.md"
       - "gemini-extension.json"
@@ -111,7 +124,7 @@ jobs:
           timeout 60s gemini extensions validate "$PWD"
           timeout 300s gemini extensions install "$PWD" --consent --skip-settings
           timeout 60s gemini extensions list --output-format json \
-            > "$RUNNER_TEMP/gemini.json"
+            > "$RUNNER_TEMP/gemini.json" 2>&1
           path="$(jq -r --arg name "$PLUGIN_NAME" '
             (if type == "array" then . else (.extensions // []) end)[]
             | select(.name == $name)
@@ -156,6 +169,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       cases: ${{ steps.cases.outputs.value }}
+      should_run: ${{ steps.cases.outputs.should_run }}
       head_repo: ${{ steps.pr.outputs.head_repo }}
       head_sha: ${{ steps.pr.outputs.head_sha }}
     steps:
@@ -189,15 +203,31 @@ jobs:
       - name: Build 54-case matrix
         id: cases
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          if [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
+            changed="$(gh api \
+              "repos/$GITHUB_REPOSITORY/pulls/${{ github.event.pull_request.number }}/files" \
+              --paginate --jq '.[].filename')"
+            if ! grep -Eq \
+              '^(\.claude-plugin/|\.github/plugin/|\.github/workflows/skill-validation\.yml$|CLAUDE\.md$|evals/evals\.(json|py)$|GEMINI\.md$|gemini-extension\.json$|requirements-test\.txt$|skills/)' \
+              <<<"$changed"; then
+              echo 'should_run=false' >> "$GITHUB_OUTPUT"
+              echo 'value=[]' >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
           cases="$(jq -c '[.skills[].evals[].id]' content/evals/evals.json)"
           [ "$(jq length <<<"$cases")" -eq 54 ]
+          echo "should_run=true" >> "$GITHUB_OUTPUT"
           echo "value=$cases" >> "$GITHUB_OUTPUT"
 
   evaluate:
     name: Evaluate ${{ matrix.case }}
     needs: authorize
+    if: needs.authorize.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:

--- a/.github/workflows/skill-validation.yml
+++ b/.github/workflows/skill-validation.yml
@@ -13,21 +13,6 @@ on:
       - "requirements-test.txt"
       - "skills/**"
       - "evals/evals.py"
-  pull_request_target:
-    types: [opened, reopened, synchronize]
-    paths:
-      - ".claude-plugin/**"
-      - ".github/plugin/**"
-      - ".github/workflows/skill-validation.yml"
-      - "CLAUDE.md"
-      - "evals/evals.json"
-      - "GEMINI.md"
-      - "gemini-extension.json"
-      - "requirements-test.txt"
-      - "skills/**"
-      - "evals/evals.py"
-  pull_request_review:
-    types: [submitted]
   push:
     branches: [main]
     paths:
@@ -149,20 +134,15 @@ jobs:
           diff -u "$RUNNER_TEMP/expected.txt" "$RUNNER_TEMP/copilot.txt"
           test -f "$path/$REQUIRED_SKILL"
 
-  authorize:
-    name: Check behavioral-eval approval
+  prepare:
+    name: Prepare behavioral-eval matrix
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'pull_request_target' ||
-      (github.event_name == 'pull_request_review' &&
-        github.event.review.state == 'approved' &&
-        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
-          github.event.review.author_association))
+      github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
       cases: ${{ steps.cases.outputs.value }}
-      should_run: ${{ steps.cases.outputs.should_run }}
       head_repo: ${{ steps.pr.outputs.head_repo }}
       head_sha: ${{ steps.pr.outputs.head_sha }}
     steps:
@@ -196,63 +176,28 @@ jobs:
       - name: Build 54-case matrix
         id: cases
         shell: bash
-        env:
-          AUTHOR_TRUSTED: >-
-            ${{ contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
-              github.event.pull_request.author_association) }}
-          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          authorized=false
-          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ] || \
-             [ "$AUTHOR_TRUSTED" = "true" ]; then
-            authorized=true
-          elif [ "$GITHUB_EVENT_NAME" != "workflow_dispatch" ]; then
-            approved="$(gh api \
-              "repos/$GITHUB_REPOSITORY/pulls/${{ github.event.pull_request.number }}/reviews" \
-              --paginate --jq '
-                [.[] | select(
-                  .state == "APPROVED" and
-                  (.author_association == "OWNER" or
-                   .author_association == "MEMBER" or
-                   .author_association == "COLLABORATOR")
-                )] | length
-              ')"
-            [ "$approved" -gt 0 ] && authorized=true
-          fi
-          if [ "$authorized" != "true" ]; then
-            echo 'should_run=false' >> "$GITHUB_OUTPUT"
-            echo 'value=[]' >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          if [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
-            changed="$(gh api \
-              "repos/$GITHUB_REPOSITORY/pulls/${{ github.event.pull_request.number }}/files" \
-              --paginate --jq '.[].filename')"
-            if ! grep -Eq \
-              '^(\.claude-plugin/|\.github/plugin/|\.github/workflows/skill-validation\.yml$|CLAUDE\.md$|evals/evals\.(json|py)$|GEMINI\.md$|gemini-extension\.json$|requirements-test\.txt$|skills/)' \
-              <<<"$changed"; then
-              echo 'should_run=false' >> "$GITHUB_OUTPUT"
-              echo 'value=[]' >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-          fi
+          jq -e '
+            [.skills[].evals[].id] as $ids
+            | ($ids | length) == 54
+              and ($ids | unique | length) == 54
+              and all($ids[];
+                test("^[a-z0-9]+(-[a-z0-9]+)*$"))
+          ' content/evals/evals.json > /dev/null
           cases="$(jq -c '[.skills[].evals[].id]' content/evals/evals.json)"
-          [ "$(jq length <<<"$cases")" -eq 54 ]
-          echo "should_run=true" >> "$GITHUB_OUTPUT"
           echo "value=$cases" >> "$GITHUB_OUTPUT"
 
   evaluate:
     name: Evaluate ${{ matrix.case }}
-    needs: authorize
-    if: needs.authorize.outputs.should_run == 'true'
+    needs: prepare
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
       fail-fast: false
       max-parallel: 4
       matrix:
-        case: ${{ fromJSON(needs.authorize.outputs.cases) }}
+        case: ${{ fromJSON(needs.prepare.outputs.cases) }}
     steps:
       - name: Checkout trusted runner
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -260,8 +205,8 @@ jobs:
       - name: Checkout skill content as data
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          repository: ${{ needs.authorize.outputs.head_repo }}
-          ref: ${{ needs.authorize.outputs.head_sha }}
+          repository: ${{ needs.prepare.outputs.head_repo }}
+          ref: ${{ needs.prepare.outputs.head_sha }}
           path: content
           persist-credentials: false
 

--- a/.github/workflows/skill-validation.yml
+++ b/.github/workflows/skill-validation.yml
@@ -152,21 +152,14 @@ jobs:
     name: Check behavioral-eval approval
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      (
-        github.event_name == 'pull_request_target' &&
-        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
-          github.event.pull_request.author_association)
-      ) ||
-      (
-        github.event_name == 'pull_request_review' &&
+      github.event_name == 'pull_request_target' ||
+      (github.event_name == 'pull_request_review' &&
         github.event.review.state == 'approved' &&
         contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
-          github.event.review.author_association) &&
-        !contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
-          github.event.pull_request.author_association)
-      )
+          github.event.review.author_association))
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    environment: copilot
     outputs:
       cases: ${{ steps.cases.outputs.value }}
       should_run: ${{ steps.cases.outputs.should_run }}
@@ -204,9 +197,39 @@ jobs:
         id: cases
         shell: bash
         env:
+          AUTHOR_TRUSTED: >-
+            ${{ contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
+              github.event.pull_request.author_association) }}
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          authorized=false
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ] || \
+             [ "$AUTHOR_TRUSTED" = "true" ]; then
+            authorized=true
+          elif [ "$GITHUB_EVENT_NAME" != "workflow_dispatch" ]; then
+            approved="$(gh api \
+              "repos/$GITHUB_REPOSITORY/pulls/${{ github.event.pull_request.number }}/reviews" \
+              --paginate --jq '
+                [.[] | select(
+                  .state == "APPROVED" and
+                  (.author_association == "OWNER" or
+                   .author_association == "MEMBER" or
+                   .author_association == "COLLABORATOR")
+                )] | length
+              ')"
+            [ "$approved" -gt 0 ] && authorized=true
+          fi
+          if [ "$authorized" != "true" ]; then
+            echo 'should_run=false' >> "$GITHUB_OUTPUT"
+            echo 'value=[]' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ -z "$COPILOT_GITHUB_TOKEN" ]; then
+            echo "::error::COPILOT_GITHUB_TOKEN is not configured in the copilot environment."
+            exit 1
+          fi
           if [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             changed="$(gh api \
               "repos/$GITHUB_REPOSITORY/pulls/${{ github.event.pull_request.number }}/files" \
@@ -230,6 +253,7 @@ jobs:
     if: needs.authorize.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    environment: copilot
     strategy:
       fail-fast: false
       max-parallel: 4

--- a/.github/workflows/skill-validation.yml
+++ b/.github/workflows/skill-validation.yml
@@ -1,0 +1,250 @@
+name: Skill validation
+
+on:
+  pull_request:
+    paths:
+      - ".claude-plugin/**"
+      - ".github/plugin/**"
+      - ".github/workflows/skill-validation.yml"
+      - "evals/evals.json"
+      - "GEMINI.md"
+      - "gemini-extension.json"
+      - "requirements-test.txt"
+      - "skills/**"
+      - "evals/evals.py"
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+  pull_request_review:
+    types: [submitted]
+  push:
+    branches: [main]
+    paths:
+      - ".claude-plugin/**"
+      - ".github/plugin/**"
+      - ".github/workflows/skill-validation.yml"
+      - "evals/evals.json"
+      - "GEMINI.md"
+      - "gemini-extension.json"
+      - "requirements-test.txt"
+      - "skills/**"
+      - "evals/evals.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+env:
+  EXPECTED_SKILL_COUNT: "18"
+  MARKETPLACE_NAME: "sap-automation"
+  PLUGIN_NAME: "azure-sap-automation"
+  PLUGIN_ID: "azure-sap-automation@sap-automation"
+  REQUIRED_SKILL: "skills/sdaf-workspace-and-tfvars/SKILL.md"
+  COPILOT_VERSION: "1.0.79"
+  CLAUDE_VERSION: "2.1.231"
+  GEMINI_VERSION: "0.56.0-preview.1"
+  SDAF_EVAL_MAX_AI_CREDITS: "30"
+  SDAF_EVAL_MAX_OUTPUT_TOKENS: "1024"
+  SDAF_EVAL_SESSION_TIMEOUT_SECONDS: "120"
+
+jobs:
+  install:
+    name: Install skills on all three CLIs
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "20"
+
+      - name: Validate skill and eval counts
+        shell: bash
+        run: |
+          set -euo pipefail
+          find skills -mindepth 2 -maxdepth 2 -type f -name SKILL.md \
+            | sort > "$RUNNER_TEMP/expected.txt"
+          [ "$(wc -l < "$RUNNER_TEMP/expected.txt")" -eq "$EXPECTED_SKILL_COUNT" ]
+          grep -qx "$REQUIRED_SKILL" "$RUNNER_TEMP/expected.txt"
+          [ "$(jq '[.skills[].evals[]] | length' evals/evals.json)" -eq 54 ]
+
+      - name: Install pinned AI CLIs
+        shell: bash
+        run: |
+          set -euo pipefail
+          retry() {
+            for attempt in 1 2 3; do
+              "$@" && return 0
+              [ "$attempt" -eq 3 ] && return 1
+              sleep 5
+            done
+          }
+          retry npm install -g "@github/copilot@${COPILOT_VERSION}"
+          retry npm install -g "@anthropic-ai/claude-code@${CLAUDE_VERSION}"
+          retry npm install -g "@google/gemini-cli@${GEMINI_VERSION}"
+          copilot --version
+          claude --version
+          gemini --version
+
+      - name: Claude install
+        shell: bash
+        run: |
+          set -euo pipefail
+          claude plugin validate . --strict
+          claude plugin marketplace add ./
+          claude plugin install "$PLUGIN_ID"
+          path="$(claude plugin list --json \
+            | jq -r --arg id "$PLUGIN_ID" '.[] | select(.id == $id) | .installPath')"
+          find "$path/skills" -mindepth 2 -maxdepth 2 -type f -name SKILL.md \
+            -printf 'skills/%P\n' | sort > "$RUNNER_TEMP/claude.txt"
+          diff -u "$RUNNER_TEMP/expected.txt" "$RUNNER_TEMP/claude.txt"
+          test -f "$path/$REQUIRED_SKILL"
+
+      - name: Gemini install
+        shell: bash
+        env:
+          GEMINI_CLI_TRUST_WORKSPACE: "true"
+        run: |
+          set -euo pipefail
+          timeout 60s gemini extensions validate "$PWD"
+          timeout 300s gemini extensions install "$PWD" --consent --skip-settings
+          timeout 60s gemini extensions list --output-format json \
+            > "$RUNNER_TEMP/gemini.json"
+          path="$(jq -r --arg name "$PLUGIN_NAME" '
+            (if type == "array" then . else (.extensions // []) end)[]
+            | select(.name == $name)
+            | (.path // .installPath // .location // empty)
+          ' "$RUNNER_TEMP/gemini.json")"
+          test -n "$path"
+          find "$path/skills" -mindepth 2 -maxdepth 2 -type f -name SKILL.md \
+            -printf 'skills/%P\n' | sort > "$RUNNER_TEMP/gemini.txt"
+          diff -u "$RUNNER_TEMP/expected.txt" "$RUNNER_TEMP/gemini.txt"
+          test -f "$path/$REQUIRED_SKILL"
+
+      - name: Copilot install
+        shell: bash
+        run: |
+          set -euo pipefail
+          copilot plugin marketplace add .
+          copilot plugin install "$PLUGIN_ID"
+          path="$HOME/.copilot/installed-plugins/$MARKETPLACE_NAME/$PLUGIN_NAME"
+          find "$path/skills" -mindepth 2 -maxdepth 2 -type f -name SKILL.md \
+            -printf 'skills/%P\n' | sort > "$RUNNER_TEMP/copilot.txt"
+          diff -u "$RUNNER_TEMP/expected.txt" "$RUNNER_TEMP/copilot.txt"
+          test -f "$path/$REQUIRED_SKILL"
+
+  authorize:
+    name: Check behavioral-eval approval
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event_name == 'pull_request_target' &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
+          github.event.pull_request.author_association)
+      ) ||
+      (
+        github.event_name == 'pull_request_review' &&
+        github.event.review.state == 'approved' &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
+          github.event.review.author_association) &&
+        !contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
+          github.event.pull_request.author_association)
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      cases: ${{ steps.cases.outputs.value }}
+      head_repo: ${{ steps.pr.outputs.head_repo }}
+      head_sha: ${{ steps.pr.outputs.head_sha }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Resolve content revision
+        id: pr
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "head_repo=$GITHUB_REPOSITORY" >> "$GITHUB_OUTPUT"
+            echo "head_sha=$GITHUB_SHA" >> "$GITHUB_OUTPUT"
+          else
+            echo "head_repo=${{ github.event.pull_request.head.repo.full_name }}" \
+              >> "$GITHUB_OUTPUT"
+            echo "head_sha=${{ github.event.pull_request.head.sha }}" \
+              >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout skill content as data
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ${{ steps.pr.outputs.head_repo }}
+          ref: ${{ steps.pr.outputs.head_sha }}
+          path: content
+          persist-credentials: false
+
+      - name: Build 54-case matrix
+        id: cases
+        shell: bash
+        run: |
+          set -euo pipefail
+          cases="$(jq -c '[.skills[].evals[].id]' content/evals/evals.json)"
+          [ "$(jq length <<<"$cases")" -eq 54 ]
+          echo "value=$cases" >> "$GITHUB_OUTPUT"
+
+  evaluate:
+    name: Evaluate ${{ matrix.case }}
+    needs: authorize
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix:
+        case: ${{ fromJSON(needs.authorize.outputs.cases) }}
+    steps:
+      - name: Checkout trusted runner
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Checkout skill content as data
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ${{ needs.authorize.outputs.head_repo }}
+          ref: ${{ needs.authorize.outputs.head_sha }}
+          path: content
+          persist-credentials: false
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install trusted eval dependencies
+        run: |
+          python -m pip install -r requirements-test.txt
+          python -m copilot download-runtime
+
+      - name: Run with-skill and baseline comparison
+        env:
+          CASE_ID: ${{ matrix.case }}
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+        run: >-
+          python evals/evals.py
+          --content-root "$PWD/content"
+          --case "$CASE_ID"
+          --output-dir "$RUNNER_TEMP/skill-eval/$CASE_ID"
+          --max-ai-credits "$SDAF_EVAL_MAX_AI_CREDITS"
+          --max-output-tokens "$SDAF_EVAL_MAX_OUTPUT_TOKENS"
+          --timeout "$SDAF_EVAL_SESSION_TIMEOUT_SECONDS"
+
+      - name: Upload reliability evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: skill-reliability-${{ matrix.case }}-${{ github.run_id }}
+          path: ${{ runner.temp }}/skill-eval/${{ matrix.case }}
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/skill-validation.yml
+++ b/.github/workflows/skill-validation.yml
@@ -45,6 +45,7 @@ on:
 
 permissions:
   contents: read
+  copilot-requests: write
   pull-requests: read
 
 env:
@@ -159,7 +160,6 @@ jobs:
           github.event.review.author_association))
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    environment: copilot
     outputs:
       cases: ${{ steps.cases.outputs.value }}
       should_run: ${{ steps.cases.outputs.should_run }}
@@ -200,7 +200,6 @@ jobs:
           AUTHOR_TRUSTED: >-
             ${{ contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
               github.event.pull_request.author_association) }}
-          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
@@ -226,10 +225,6 @@ jobs:
             echo 'value=[]' >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if [ -z "$COPILOT_GITHUB_TOKEN" ]; then
-            echo "::error::COPILOT_GITHUB_TOKEN is not configured in the copilot environment."
-            exit 1
-          fi
           if [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             changed="$(gh api \
               "repos/$GITHUB_REPOSITORY/pulls/${{ github.event.pull_request.number }}/files" \
@@ -253,7 +248,6 @@ jobs:
     if: needs.authorize.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    environment: copilot
     strategy:
       fail-fast: false
       max-parallel: 4
@@ -284,7 +278,7 @@ jobs:
       - name: Run with-skill and baseline comparison
         env:
           CASE_ID: ${{ matrix.case }}
-          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: >-
           python evals/evals.py
           --content-root "$PWD/content"

--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,6 @@ htmlcov/
 coverage.xml
 *.cover
 .pytest_cache/
+
+# Local report-only Copilot skill-eval artifacts
+.skill-eval-results/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# Claude Code — SDAF project context
+
+Canonical project instructions and cross-agent SDAF skills.
+
+@.github/copilot-instructions.md

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,5 @@
+# Gemini CLI — SDAF project context
+
+Canonical project instructions and cross-agent SDAF skills.
+
+@.github/copilot-instructions.md

--- a/README.md
+++ b/README.md
@@ -29,16 +29,18 @@ For selection criteria and capability differences, see
 
 ## Install SDAF AI skills ![NEW](https://img.shields.io/badge/-NEW-brightgreen?style=flat-square)
 
-The three execution models above are the primary way to onboard. Alongside
-them, SDAF now ships an **optional** AI-skills plugin,
-`azure-sap-automation`, that gives supported coding-agent CLIs (GitHub
-Copilot CLI, Claude Code, Gemini CLI) a guided way to walk the same paths
-— orient in SDAF, pre-flight readiness, deploy the control plane, workload
-zone, and SAP system, pick a BOM, lay out `WORKSPACES` and tfvars, and
-triage failed runs — grounded only in what this repository documents.
+The three execution models above are still the main way to run SDAF.
+Alongside them, this repository now ships an **optional** AI-skills hub
+plugin, `azure-sap-automation`, for supported agent CLIs (GitHub Copilot
+CLI, Claude Code, Gemini CLI). SDAF itself does not require these plugins.
 
-All SDAF AI plugins are optional; SDAF itself deploys with or without them.
-If you install them, match your execution model above:
+The **hub** plugin covers shared SDAF guidance that applies across local,
+Azure DevOps, and GitHub Actions use. The Azure DevOps and GitHub Actions
+bootstrap experiences stay in separate **surface** plugins:
+`azure-sap-automation-devops` and `azure-sap-automation-github`. Install
+those only when you use the matching platform.
+
+If you install the plugins, match them to your execution model:
 
 - **Local / scripted** — install the hub plugin (`azure-sap-automation`)
   only.
@@ -48,9 +50,10 @@ If you install them, match your execution model above:
   surface plugin (`azure-sap-automation-github`).
 
 Each plugin is independently installable; nothing installs automatically,
-and you run each command yourself. Commands for the hub plugin are below;
-the surface-plugin commands, verification steps, usage prompts, current
-scope, and troubleshooting live in [`docs/PLUGINS.md`](docs/PLUGINS.md).
+and you run each command yourself. The hub install commands are below. For
+the full 18-skill catalogue, install verification, example prompts,
+limitations, and Azure DevOps or GitHub Actions surface-plugin commands,
+see [`docs/PLUGINS.md`](docs/PLUGINS.md).
 
 ### GitHub Copilot CLI
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,51 @@ processes differ.
 For selection criteria and capability differences, see
 [Choose an SDAF deployment option](docs/deployment-options.md).
 
+## Install SDAF AI skills ![NEW](https://img.shields.io/badge/-NEW-brightgreen?style=flat-square)
+
+The three execution models above are the primary way to onboard. Alongside
+them, SDAF now ships an **optional** AI-skills plugin,
+`azure-sap-automation`, that gives supported coding-agent CLIs (GitHub
+Copilot CLI, Claude Code, Gemini CLI) a guided way to walk the same paths
+— orient in SDAF, pre-flight readiness, deploy the control plane, workload
+zone, and SAP system, pick a BOM, lay out `WORKSPACES` and tfvars, and
+triage failed runs — grounded only in what this repository documents.
+
+All SDAF AI plugins are optional; SDAF itself deploys with or without them.
+If you install them, match your execution model above:
+
+- **Local / scripted** — install the hub plugin (`azure-sap-automation`)
+  only.
+- **Azure DevOps** — install the hub plugin **and** the Azure DevOps
+  surface plugin (`azure-sap-automation-devops`).
+- **GitHub Actions** — install the hub plugin **and** the GitHub Actions
+  surface plugin (`azure-sap-automation-github`).
+
+Each plugin is independently installable; nothing installs automatically,
+and you run each command yourself. Commands for the hub plugin are below;
+the surface-plugin commands, verification steps, usage prompts, current
+scope, and troubleshooting live in [`docs/PLUGINS.md`](docs/PLUGINS.md).
+
+### GitHub Copilot CLI
+
+```bash
+copilot plugin marketplace add Azure/sap-automation
+copilot plugin install azure-sap-automation@sap-automation
+```
+
+### Claude Code
+
+```text
+/plugin marketplace add Azure/sap-automation
+/plugin install azure-sap-automation@sap-automation
+```
+
+### Gemini CLI
+
+```bash
+gemini extensions install https://github.com/Azure/sap-automation
+```
+
 ## Use samples and SAP software definitions
 
 All three execution models use shared configuration examples and SAP software

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -122,7 +122,7 @@ gemini extensions install https://github.com/Azure/sap-automation-gh-bootstrap
 ## Verify the installation
 
 A working hub install has two observable properties: the CLI's own plugin
-manager lists the hub plugin, and it reports the eight skills the hub
+manager lists the hub plugin, and it reports the 18 hub skills the plugin
 ships.
 
 ### Step 1 — Mechanical check with the CLI's plugin manager
@@ -150,24 +150,43 @@ In the Claude Code session, run the slash command:
 gemini extensions list
 ```
 
-### Step 2 — Confirm the eight hub skills
+### Step 2 — Confirm the 18 hub skills
 
-The hub ships exactly these eight skills; your CLI's plugin manager (or the
-SKILL directory it exposes) should enumerate all of them:
+The hub ships exactly these 18 skills from this repository; your CLI's
+plugin manager (or the SKILL directory it exposes) should enumerate all of
+them:
 
-1. [`sdaf-orientation-and-surface`](../skills/sdaf-orientation-and-surface/SKILL.md) — reach for it when you're new to SDAF or need to pick Local vs ADO vs GitHub.
-2. [`sdaf-readiness-check`](../skills/sdaf-readiness-check/SKILL.md) — reach for it to pre-flight a host, subscription, and workspace before any deploy.
-3. [`sdaf-workspace-and-tfvars`](../skills/sdaf-workspace-and-tfvars/SKILL.md) — reach for it to lay out `WORKSPACES` and tfvars per stage.
-4. [`sdaf-bom-selection`](../skills/sdaf-bom-selection/SKILL.md) — reach for it to pick a BOM from the samples catalog.
-5. [`sdaf-control-plane-bootstrap`](../skills/sdaf-control-plane-bootstrap/SKILL.md) — reach for it to deploy the deployer + SAP library from empty.
-6. [`sdaf-workload-zone`](../skills/sdaf-workload-zone/SKILL.md) — reach for it to deploy a landscape after the control plane exists.
-7. [`sdaf-sap-system`](../skills/sdaf-sap-system/SKILL.md) — reach for it to deploy SAP-system infrastructure and generate the Ansible inventory.
-8. [`sdaf-failure-triage`](../skills/sdaf-failure-triage/SKILL.md) — reach for it to map a failed run to a documented cause.
+- **Orientation and scope**
+  1. [`sdaf-orientation-and-surface`](../skills/sdaf-orientation-and-surface/SKILL.md) — orient a newcomer and choose Local vs Azure DevOps vs GitHub Actions.
+  2. [`sdaf-readiness-check`](../skills/sdaf-readiness-check/SKILL.md) — pre-flight a host, subscription, and configuration before any deploy.
+  3. [`sdaf-workspace-and-tfvars`](../skills/sdaf-workspace-and-tfvars/SKILL.md) — lay out `WORKSPACES`, region-code naming, and stage tfvars.
+  4. [`sdaf-bom-selection`](../skills/sdaf-bom-selection/SKILL.md) — choose a BOM from the samples catalogue.
+  5. [`sdaf-plan-and-test-semantics`](../skills/sdaf-plan-and-test-semantics/SKILL.md) — explain plan-only / test / apply behavior across surfaces and stages.
+  6. [`sdaf-sovereign-cloud`](../skills/sdaf-sovereign-cloud/SKILL.md) — explain the current Azure Government deltas without inventing a generic sovereign runbook.
+
+- **Deployment and installation**
+  7. [`sdaf-control-plane-bootstrap`](../skills/sdaf-control-plane-bootstrap/SKILL.md) — deploy the deployer + SAP library from empty.
+  8. [`sdaf-workload-zone`](../skills/sdaf-workload-zone/SKILL.md) — deploy a workload zone after the control plane exists.
+  9. [`sdaf-sap-system`](../skills/sdaf-sap-system/SKILL.md) — deploy SAP-system infrastructure and generate the Ansible inventory.
+  10. [`sdaf-media-acquisition`](../skills/sdaf-media-acquisition/SKILL.md) — download approved SAP media into the SDAF library.
+  11. [`sdaf-media-diagnostics`](../skills/sdaf-media-diagnostics/SKILL.md) — troubleshoot media-download and BOM-processing failures.
+  12. [`sdaf-sap-installation`](../skills/sdaf-sap-installation/SKILL.md) — guide operating-system, database, and SAP installation once infra and media are ready.
+
+- **Validation, operations, and recovery**
+  13. [`sdaf-quality-assurance`](../skills/sdaf-quality-assurance/SKILL.md) — run and interpret the SDAF-owned QA entry points.
+  14. [`sdaf-ha-topology`](../skills/sdaf-ha-topology/SKILL.md) — choose the documented HA topology before SAP-system deployment.
+  15. [`sdaf-ha-diagnostics`](../skills/sdaf-ha-diagnostics/SKILL.md) — diagnose a live or recently failed HA cluster without changing it.
+  16. [`sdaf-state-management`](../skills/sdaf-state-management/SKILL.md) — inspect and repair Terraform state safely.
+  17. [`sdaf-safe-removal`](../skills/sdaf-safe-removal/SKILL.md) — remove SAP systems, workload zones, and the control plane in documented reverse order.
+  18. [`sdaf-failure-triage`](../skills/sdaf-failure-triage/SKILL.md) — map a failed or suspicious run to a documented cause.
 
 The two **samples-origin primers** (`sdaf-workspace-and-tfvars`,
 `sdaf-bom-selection`) teach `Azure/SAP-automation-samples` conventions that
 every execution surface consumes, so they live in the hub — not in either
-bootstrap repo — and load once regardless of which surface you pick.
+bootstrap repo — and load once regardless of which surface you pick. The
+other 16 skills above are also hub-owned; the Azure DevOps and GitHub
+Actions surface skills stay in their own bootstrap plugins rather than
+being bundled here.
 
 ### Step 3 — Prompt smoke test
 
@@ -192,12 +211,23 @@ don't type skill names. Some prompts that work today:
   tfvars file go?"
 - **Pick a BOM** — "Which BOM should I use for S/4HANA 2023?" · "What's the
   difference between a product BOM and a component BOM?"
+- **Understand plan/test behavior** — "What does `test` mean for workflow 01?"
+  · "Is this a real dry run or a reviewed apply path?"
 - **Deploy** — "Deploy the SDAF control plane from empty." · "Deploy a
   workload zone after the control plane exists." · "Deploy an SAP system
   and generate the Ansible inventory."
+- **Acquire media and install software** — "Download approved SAP media into
+  the library." · "Diagnose why the BOM downloader 404'd." · "Resume the
+  DB/SAP installation after a partial run."
+- **Validate and operate** — "Run the SDAF quality-assurance checks." ·
+  "Which HA topology is documented here?" · "Review this `crm status full`
+  output." · "List the Terraform addresses in remote state."
+- **Remove or recover** — "Remove this SAP system safely." · "Why did the
+  control-plane removal exit 0 even though the deployer is still there?"
 - **Triage** — "My control-plane deploy failed at library bootstrap — what
   do the docs say?" · "Ansible playbook 04 errored — walk me through the
-  documented triage."
+  documented triage." · "What are the current Azure Government deltas for
+  this repository?"
 
 Each skill is scoped to what the shipped docs describe. When your question
 goes past that, the skill will say so and stop rather than guess.
@@ -219,22 +249,41 @@ this file. The operator runs the command.
 
 ## Current scope and what is not shipped yet
 
-The hub currently ships the **eight** skills listed above under
-[Verify the installation](#verify-the-installation). The catalogue will
-grow over time, but the following are deliberately **not** included today:
+The hub currently ships all **18** skills listed above under
+[Verify the installation](#verify-the-installation). The following are
+deliberately **not** bundled into the hub:
 
-- **Sovereign / Azure Government end-to-end procedures** — not shipped. The
-  in-repo docs do not yet describe an end-to-end sovereign-cloud path;
-  skills will surface the gap and stop rather than reconstruct a procedure
-  the docs do not describe.
-- **Azure Center for SAP solutions (ACSS) / Azure Monitor for SAP
-  solutions (AMS)** — no dedicated skills today.
-- **Additional operations, upgrade, and recovery skills** — planned for
-  later; today, use the shipped docs and the general-purpose
-  `sdaf-failure-triage` skill.
+- **Azure DevOps surface skills** — install
+  `azure-sap-automation-devops` from
+  [`Azure/sap-automation-bootstrap`](https://github.com/Azure/sap-automation-bootstrap)
+  for `sdaf-ado-project-bootstrap` and `sdaf-ado-pipeline-catalogue`.
+- **GitHub Actions surface skills** — install
+  `azure-sap-automation-github` from
+  [`Azure/sap-automation-gh-bootstrap`](https://github.com/Azure/sap-automation-gh-bootstrap)
+  for `sdaf-gh-bootstrap`, `sdaf-gh-oidc-and-auth`, and
+  `sdaf-gh-workflow-sequence`.
+- **Dedicated ACSS / AMS skills** — not shipped today.
+- **Non-documented sovereign-cloud procedures beyond the current Azure
+  Government deltas** — not shipped. The hub skill surfaces the current
+  documented deltas and stops where the docs stop.
 
 If your task falls in one of these areas, the skills will tell you and hand
 off to the corresponding document rather than fabricate a procedure.
+
+## Routing eval coverage
+
+The routing-eval harness in this repo covers the **hub only**:
+
+- **18** production hub skills in `skills/`
+- **72** skill-owned cases in `evals/skills/`
+- **6** shared null cases in `evals/shared/`
+- **78** total hub cases
+
+Those evals are **report-only**. They collect witness evidence for review,
+but this document does not claim calibrated side-channel behavior or present
+the routing harness as a blocking quality gate. The Azure DevOps and GitHub
+Actions surface plugins keep their own deferred eval scope in
+`Azure/sap-automation-bootstrap` and `Azure/sap-automation-gh-bootstrap`.
 
 ## Ground rules and exclusions
 

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -275,14 +275,13 @@ off to the corresponding document rather than fabricate a procedure.
 The routing-eval harness in this repo covers the **hub only**:
 
 - **18** production hub skills in `skills/`
-- **72** skill-owned cases in `evals/skills/`
-- **6** shared null cases in `evals/shared/`
-- **78** total hub cases
+- **54** cases in the consolidated `evals/evals.json` catalogue
+- three prompts for each skill, each compared with a target-disabled baseline
 
-Those evals are **report-only**. They collect witness evidence for review,
-but this document does not claim calibrated side-channel behavior or present
-the routing harness as a blocking quality gate. The Azure DevOps and GitHub
-Actions surface plugins keep their own deferred eval scope in
+These evals are a blocking reliability quality gate. A case fails when its
+fixed assertions do not pass, and the workflow uploads the native Copilot SDK
+event evidence for review. The Azure DevOps and GitHub Actions surface plugins
+keep their own deferred eval scope in
 `Azure/sap-automation-bootstrap` and `Azure/sap-automation-gh-bootstrap`.
 
 ## Ground rules and exclusions

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -1,0 +1,285 @@
+# SDAF AI skills — install and use
+
+This repository ships one AI-skills plugin, **`azure-sap-automation`**
+(the **hub**), that works across supported agent CLIs (GitHub Copilot CLI,
+Claude Code, Gemini CLI). It teaches your coding agent about SDAF using
+only what this repository documents. Depending on how you run SDAF, you
+may additionally install one **surface** plugin from a separate bootstrap
+repository.
+
+All SDAF AI plugins are **optional**; SDAF itself deploys with or without
+them. Each plugin is independently installable and independently useful,
+and nothing installs automatically — you run every command yourself.
+
+## Contents
+
+- [Which plugins do I install?](#which-plugins-do-i-install)
+- [Install the hub plugin (`azure-sap-automation`)](#install-the-hub-plugin-azure-sap-automation)
+- [Install a surface plugin (Azure DevOps or GitHub Actions)](#install-a-surface-plugin-azure-devops-or-github-actions)
+- [Verify the installation](#verify-the-installation)
+- [Use the skills — example prompts](#use-the-skills--example-prompts)
+- [How the hub and surface plugins relate](#how-the-hub-and-surface-plugins-relate)
+- [Current scope and what is not shipped yet](#current-scope-and-what-is-not-shipped-yet)
+- [Ground rules and exclusions](#ground-rules-and-exclusions)
+- [Troubleshooting](#troubleshooting)
+
+## Which plugins do I install?
+
+All plugins are optional. If you want AI coverage for how you actually run
+SDAF, this is the complete map:
+
+- **Local / scripted** — hub plugin (`azure-sap-automation`) only, from
+  `Azure/sap-automation` (this repo).
+- **Azure DevOps** — hub plugin **plus** the Azure DevOps surface plugin
+  (`azure-sap-automation-devops`), from this repo **plus**
+  `Azure/sap-automation-bootstrap`.
+- **GitHub Actions** — hub plugin **plus** the GitHub Actions surface
+  plugin (`azure-sap-automation-github`), from this repo **plus**
+  `Azure/sap-automation-gh-bootstrap`.
+
+Each plugin is independently installable, so you can add just the hub, just
+a surface plugin, or both. Install the hub first if you want the guided
+experience; the hub will name and print the install command for the
+matching surface plugin when it's needed, and you run that command.
+
+## Install the hub plugin (`azure-sap-automation`)
+
+### GitHub Copilot CLI
+
+```bash
+copilot plugin marketplace add Azure/sap-automation
+copilot plugin install azure-sap-automation@sap-automation
+```
+
+### Claude Code
+
+```text
+/plugin marketplace add Azure/sap-automation
+/plugin install azure-sap-automation@sap-automation
+```
+
+### Gemini CLI
+
+Use the **extensions** form (not `gemini skills install`):
+
+```bash
+gemini extensions install https://github.com/Azure/sap-automation
+```
+
+The extension reads root `gemini-extension.json` and auto-loads root
+`skills/`.
+
+## Install a surface plugin (Azure DevOps or GitHub Actions)
+
+Only install a surface plugin if you run SDAF from Azure DevOps or from
+GitHub Actions. Local users skip this section entirely. The command shapes
+below match the `docs/PLUGINS.md` in the bootstrap repositories.
+
+### Azure DevOps — `azure-sap-automation-devops`
+
+#### GitHub Copilot CLI
+
+```bash
+copilot plugin marketplace add Azure/sap-automation-bootstrap
+copilot plugin install azure-sap-automation-devops@sap-automation-bootstrap
+```
+
+#### Claude Code
+
+```text
+/plugin marketplace add Azure/sap-automation-bootstrap
+/plugin install azure-sap-automation-devops@sap-automation-bootstrap
+```
+
+#### Gemini CLI
+
+```bash
+gemini extensions install https://github.com/Azure/sap-automation-bootstrap
+```
+
+### GitHub Actions — `azure-sap-automation-github`
+
+#### GitHub Copilot CLI
+
+```bash
+copilot plugin marketplace add Azure/sap-automation-gh-bootstrap
+copilot plugin install azure-sap-automation-github@sap-automation-gh-bootstrap
+```
+
+#### Claude Code
+
+```text
+/plugin marketplace add Azure/sap-automation-gh-bootstrap
+/plugin install azure-sap-automation-github@sap-automation-gh-bootstrap
+```
+
+#### Gemini CLI
+
+```bash
+gemini extensions install https://github.com/Azure/sap-automation-gh-bootstrap
+```
+
+## Verify the installation
+
+A working hub install has two observable properties: the CLI's own plugin
+manager lists the hub plugin, and it reports the eight skills the hub
+ships.
+
+### Step 1 — Mechanical check with the CLI's plugin manager
+
+Run the listing command for your CLI. The hub plugin
+`azure-sap-automation` (sourced from `Azure/sap-automation`) must appear.
+
+#### GitHub Copilot CLI
+
+```bash
+copilot plugin list
+```
+
+#### Claude Code
+
+In the Claude Code session, run the slash command:
+
+```text
+/plugin
+```
+
+#### Gemini CLI
+
+```bash
+gemini extensions list
+```
+
+### Step 2 — Confirm the eight hub skills
+
+The hub ships exactly these eight skills; your CLI's plugin manager (or the
+SKILL directory it exposes) should enumerate all of them:
+
+1. [`sdaf-orientation-and-surface`](../skills/sdaf-orientation-and-surface/SKILL.md) — reach for it when you're new to SDAF or need to pick Local vs ADO vs GitHub.
+2. [`sdaf-readiness-check`](../skills/sdaf-readiness-check/SKILL.md) — reach for it to pre-flight a host, subscription, and workspace before any deploy.
+3. [`sdaf-workspace-and-tfvars`](../skills/sdaf-workspace-and-tfvars/SKILL.md) — reach for it to lay out `WORKSPACES` and tfvars per stage.
+4. [`sdaf-bom-selection`](../skills/sdaf-bom-selection/SKILL.md) — reach for it to pick a BOM from the samples catalog.
+5. [`sdaf-control-plane-bootstrap`](../skills/sdaf-control-plane-bootstrap/SKILL.md) — reach for it to deploy the deployer + SAP library from empty.
+6. [`sdaf-workload-zone`](../skills/sdaf-workload-zone/SKILL.md) — reach for it to deploy a landscape after the control plane exists.
+7. [`sdaf-sap-system`](../skills/sdaf-sap-system/SKILL.md) — reach for it to deploy SAP-system infrastructure and generate the Ansible inventory.
+8. [`sdaf-failure-triage`](../skills/sdaf-failure-triage/SKILL.md) — reach for it to map a failed run to a documented cause.
+
+The two **samples-origin primers** (`sdaf-workspace-and-tfvars`,
+`sdaf-bom-selection`) teach `Azure/SAP-automation-samples` conventions that
+every execution surface consumes, so they live in the hub — not in either
+bootstrap repo — and load once regardless of which surface you pick.
+
+### Step 3 — Prompt smoke test
+
+Only after Steps 1 and 2 pass, open a new session and ask "what is SDAF and
+where do I start?" — the agent should invoke `sdaf-orientation-and-surface`,
+summarise the deployment spine, and ask which execution surface you want.
+If the agent answers from general knowledge without naming a skill, the
+plugin loaded incorrectly; see [Troubleshooting](#troubleshooting).
+
+## Use the skills — example prompts
+
+You invoke skills by describing your task in natural language; the trigger
+phrases in each skill's `SKILL.md` map your request to the right skill. You
+don't type skill names. Some prompts that work today:
+
+- **Orient / choose a surface** — "I'm new to SDAF, where do I start?" ·
+  "Local vs ADO vs GitHub Actions — which surface fits me?"
+- **Pre-flight before any deploy** — "Am I ready to deploy the control plane?" ·
+  "Run the SDAF readiness checks on this host." · "Validate my tfvars."
+- **Lay out configuration** — "Show me the `WORKSPACES` layout and
+  region-code naming for a new landscape." · "Where does the SAP-system
+  tfvars file go?"
+- **Pick a BOM** — "Which BOM should I use for S/4HANA 2023?" · "What's the
+  difference between a product BOM and a component BOM?"
+- **Deploy** — "Deploy the SDAF control plane from empty." · "Deploy a
+  workload zone after the control plane exists." · "Deploy an SAP system
+  and generate the Ansible inventory."
+- **Triage** — "My control-plane deploy failed at library bootstrap — what
+  do the docs say?" · "Ansible playbook 04 errored — walk me through the
+  documented triage."
+
+Each skill is scoped to what the shipped docs describe. When your question
+goes past that, the skill will say so and stop rather than guess.
+
+## How the hub and surface plugins relate
+
+The hub, `azure-sap-automation`, ships in this repo (`Azure/sap-automation`)
+and owns every skill that references code, docs, or samples living here —
+including the samples-origin primers noted above. Those primers live in the
+hub, not in either bootstrap repo, so they load once for every operator
+regardless of surface.
+
+A **surface plugin** — `azure-sap-automation-devops` or
+`azure-sap-automation-github` — teaches the pipeline/workflow, service
+connection, variable group, environment, and identity model of its own
+platform, sourced from its own repository's docs. The hub never installs a
+surface plugin for you; it prints the install command and points you at
+this file. The operator runs the command.
+
+## Current scope and what is not shipped yet
+
+The hub currently ships the **eight** skills listed above under
+[Verify the installation](#verify-the-installation). The catalogue will
+grow over time, but the following are deliberately **not** included today:
+
+- **Sovereign / Azure Government end-to-end procedures** — not shipped. The
+  in-repo docs do not yet describe an end-to-end sovereign-cloud path;
+  skills will surface the gap and stop rather than reconstruct a procedure
+  the docs do not describe.
+- **Azure Center for SAP solutions (ACSS) / Azure Monitor for SAP
+  solutions (AMS)** — no dedicated skills today.
+- **Additional operations, upgrade, and recovery skills** — planned for
+  later; today, use the shipped docs and the general-purpose
+  `sdaf-failure-triage` skill.
+
+If your task falls in one of these areas, the skills will tell you and hand
+off to the corresponding document rather than fabricate a procedure.
+
+## Ground rules and exclusions
+
+- **Documented behaviour only.** Skills teach what this repository (and, for
+  BOM selection, `Azure/SAP-automation-samples`) documents. When a question
+  falls outside the shipped docs — Azure Government end-to-end procedures,
+  air-gapped / offline media, undocumented script flags, or an exhaustive
+  tfvars catalogue — the skill surfaces the gap and stops rather than
+  reconstructing behaviour from source.
+- **Manual install only.** Skills never install other plugins automatically.
+  They print the install commands in this file and the operator runs them.
+- **No production-code changes.** These skills are documentation-driven
+  primers and action-loops around already-shipped scripts. They do not edit
+  Terraform modules, Ansible roles, or `deploy/scripts/`.
+- **Out of scope for the hub.** ADO- or GitHub-specific pipeline, workflow,
+  and identity procedures live in the surface plugin for that platform.
+
+## Troubleshooting
+
+- **Agent doesn't recognise SDAF skills after install.** Restart the agent
+  session so it re-reads plugins, then re-run the listing command for your
+  CLI (`copilot plugin list`, the `/plugin` slash command in Claude Code,
+  or `gemini extensions list`) and confirm the hub plugin appears. If it
+  does not, the install did not complete; consult the CLI's own install
+  output and its `--help`.
+- **`gemini skills install …` fails.** SDAF ships as a Gemini **extension**,
+  not a stand-alone skill package — use
+  `gemini extensions install https://github.com/Azure/sap-automation`.
+- **Marketplace name doesn't match the plugin name.** That is expected: in
+  Copilot CLI and Claude Code the form is
+  `<plugin-name>@<marketplace-name>`, where the marketplace name matches
+  the repository slug. For the hub it is
+  `azure-sap-automation@sap-automation`.
+- **Skill triggered for the wrong task.** Each `SKILL.md` lists both
+  trigger phrases and explicit *"do NOT use for …"* exclusions. Re-phrase
+  your request to match a listed trigger, or the skill you actually want.
+- **A skill says the answer isn't in the docs.** That's by design — see
+  [Current scope](#current-scope-and-what-is-not-shipped-yet). File
+  an issue on this repository if the gap is worth closing later.
+
+### Updating and uninstalling
+
+Use your agent CLI's own plugin manager to update or uninstall SDAF plugins;
+this repository does not publish version-specific syntax. Consult
+`copilot plugin --help`, the Claude Code `/plugin` in-session menu, or
+`gemini extensions --help` for the exact verbs your CLI version supports at
+the time you run it. Do not treat "re-install" as an update path — install
+the update through the CLI's documented update command instead.

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -278,10 +278,13 @@ The routing-eval harness in this repo covers the **hub only**:
 - **54** cases in the consolidated `evals/evals.json` catalogue
 - three prompts for each skill, each compared with a target-disabled baseline
 
-These evals are a blocking reliability quality gate. A case fails when its
-fixed assertions do not pass, and the workflow uploads the native Copilot SDK
-event evidence for review. The Azure DevOps and GitHub Actions surface plugins
-keep their own deferred eval scope in
+These evals are a blocking **routing-reliability** gate. They measure native
+skill loading and invocation behavior, target-disabled baseline behavior,
+session completion, and response viability; they do not grade operational
+answer quality. A case fails when its fixed routing assertions do not pass,
+and the workflow uploads native Copilot SDK event evidence for review. The
+Azure DevOps and GitHub Actions surface plugins keep their own deferred eval
+scope in
 `Azure/sap-automation-bootstrap` and `Azure/sap-automation-gh-bootstrap`.
 
 ## Ground rules and exclusions

--- a/docs/local/02-00-prepare-execution-environment.md
+++ b/docs/local/02-00-prepare-execution-environment.md
@@ -202,6 +202,68 @@ Azure deployment.
    The output identifies the intended subscription, tenant, and principal.
    Reauthenticate with the approved identity if the context changed.
 
+
+## Readiness verification
+
+Before running any deployment command, run the shipped readiness scripts and
+resolve every item they report. The scripts' own output is the authority on
+what they check; this section names them, describes only their
+operator-visible pass/fail role, and points at their built-in help for
+detail.
+
+1. Verify the toolchain on the execution host.
+
+   ```bash
+   "$SAP_AUTOMATION_REPO_PATH/deploy/scripts/helpers/check_workstation.sh"
+   ```
+
+   The command prints a version for `az`, `terraform`, `ansible`, and
+   `jq` (see also step 9 of *Prepare the host*). A missing tool or an
+   error exit means the host is not ready.
+
+2. Verify overall host readiness with the PowerShell readiness script.
+
+   ```powershell
+   & "$env:SAP_AUTOMATION_REPO_PATH/deploy/scripts/Test-SDAFReadiness.ps1"
+   ```
+
+   `Test-SDAFReadiness.ps1` reports readiness of the execution host for
+   an SDAF deployment. Read its output; each item it flags must be
+   resolved before deploying. For its parameter and mode surface, use
+   `Get-Help "$env:SAP_AUTOMATION_REPO_PATH/deploy/scripts/Test-SDAFReadiness.ps1" -Full`
+   — this document does not restate flags the script itself may change.
+
+3. Verify outbound endpoint reachability from the execution host.
+
+   ```powershell
+   & "$env:SAP_AUTOMATION_REPO_PATH/deploy/scripts/Test-SDAFURLs.ps1"
+   ```
+
+   `Test-SDAFURLs.ps1` reports whether the endpoints SDAF contacts at
+   deploy time are reachable from this host. A failure here is a
+   connectivity problem, not a deployment problem — see
+   [`troubleshooting.md § The execution host cannot reach Key Vault or Storage`](troubleshooting.md).
+   Use `Get-Help` for its parameter surface.
+
+4. Validate each prepared workspace's `.tfvars` before deploying it.
+
+   From the directory that contains the `.tfvars` (pass the basename
+   only — see
+   [`troubleshooting.md § A parameter file is not found`](troubleshooting.md)):
+
+   ```bash
+   cd "$CONFIG_REPO_PATH/<WORKSPACES-leaf>"
+   "$SAP_AUTOMATION_REPO_PATH/deploy/scripts/validate.sh" \
+       --parameterfile "<same-name>.tfvars" \
+       --type <sap_deployer|sap_library|sap_landscape|sap_system>
+   ```
+
+   `validate.sh` inspects the parameter file's presence and expected
+   fields; a non-zero exit or a printed error means the file is not ready.
+
+Do not proceed to *Prepare configuration* below until each script above
+exits successfully or its output has been reviewed and each item resolved.
+
 ## Prepare configuration
 
 Local execution has no hosted stage-specific generator.

--- a/docs/local/02-00-prepare-execution-environment.md
+++ b/docs/local/02-00-prepare-execution-environment.md
@@ -246,7 +246,7 @@ this section describes only their operator-visible pass/fail role.
    ```
 
    This is an additional diagnostic, not a Linux-host prerequisite. The
-   supported Linux path remains steps 1 and 4. If you use this diagnostic,
+   supported Linux readiness path remains step 1. If you use this diagnostic,
    resolve each reported item before deploying.
 
 3. Where `pwsh` is available, optionally run the outbound-endpoint diagnostic.
@@ -259,23 +259,12 @@ this section describes only their operator-visible pass/fail role.
    see
    [`troubleshooting.md § The execution host cannot reach Key Vault or Storage`](troubleshooting.md).
 
-4. Validate each workspace `.tfvars` prepared in the preceding section.
+Do not use `deploy/scripts/validate.sh` for current workspace `.tfvars`; that
+script expects the legacy JSON parameter shape, while current `.tfvars` files
+use Terraform HCL. Review the HCL configuration through the documented
+stage-specific plan and review gate instead.
 
-   From the directory that contains the `.tfvars` (pass the basename
-   only — see
-   [`troubleshooting.md § A parameter file is not found`](troubleshooting.md)):
-
-   ```bash
-   cd "$CONFIG_REPO_PATH/<WORKSPACES-leaf>"
-   "$SAP_AUTOMATION_REPO_PATH/deploy/scripts/validate.sh" \
-       --parameterfile "<same-name>.tfvars" \
-       --type <sap_deployer|sap_library|sap_landscape|sap_system>
-   ```
-
-   `validate.sh` inspects the parameter file's presence and expected
-   fields; a non-zero exit or a printed error means the file is not ready.
-
-Do not proceed until the required Linux checks exit successfully and any
+Do not proceed until the required Linux check exits successfully and any
 optional diagnostics you ran have been reviewed and resolved.
 
 ## Protect secrets and transient files

--- a/docs/local/02-00-prepare-execution-environment.md
+++ b/docs/local/02-00-prepare-execution-environment.md
@@ -203,67 +203,6 @@ Azure deployment.
    Reauthenticate with the approved identity if the context changed.
 
 
-## Readiness verification
-
-Before running any deployment command, run the shipped readiness scripts and
-resolve every item they report. The scripts' own output is the authority on
-what they check; this section names them, describes only their
-operator-visible pass/fail role, and points at their built-in help for
-detail.
-
-1. Verify the toolchain on the execution host.
-
-   ```bash
-   "$SAP_AUTOMATION_REPO_PATH/deploy/scripts/helpers/check_workstation.sh"
-   ```
-
-   The command prints a version for `az`, `terraform`, `ansible`, and
-   `jq` (see also step 9 of *Prepare the host*). A missing tool or an
-   error exit means the host is not ready.
-
-2. Verify overall host readiness with the PowerShell readiness script.
-
-   ```powershell
-   & "$env:SAP_AUTOMATION_REPO_PATH/deploy/scripts/Test-SDAFReadiness.ps1"
-   ```
-
-   `Test-SDAFReadiness.ps1` reports readiness of the execution host for
-   an SDAF deployment. Read its output; each item it flags must be
-   resolved before deploying. For its parameter and mode surface, use
-   `Get-Help "$env:SAP_AUTOMATION_REPO_PATH/deploy/scripts/Test-SDAFReadiness.ps1" -Full`
-   — this document does not restate flags the script itself may change.
-
-3. Verify outbound endpoint reachability from the execution host.
-
-   ```powershell
-   & "$env:SAP_AUTOMATION_REPO_PATH/deploy/scripts/Test-SDAFURLs.ps1"
-   ```
-
-   `Test-SDAFURLs.ps1` reports whether the endpoints SDAF contacts at
-   deploy time are reachable from this host. A failure here is a
-   connectivity problem, not a deployment problem — see
-   [`troubleshooting.md § The execution host cannot reach Key Vault or Storage`](troubleshooting.md).
-   Use `Get-Help` for its parameter surface.
-
-4. Validate each prepared workspace's `.tfvars` before deploying it.
-
-   From the directory that contains the `.tfvars` (pass the basename
-   only — see
-   [`troubleshooting.md § A parameter file is not found`](troubleshooting.md)):
-
-   ```bash
-   cd "$CONFIG_REPO_PATH/<WORKSPACES-leaf>"
-   "$SAP_AUTOMATION_REPO_PATH/deploy/scripts/validate.sh" \
-       --parameterfile "<same-name>.tfvars" \
-       --type <sap_deployer|sap_library|sap_landscape|sap_system>
-   ```
-
-   `validate.sh` inspects the parameter file's presence and expected
-   fields; a non-zero exit or a printed error means the file is not ready.
-
-Do not proceed to *Prepare configuration* below until each script above
-exits successfully or its output has been reviewed and each item resolved.
-
 ## Prepare configuration
 
 Local execution has no hosted stage-specific generator.
@@ -280,6 +219,64 @@ Local execution has no hosted stage-specific generator.
 
 The Web application assists with configuration. It does not replace local
 identity setup, plan review, or script execution.
+
+## Readiness verification
+
+After preparing the configuration above and before running any deployment
+command, run the applicable shipped readiness checks and resolve every item
+they report. The checks' own output is the authority on what they inspect;
+this section describes only their operator-visible pass/fail role.
+
+1. Verify the toolchain on the execution host.
+
+   ```bash
+   "$SAP_AUTOMATION_REPO_PATH/deploy/scripts/helpers/check_workstation.sh"
+   ```
+
+   The command prints a version for `az`, `terraform`, `ansible`, and
+   `jq` (see also step 9 of *Prepare the host*). A missing tool or an
+   error exit means the host is not ready.
+
+2. On an execution host where PowerShell (`pwsh`) is already available,
+   optionally run the PowerShell host-readiness diagnostic.
+
+   ```bash
+   pwsh -File \
+     "$SAP_AUTOMATION_REPO_PATH/deploy/scripts/Test-SDAFReadiness.ps1"
+   ```
+
+   This is an additional diagnostic, not a Linux-host prerequisite. The
+   supported Linux path remains steps 1 and 4. If you use this diagnostic,
+   resolve each reported item before deploying.
+
+3. Where `pwsh` is available, optionally run the outbound-endpoint diagnostic.
+
+   ```bash
+   pwsh -File "$SAP_AUTOMATION_REPO_PATH/deploy/scripts/Test-SDAFURLs.ps1"
+   ```
+
+   A reported failure is a connectivity problem, not a deployment problem —
+   see
+   [`troubleshooting.md § The execution host cannot reach Key Vault or Storage`](troubleshooting.md).
+
+4. Validate each workspace `.tfvars` prepared in the preceding section.
+
+   From the directory that contains the `.tfvars` (pass the basename
+   only — see
+   [`troubleshooting.md § A parameter file is not found`](troubleshooting.md)):
+
+   ```bash
+   cd "$CONFIG_REPO_PATH/<WORKSPACES-leaf>"
+   "$SAP_AUTOMATION_REPO_PATH/deploy/scripts/validate.sh" \
+       --parameterfile "<same-name>.tfvars" \
+       --type <sap_deployer|sap_library|sap_landscape|sap_system>
+   ```
+
+   `validate.sh` inspects the parameter file's presence and expected
+   fields; a non-zero exit or a printed error means the file is not ready.
+
+Do not proceed until the required Linux checks exit successfully and any
+optional diagnostics you ran have been reviewed and resolved.
 
 ## Protect secrets and transient files
 

--- a/evals/evals.json
+++ b/evals/evals.json
@@ -1,0 +1,904 @@
+{
+  "skills": [
+    {
+      "skill_name": "sdaf-bom-selection",
+      "evals": [
+        {
+          "id": "bom-positive-01",
+          "prompt": "Should this flow use a product BOM or component BOMs?",
+          "expected_output": "Copilot loads sdaf-bom-selection.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-bom-selection.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-bom-selection.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-bom-selection"
+          }
+        },
+        {
+          "id": "bom-positive-02",
+          "prompt": "Help me choose pinned versus latest software definitions without inventing compatibility.",
+          "expected_output": "Copilot loads sdaf-bom-selection.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-bom-selection.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-bom-selection.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-bom-selection"
+          }
+        },
+        {
+          "id": "bom-positive-03",
+          "prompt": "Given my product, database, platform, and kernel requirements, identify the documented BOM keys and compatibility checks and point me to current samples.",
+          "expected_output": "Copilot loads sdaf-bom-selection.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-bom-selection.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-bom-selection.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-bom-selection"
+          }
+        }
+      ]
+    },
+    {
+      "skill_name": "sdaf-control-plane-bootstrap",
+      "evals": [
+        {
+          "id": "control-plane-positive-01",
+          "prompt": "Deploy the SDAF control plane in an empty subscription.",
+          "expected_output": "Copilot loads sdaf-control-plane-bootstrap.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-control-plane-bootstrap.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-control-plane-bootstrap.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-control-plane-bootstrap"
+          }
+        },
+        {
+          "id": "control-plane-positive-02",
+          "prompt": "Set up the deployer and library from my reviewed parameter files.",
+          "expected_output": "Copilot loads sdaf-control-plane-bootstrap.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-control-plane-bootstrap.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-control-plane-bootstrap.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-control-plane-bootstrap"
+          }
+        },
+        {
+          "id": "control-plane-positive-03",
+          "prompt": "I have approved deployer/library tfvars and state settings; guide the documented first control-plane run and validation using the operator-facing path.",
+          "expected_output": "Copilot loads sdaf-control-plane-bootstrap.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-control-plane-bootstrap.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-control-plane-bootstrap.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-control-plane-bootstrap"
+          }
+        }
+      ]
+    },
+    {
+      "skill_name": "sdaf-failure-triage",
+      "evals": [
+        {
+          "id": "sdaf-failure-triage-direct-01",
+          "prompt": "My SDAF run failed. The last log lines mention a Terraform state lock. Help me triage the documented cause before I retry.",
+          "expected_output": "Copilot loads sdaf-failure-triage.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-failure-triage.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-failure-triage.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-failure-triage"
+          }
+        },
+        {
+          "id": "sdaf-failure-triage-paraphrase-01",
+          "prompt": "The plan looked clean, but the SDAF run still exited 1. I need the documented failure mapping and the right hand-off, not a guess.",
+          "expected_output": "Copilot loads sdaf-failure-triage.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-failure-triage.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-failure-triage.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-failure-triage"
+          }
+        },
+        {
+          "id": "sdaf-failure-triage-context-rich-01",
+          "prompt": "A control-plane deploy returned exit 0, but the library state never showed up in storage and `.sap_deployment_automation` is incomplete. Use the SDAF docs to decide whether this was a false success, identify the documented failure class, and send me to the right owning skill for retry.",
+          "expected_output": "Copilot loads sdaf-failure-triage.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-failure-triage.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-failure-triage.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-failure-triage"
+          }
+        }
+      ]
+    },
+    {
+      "skill_name": "sdaf-ha-diagnostics",
+      "evals": [
+        {
+          "id": "ha-diagnostics-positive-01",
+          "prompt": "Diagnose this SDAF HANA high-availability cluster without changing anything; start with crm status or pcs status and read-only fencing evidence.",
+          "expected_output": "Copilot loads sdaf-ha-diagnostics.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-ha-diagnostics.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-ha-diagnostics.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-ha-diagnostics"
+          }
+        },
+        {
+          "id": "ha-diagnostics-positive-02",
+          "prompt": "I have a Pacemaker issue on an SDAF SCS/ERS deployment. Help me read the current resource placement, offline_validation bundle, and existing QA logs without moving resources.",
+          "expected_output": "Copilot loads sdaf-ha-diagnostics.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-ha-diagnostics.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-ha-diagnostics.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-ha-diagnostics"
+          }
+        },
+        {
+          "id": "ha-diagnostics-positive-03",
+          "prompt": "After an SDAF maintenance window, the HANA failover looks wrong. I already have crm status output, quality_assurance logs, and an hcmtresult zip; tell me whether this is live-cluster diagnosis, offline validation, or a disruptive QA exercise, but do not invent recovery commands.",
+          "expected_output": "Copilot loads sdaf-ha-diagnostics.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-ha-diagnostics.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-ha-diagnostics.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-ha-diagnostics"
+          }
+        }
+      ]
+    },
+    {
+      "skill_name": "sdaf-ha-topology",
+      "evals": [
+        {
+          "id": "ha-topology-positive-01",
+          "prompt": "Help me choose the SDAF HA topology before deployment: AFA versus shared-disk quorum, AFS versus ANF, and HANA scale-up versus scale-out.",
+          "expected_output": "Copilot loads sdaf-ha-topology.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-ha-topology.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-ha-topology.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-ha-topology"
+          }
+        },
+        {
+          "id": "ha-topology-positive-02",
+          "prompt": "Before I edit my system tfvars, tell me which cluster model, shared storage, and HANA layout fit this SAP design without deploying anything yet.",
+          "expected_output": "Copilot loads sdaf-ha-topology.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-ha-topology.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-ha-topology.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-ha-topology"
+          }
+        },
+        {
+          "id": "ha-topology-positive-03",
+          "prompt": "I'm reviewing a new S/4HANA system on Azure and need to decide whether to follow a QA-style AFS/AFA setup or a production ANF/ISCSI design, plus whether ANGI is allowed on my OS release. Use the documented SDAF options and required inputs before I approve the build.",
+          "expected_output": "Copilot loads sdaf-ha-topology.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-ha-topology.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-ha-topology.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-ha-topology"
+          }
+        }
+      ]
+    },
+    {
+      "skill_name": "sdaf-media-acquisition",
+      "evals": [
+        {
+          "id": "media-acquisition-positive-01",
+          "prompt": "Help me download approved SAP media into the SDAF library with the BOM Downloader.",
+          "expected_output": "Copilot loads sdaf-media-acquisition.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-media-acquisition.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-media-acquisition.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-media-acquisition"
+          }
+        },
+        {
+          "id": "media-acquisition-positive-02",
+          "prompt": "Use my reviewed application, database, and kernel BOMs to fetch the software archives before installation.",
+          "expected_output": "Copilot loads sdaf-media-acquisition.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-media-acquisition.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-media-acquisition.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-media-acquisition"
+          }
+        },
+        {
+          "id": "media-acquisition-positive-03",
+          "prompt": "The SAP-system workspace already has sap-parameters.yaml and X00_hosts.yaml. Before we run installation, walk the documented media-acquisition flow, confirm BOM_CATALOG plus the four BOM keys, and tell me what to run from the system directory.",
+          "expected_output": "Copilot loads sdaf-media-acquisition.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-media-acquisition.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-media-acquisition.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-media-acquisition"
+          }
+        }
+      ]
+    },
+    {
+      "skill_name": "sdaf-media-diagnostics",
+      "evals": [
+        {
+          "id": "media-diagnostics-positive-01",
+          "prompt": "Diagnose this SDAF media failure: download_menu.sh hit a 404 for one of the SAP archives in the approved BOM.",
+          "expected_output": "Copilot loads sdaf-media-diagnostics.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-media-diagnostics.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-media-diagnostics.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-media-diagnostics"
+          }
+        },
+        {
+          "id": "media-diagnostics-positive-02",
+          "prompt": "We already chose the HANA SPS07 media set, but the combined BOM points to a file that never appears in the library and BOM processing reports a checksum mismatch. Help me troubleshoot the media path without changing the BOM by guess.",
+          "expected_output": "Copilot loads sdaf-media-diagnostics.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-media-diagnostics.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-media-diagnostics.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-media-diagnostics"
+          }
+        },
+        {
+          "id": "media-diagnostics-positive-03",
+          "prompt": "The four BOM keys are set and playbook 03 started from configuration_menu.sh, but a SAR file now fails at SAPCAR -manifest SIGNATURE.SMF and .progress/bom-processing-done never appears. Help me follow the documented media-only diagnostic path without inventing a replacement URL.",
+          "expected_output": "Copilot loads sdaf-media-diagnostics.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-media-diagnostics.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-media-diagnostics.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-media-diagnostics"
+          }
+        }
+      ]
+    },
+    {
+      "skill_name": "sdaf-orientation-and-surface",
+      "evals": [
+        {
+          "id": "sdaf-orientation-and-surface-direct-01",
+          "prompt": "I'm new to SDAF. What is it, where do I start, and which execution surface should I use: Local, Azure DevOps, or GitHub Actions?",
+          "expected_output": "Copilot loads sdaf-orientation-and-surface.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-orientation-and-surface.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-orientation-and-surface.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-orientation-and-surface"
+          }
+        },
+        {
+          "id": "sdaf-orientation-and-surface-paraphrase-01",
+          "prompt": "Can you walk me through how SDAF is structured and help me choose between running it from a workstation, Azure Pipelines, or GitHub workflows?",
+          "expected_output": "Copilot loads sdaf-orientation-and-surface.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-orientation-and-surface.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-orientation-and-surface.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-orientation-and-surface"
+          }
+        },
+        {
+          "id": "sdaf-orientation-and-surface-context-rich-01",
+          "prompt": "We're onboarding an SAP Basis team to SDAF. Our config repo lives in Azure Repos and the process will run from Azure Pipelines, but before anyone touches tfvars or deploy scripts I need the deployment spine in order and the exact Azure DevOps surface-plugin install commands from the docs.",
+          "expected_output": "Copilot loads sdaf-orientation-and-surface.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-orientation-and-surface.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-orientation-and-surface.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-orientation-and-surface"
+          }
+        }
+      ]
+    },
+    {
+      "skill_name": "sdaf-plan-and-test-semantics",
+      "evals": [
+        {
+          "id": "sdaf-plan-and-test-semantics-direct-01",
+          "prompt": "What does `test` actually do in SDAF? Is it a safe dry run for the control plane, workload zone, and SAP system on Local, Azure DevOps, and GitHub Actions?",
+          "expected_output": "Copilot loads sdaf-plan-and-test-semantics.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-plan-and-test-semantics.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-plan-and-test-semantics.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-plan-and-test-semantics"
+          }
+        },
+        {
+          "id": "sdaf-plan-and-test-semantics-paraphrase-01",
+          "prompt": "Before I trust that checkbox, map which SDAF entry points stop after Terraform review and which ones still make changes. I need the surface-by-surface answer, not a generic dry-run story.",
+          "expected_output": "Copilot loads sdaf-plan-and-test-semantics.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-plan-and-test-semantics.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-plan-and-test-semantics.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-plan-and-test-semantics"
+          }
+        },
+        {
+          "id": "sdaf-plan-and-test-semantics-context-rich-01",
+          "prompt": "Our operators review control-plane changes in GitHub, deploy workload zones from Azure Pipelines, and sometimes reproduce locally. Build the real SDAF plan-only versus apply map for the control plane, workload zone, and SAP system so nobody invents a universal flag or transfers Local behavior to a hosted surface.",
+          "expected_output": "Copilot loads sdaf-plan-and-test-semantics.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-plan-and-test-semantics.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-plan-and-test-semantics.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-plan-and-test-semantics"
+          }
+        }
+      ]
+    },
+    {
+      "skill_name": "sdaf-quality-assurance",
+      "evals": [
+        {
+          "id": "quality-assurance-positive-01",
+          "prompt": "Run the SDAF quality assurance configuration checks for this deployed SAP system.",
+          "expected_output": "Copilot loads sdaf-quality-assurance.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-quality-assurance.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-quality-assurance.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-quality-assurance"
+          }
+        },
+        {
+          "id": "quality-assurance-positive-02",
+          "prompt": "Validate this already-installed SAP system with SDAF's post-deployment checks and tell me where the HTML report and logs end up.",
+          "expected_output": "Copilot loads sdaf-quality-assurance.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-quality-assurance.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-quality-assurance.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-quality-assurance"
+          }
+        },
+        {
+          "id": "quality-assurance-positive-03",
+          "prompt": "The system is already installed, I have `sap-parameters.yaml`, `X00_hosts.yaml`, Key Vault access, and an approved maintenance window. Walk the documented offline central-services validation path, including why `TEST_CASES=\"Manual ASCS Migration\"` is wrong, what `TEST_GROUPS` it needs, and what `No test results found.` means.",
+          "expected_output": "Copilot loads sdaf-quality-assurance.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-quality-assurance.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-quality-assurance.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-quality-assurance"
+          }
+        }
+      ]
+    },
+    {
+      "skill_name": "sdaf-readiness-check",
+      "evals": [
+        {
+          "id": "readiness-positive-01",
+          "prompt": "Check whether this host and SDAF configuration are ready to deploy.",
+          "expected_output": "Copilot loads sdaf-readiness-check.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-readiness-check.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-readiness-check.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-readiness-check"
+          }
+        },
+        {
+          "id": "readiness-positive-02",
+          "prompt": "Can this machine reach the required tools, endpoints, state storage, and Key Vault?",
+          "expected_output": "Copilot loads sdaf-readiness-check.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-readiness-check.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-readiness-check.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-readiness-check"
+          }
+        },
+        {
+          "id": "readiness-positive-03",
+          "prompt": "Before control-plane deployment, verify prerequisites, configuration files, identity, connectivity, and quota without deploying anything.",
+          "expected_output": "Copilot loads sdaf-readiness-check.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-readiness-check.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-readiness-check.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-readiness-check"
+          }
+        }
+      ]
+    },
+    {
+      "skill_name": "sdaf-safe-removal",
+      "evals": [
+        {
+          "id": "safe-removal-positive-01",
+          "prompt": "Help me remove this SDAF deployment safely in the documented reverse order: SAP system first, then the workload zone, then the control plane.",
+          "expected_output": "Copilot loads sdaf-safe-removal.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-safe-removal.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-safe-removal.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-safe-removal"
+          }
+        },
+        {
+          "id": "safe-removal-positive-02",
+          "prompt": "I need to retire this SDAF environment without leaving tfstate surprises, orphaned shared resources, or half-finished teardown steps. What does the repo's documented shutdown path say to do?",
+          "expected_output": "Copilot loads sdaf-safe-removal.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-safe-removal.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-safe-removal.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-safe-removal"
+          }
+        },
+        {
+          "id": "safe-removal-positive-03",
+          "prompt": "Yesterday the control-plane teardown deleted the library. Today rerunning the same command exits 0, but the deployer and state account are still there. Walk the repo's documented safeguards before I touch .sap_deployment_automation or delete any resource groups.",
+          "expected_output": "Copilot loads sdaf-safe-removal and surfaces the control-plane partial-removal guard.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-safe-removal.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-safe-removal.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-safe-removal"
+          }
+        }
+      ]
+    },
+    {
+      "skill_name": "sdaf-sap-installation",
+      "evals": [
+        {
+          "id": "sap-installation-positive-01",
+          "prompt": "Run the SDAF configuration and installation flow after the SAP-system workspace is ready.",
+          "expected_output": "Copilot loads sdaf-sap-installation.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-sap-installation.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-sap-installation.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-sap-installation"
+          }
+        },
+        {
+          "id": "sap-installation-positive-02",
+          "prompt": "I already have sap-parameters.yaml and the generated hosts inventory. Which reviewed stage or Azure DevOps boolean should I use for BOM processing, SCS, database load, or PAS without starting over?",
+          "expected_output": "Copilot loads sdaf-sap-installation.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-sap-installation.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-sap-installation.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-sap-installation"
+          }
+        },
+        {
+          "id": "sap-installation-positive-03",
+          "prompt": "A previous Ansible sequence stopped after database load and left .progress markers. Walk me through the documented smallest-scope rerun, hook behavior, and SSH-key cleanup instead of replaying every playbook.",
+          "expected_output": "Copilot loads sdaf-sap-installation.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-sap-installation.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-sap-installation.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-sap-installation"
+          }
+        }
+      ]
+    },
+    {
+      "skill_name": "sdaf-sap-system",
+      "evals": [
+        {
+          "id": "sap-system-positive-01",
+          "prompt": "Deploy the SAP system infrastructure for this workload zone.",
+          "expected_output": "Copilot loads sdaf-sap-system.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-sap-system.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-sap-system.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-sap-system"
+          }
+        },
+        {
+          "id": "sap-system-positive-02",
+          "prompt": "Create the system layer and its generated Ansible inventory from my system tfvars.",
+          "expected_output": "Copilot loads sdaf-sap-system.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-sap-system.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-sap-system.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-sap-system"
+          }
+        },
+        {
+          "id": "sap-system-positive-03",
+          "prompt": "The system Terraform plan shows replacements; guide the documented review, apply, state, inventory, and output validation for the SAP-system stage.",
+          "expected_output": "Copilot loads sdaf-sap-system.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-sap-system.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-sap-system.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-sap-system"
+          }
+        }
+      ]
+    },
+    {
+      "skill_name": "sdaf-sovereign-cloud",
+      "evals": [
+        {
+          "id": "sovereign-positive-01",
+          "prompt": "We're deploying SDAF to Azure Government through GitHub Actions. Which sovereign-cloud variables and audience values must be set together before workflow 00?",
+          "expected_output": "Copilot loads sdaf-sovereign-cloud.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-sovereign-cloud.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-sovereign-cloud.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-sovereign-cloud"
+          }
+        },
+        {
+          "id": "sovereign-positive-02",
+          "prompt": "My Azure US Government run signs in, then Terraform fails with AADSTS900382. Explain the documented split between azure/login and ARM_ENVIRONMENT for SDAF.",
+          "expected_output": "Copilot loads sdaf-sovereign-cloud.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-sovereign-cloud.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-sovereign-cloud.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-sovereign-cloud"
+          }
+        },
+        {
+          "id": "sovereign-positive-03",
+          "prompt": "I'm bootstrapping a USVI control plane for SDAF. Confirm the US Gov region code, the Government dns_zone_names change in generated WORKSPACES, the 3.22+ image boundary, and what to do if the default VM size isn't offered.",
+          "expected_output": "Copilot loads sdaf-sovereign-cloud.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-sovereign-cloud.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-sovereign-cloud.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-sovereign-cloud"
+          }
+        }
+      ]
+    },
+    {
+      "skill_name": "sdaf-state-management",
+      "evals": [
+        {
+          "id": "state-management-positive-01",
+          "prompt": "Help me use advanced_state_management.sh safely to inspect SDAF Terraform state before I change anything.",
+          "expected_output": "Copilot loads sdaf-state-management.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-state-management.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-state-management.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-state-management"
+          }
+        },
+        {
+          "id": "state-management-positive-02",
+          "prompt": "Terraform and Azure disagree about one SDAF resource; show me the reviewed backup, list, and re-association path before anything edits the remote tfstate.",
+          "expected_output": "Copilot loads sdaf-state-management.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-state-management.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-state-management.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-state-management"
+          }
+        },
+        {
+          "id": "state-management-positive-03",
+          "prompt": "We need to repair a sap_system backend after a failed change review. I can provide the parameter file, state subscription, storage account, blob key, exact Terraform address, and Azure resource ID; walk the documented inspection and backup steps and only then the supported state command path.",
+          "expected_output": "Copilot loads sdaf-state-management.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-state-management.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-state-management.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-state-management"
+          }
+        }
+      ]
+    },
+    {
+      "skill_name": "sdaf-workload-zone",
+      "evals": [
+        {
+          "id": "workload-zone-positive-01",
+          "prompt": "I already deployed the control plane. Help me deploy the SDAF workload zone and review the landscape plan.",
+          "expected_output": "Copilot loads sdaf-workload-zone.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-workload-zone.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-workload-zone.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-workload-zone"
+          }
+        },
+        {
+          "id": "workload-zone-positive-02",
+          "prompt": "Connect the landscape network and state to the existing deployer/library.",
+          "expected_output": "Copilot loads sdaf-workload-zone.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-workload-zone.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-workload-zone.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-workload-zone"
+          }
+        },
+        {
+          "id": "workload-zone-positive-03",
+          "prompt": "Review my workload-zone plan, state inputs, networking, Key Vault, and a private-endpoint/subnet-policy failure before I rerun the documented installer.",
+          "expected_output": "Copilot loads sdaf-workload-zone.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-workload-zone.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-workload-zone.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-workload-zone"
+          }
+        }
+      ]
+    },
+    {
+      "skill_name": "sdaf-workspace-and-tfvars",
+      "evals": [
+        {
+          "id": "workspace-positive-01",
+          "prompt": "Explain where SDAF deployer, landscape, and system tfvars belong.",
+          "expected_output": "Copilot loads sdaf-workspace-and-tfvars.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-workspace-and-tfvars.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-workspace-and-tfvars.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-workspace-and-tfvars"
+          }
+        },
+        {
+          "id": "workspace-positive-02",
+          "prompt": "How should I name the workspace and region/location portions of these parameter files?",
+          "expected_output": "Copilot loads sdaf-workspace-and-tfvars.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-workspace-and-tfvars.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-workspace-and-tfvars.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-workspace-and-tfvars"
+          }
+        },
+        {
+          "id": "workspace-positive-03",
+          "prompt": "I have control-plane, workload-zone, and SAP-system configurations; show the documented directory and filename relationships and the filename/content validation gate.",
+          "expected_output": "Copilot loads sdaf-workspace-and-tfvars.",
+          "assertions": [
+            "With-skill run emits exactly one skill.invoked event naming sdaf-workspace-and-tfvars.",
+            "With-skill run emits no skill.invoked event naming any other SDAF skill.",
+            "Without-target baseline emits no skill.invoked event naming sdaf-workspace-and-tfvars.",
+            "Both runs complete successfully.",
+            "With-skill response is non-empty."
+          ],
+          "x-sdaf-routing": {
+            "expected_skill": "sdaf-workspace-and-tfvars"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/evals/evals.py
+++ b/evals/evals.py
@@ -91,7 +91,6 @@ class EvalRequest:
     output_dir: Path
     model: str
     limits: RunLimits
-    token: str | None
 
 
 class EvalCatalog:
@@ -346,11 +345,12 @@ class SdafSkillEvals:
             workspace = temp_root / "workspace"
             home.mkdir()
             workspace.mkdir()
+            authentication = load_authentication_environment()
             async with CopilotClient(
                 working_directory=str(workspace),
                 base_directory=str(home),
-                github_token=self.request.token,
-                use_logged_in_user=self.request.token is None,
+                env=authentication or None,
+                use_logged_in_user=not authentication,
                 log_level="error",
                 mode="empty",
                 session_idle_timeout_seconds=self.request.limits.timeout_seconds,
@@ -555,11 +555,14 @@ def redact(text: str) -> str:
     )
 
 
-def load_token(environment_name: str) -> str | None:
-    """Load an optional token from the named environment variable."""
+def load_authentication_environment() -> dict[str, str]:
+    """Return supported token variables for the child Copilot runtime."""
 
-    value = os.environ.get(environment_name, "").strip()
-    return value or None
+    return {
+        name: value
+        for name in ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN")
+        if (value := os.environ.get(name, "").strip())
+    }
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -592,7 +595,6 @@ def build_parser() -> argparse.ArgumentParser:
             )
         ),
     )
-    parser.add_argument("--github-token-env", default="COPILOT_GITHUB_TOKEN")
     return parser
 
 
@@ -609,7 +611,6 @@ async def run_case(args: argparse.Namespace, case: EvalCase) -> int:
         output_dir=args.output_dir.resolve(),
         model=args.model,
         limits=limits,
-        token=load_token(args.github_token_env),
     )
     result = await SdafSkillEvals(request).evaluate()
     print(json.dumps({"case_id": case.case_id, "passed": result["passed"]}))

--- a/evals/evals.py
+++ b/evals/evals.py
@@ -1,0 +1,638 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Evaluate SDAF skill invocation through the official GitHub Copilot SDK."""
+
+from __future__ import annotations
+import argparse
+import asyncio
+import hashlib
+import json
+import os
+import re
+import sys
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Sequence
+from copilot import (
+    CopilotClient,
+    ModelCapabilitiesOverride,
+    ModelLimitsOverride,
+    SessionEvent,
+    SessionEventType,
+    ToolSet,
+)
+from copilot.session_events import (
+    AssistantMessageData,
+    AssistantUsageData,
+    SessionErrorData,
+    SessionIdleData,
+    SessionSkillsLoadedData,
+    SkillInvokedData,
+    SkillInvokedTrigger,
+    SkillsLoadedSkill,
+)
+
+CASE_ID_PATTERN = re.compile(r"\A[a-z0-9]+(?:-[a-z0-9]+)*\Z")
+ASSERTION_COUNT = 5
+DEFAULT_AI_CREDITS = 30
+DEFAULT_OUTPUT_TOKENS = 1024
+DEFAULT_TIMEOUT_SECONDS = 120
+SENSITIVE_ASSIGNMENT = re.compile(
+    r'(?im)(["\']?(?:authorization|token|password|secret|client[_-]?secret|'
+    r'(?:x-)?api[_-]?key)["\']?\s*[:=]\s*)(["\']?)([^"\'\s,}\]]+)'
+)
+
+
+class EvalError(RuntimeError):
+    """Represent an invalid eval configuration or failed SDK run."""
+
+
+@dataclass(frozen=True, slots=True)
+class EvalCase:
+    """Store one validated reliability prompt."""
+
+    case_id: str
+    skill_name: str
+    prompt: str
+    expected_output: str
+    assertions: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class RunLimits:
+    """Store bounded SDK session settings."""
+
+    ai_credits: int
+    output_tokens: int
+    timeout_seconds: int
+
+    def validate(self) -> None:
+        """Reject unsafe or unsupported limit values."""
+
+        if not 30 <= self.ai_credits <= 100:
+            raise EvalError("max AI credits must be between 30 and 100")
+        if not 128 <= self.output_tokens <= 2048:
+            raise EvalError("max output tokens must be between 128 and 2048")
+        if not 30 <= self.timeout_seconds <= 300:
+            raise EvalError("session timeout must be between 30 and 300 seconds")
+
+
+@dataclass(frozen=True, slots=True)
+class EvalRequest:
+    """Store the inputs for one with-skill and baseline comparison."""
+
+    case: EvalCase
+    content_root: Path
+    output_dir: Path
+    model: str
+    limits: RunLimits
+    token: str | None
+
+
+class EvalCatalog:
+    """Load and validate the consolidated SDAF reliability corpus."""
+
+    def __init__(self, content_root: Path) -> None:
+        """Load cases from ``evals/evals.json`` below the content root."""
+
+        self.content_root = content_root.resolve()
+        self.skill_names = self._load_skill_names()
+        self.cases = self._load_cases()
+
+    def case_ids(self) -> tuple[str, ...]:
+        """Return all validated case IDs in stable order."""
+
+        return tuple(sorted(self.cases))
+
+    def get(self, case_id: str) -> EvalCase:
+        """Return one validated case or raise a clear configuration error."""
+
+        try:
+            return self.cases[case_id]
+        except KeyError as error:
+            raise EvalError(f"unknown case: {case_id!r}") from error
+
+    def _load_skill_names(self) -> frozenset[str]:
+        """Return names backed by safe production skill documents."""
+
+        skill_root = self.content_root / "skills"
+        if not skill_root.is_dir():
+            raise EvalError(f"missing skills directory: {skill_root}")
+        names: set[str] = set()
+        for skill_file in sorted(skill_root.glob("*/SKILL.md")):
+            self._require_safe_file(skill_file, skill_root)
+            names.add(skill_file.parent.name)
+        if len(names) != 18:
+            raise EvalError(f"expected 18 skills, found {len(names)}")
+        return frozenset(names)
+
+    def _load_cases(self) -> dict[str, EvalCase]:
+        """Parse 18 skill groups and 54 unique cases."""
+
+        eval_file = self.content_root / "evals" / "evals.json"
+        self._require_safe_file(eval_file, self.content_root / "evals")
+        try:
+            document = json.loads(eval_file.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as error:
+            raise EvalError(f"cannot read {eval_file}: {error}") from error
+        groups = document.get("skills") if isinstance(document, dict) else None
+        if not isinstance(groups, list) or len(groups) != 18:
+            raise EvalError("evals/evals.json must contain exactly 18 skill groups")
+        cases: dict[str, EvalCase] = {}
+        owners: set[str] = set()
+        for group in groups:
+            self._load_group(group, owners, cases)
+        if owners != set(self.skill_names):
+            raise EvalError("eval skill groups must exactly match production skills")
+        if len(cases) != 54:
+            raise EvalError(f"expected 54 eval cases, found {len(cases)}")
+        return cases
+
+    def _load_group(
+        self,
+        group: Any,
+        owners: set[str],
+        cases: dict[str, EvalCase],
+    ) -> None:
+        """Validate one skill group and add its cases."""
+
+        if not isinstance(group, dict) or set(group) != {"skill_name", "evals"}:
+            raise EvalError("each eval skill group must contain skill_name and evals")
+        owner = self._text(group["skill_name"], "skill_name")
+        if owner not in self.skill_names or owner in owners:
+            raise EvalError(f"invalid or duplicate eval skill group: {owner}")
+        owners.add(owner)
+        raw_cases = group["evals"]
+        if not isinstance(raw_cases, list) or len(raw_cases) != 3:
+            raise EvalError(f"{owner} must contain exactly three eval cases")
+        for raw_case in raw_cases:
+            case = self._parse_case(owner, raw_case)
+            if case.case_id in cases:
+                raise EvalError(f"duplicate eval case ID: {case.case_id}")
+            cases[case.case_id] = case
+
+    def _parse_case(self, owner: str, value: Any) -> EvalCase:
+        """Validate one eval case."""
+
+        expected_fields = {
+            "id",
+            "prompt",
+            "expected_output",
+            "assertions",
+            "x-sdaf-routing",
+        }
+        if not isinstance(value, dict) or set(value) != expected_fields:
+            raise EvalError(f"{owner} case fields do not match the reliability schema")
+        case_id = self._text(value["id"], f"{owner}.id")
+        if not CASE_ID_PATTERN.fullmatch(case_id):
+            raise EvalError(f"invalid case ID: {case_id}")
+        routing = value["x-sdaf-routing"]
+        if routing != {"expected_skill": owner}:
+            raise EvalError(f"{case_id} expected_skill must be {owner}")
+        assertions = value["assertions"]
+        if (
+            not isinstance(assertions, list)
+            or len(assertions) != ASSERTION_COUNT
+            or not all(isinstance(item, str) and item.strip() for item in assertions)
+        ):
+            raise EvalError(f"{case_id} must contain five non-empty assertions")
+        return EvalCase(
+            case_id=case_id,
+            skill_name=owner,
+            prompt=self._text(value["prompt"], f"{case_id}.prompt"),
+            expected_output=self._text(
+                value["expected_output"],
+                f"{case_id}.expected_output",
+            ),
+            assertions=tuple(assertions),
+        )
+
+    @staticmethod
+    def _text(value: Any, location: str) -> str:
+        """Return one required non-empty string."""
+
+        if not isinstance(value, str) or not value.strip():
+            raise EvalError(f"{location} must be a non-empty string")
+        return value
+
+    @staticmethod
+    def _require_safe_file(path: Path, root: Path) -> None:
+        """Reject missing files, links, hardlinks, and root escapes."""
+
+        try:
+            info = path.lstat()
+        except OSError as error:
+            raise EvalError(f"cannot inspect {path}: {error}") from error
+        if path.is_symlink() or info.st_nlink != 1 or not path.is_file():
+            raise EvalError(f"unsafe eval input file: {path}")
+        try:
+            path.resolve().relative_to(root.resolve())
+        except ValueError as error:
+            raise EvalError(f"eval input escapes its root: {path}") from error
+
+
+class SessionEvidence:
+    """Collect official typed Copilot SDK events for one session."""
+
+    def __init__(self) -> None:
+        """Initialize empty evidence and an idle completion signal."""
+
+        self.loaded_skills: tuple[SkillsLoadedSkill, ...] = ()
+        self.invocations: list[SkillInvokedData] = []
+        self.messages: list[AssistantMessageData] = []
+        self.usage: list[AssistantUsageData] = []
+        self.errors: list[SessionErrorData] = []
+        self.idle: SessionIdleData | None = None
+        self._done = asyncio.Event()
+
+    def handle(self, event: SessionEvent) -> None:
+        """Collect one event using the SDK's event discriminator and types."""
+
+        if event.type == SessionEventType.SESSION_SKILLS_LOADED:
+            if isinstance(event.data, SessionSkillsLoadedData):
+                self.loaded_skills = tuple(event.data.skills)
+        elif event.type == SessionEventType.SKILL_INVOKED:
+            if isinstance(event.data, SkillInvokedData):
+                self.invocations.append(event.data)
+        elif event.type == SessionEventType.ASSISTANT_MESSAGE:
+            if isinstance(event.data, AssistantMessageData):
+                self.messages.append(event.data)
+        elif event.type == SessionEventType.ASSISTANT_USAGE:
+            if isinstance(event.data, AssistantUsageData):
+                self.usage.append(event.data)
+        elif event.type == SessionEventType.SESSION_ERROR:
+            if isinstance(event.data, SessionErrorData):
+                self.errors.append(event.data)
+        elif event.type == SessionEventType.SESSION_IDLE:
+            if isinstance(event.data, SessionIdleData):
+                self.idle = event.data
+                self._done.set()
+
+    async def wait(self, timeout_seconds: int) -> None:
+        """Wait until the SDK reports the session is idle."""
+
+        await asyncio.wait_for(self._done.wait(), timeout=timeout_seconds)
+
+    @property
+    def response(self) -> str:
+        """Return the last non-empty complete assistant message."""
+
+        responses = [item.content.strip() for item in self.messages if item.content.strip()]
+        return responses[-1] if responses else ""
+
+    @property
+    def successful(self) -> bool:
+        """Return whether the session reached idle without an error."""
+
+        return self.idle is not None and not self.idle.aborted and not self.errors
+
+
+class SdafSkillEvals:
+    """Run one case with the target enabled and disabled."""
+
+    def __init__(self, request: EvalRequest) -> None:
+        """Initialize one case evaluator."""
+
+        self.request = request
+        self.skills_dir = request.content_root / "skills"
+        self.skill_hashes = self.source_hashes()
+
+    async def evaluate(self) -> dict[str, Any]:
+        """Run both isolated sessions and return the complete result."""
+
+        started = datetime.now(timezone.utc)
+        with_skill = await self._run_session(disable_target=False)
+        baseline = await self._run_session(disable_target=True)
+        unchanged = self.skill_hashes == self.source_hashes()
+        grades = self._grade(with_skill, baseline, unchanged)
+        result = {
+            "schema_version": 1,
+            "case_id": self.request.case.case_id,
+            "expected_skill": self.request.case.skill_name,
+            "expected_output": self.request.case.expected_output,
+            "passed": all(item["passed"] for item in grades),
+            "assertions": grades,
+            "with_skill": self._session_summary(with_skill),
+            "without_skill": self._session_summary(baseline),
+            "production_hashes_unchanged": unchanged,
+            "started_at": started.isoformat(),
+            "ended_at": datetime.now(timezone.utc).isoformat(),
+        }
+        self._write_artifacts(with_skill, baseline, result)
+        return result
+
+    def source_hashes(self) -> dict[str, str]:
+        """Hash all source skill files before and after sessions."""
+
+        return {
+            str(path.relative_to(self.request.content_root)): hashlib.sha256(
+                path.read_bytes()
+            ).hexdigest()
+            for path in sorted(self.skills_dir.glob("*/SKILL.md"))
+        }
+
+    async def _run_session(self, disable_target: bool) -> SessionEvidence:
+        """Run one isolated SDK session."""
+
+        evidence = SessionEvidence()
+        with tempfile.TemporaryDirectory(prefix="sdaf-skill-eval-") as directory:
+            temp_root = Path(directory)
+            home = temp_root / "copilot-home"
+            workspace = temp_root / "workspace"
+            home.mkdir()
+            workspace.mkdir()
+            async with CopilotClient(
+                working_directory=str(workspace),
+                base_directory=str(home),
+                github_token=self.request.token,
+                use_logged_in_user=self.request.token is None,
+                log_level="error",
+                mode="empty",
+                session_idle_timeout_seconds=self.request.limits.timeout_seconds,
+            ) as client:
+                session = await client.create_session(
+                    model=self.request.model,
+                    working_directory=str(workspace),
+                    enable_config_discovery=False,
+                    enable_on_demand_instruction_discovery=False,
+                    enable_file_hooks=False,
+                    enable_host_git_operations=False,
+                    enable_session_store=False,
+                    enable_skills=True,
+                    skill_directories=[str(self.skills_dir.resolve())],
+                    disabled_skills=([self.request.case.skill_name] if disable_target else None),
+                    available_tools=ToolSet().add_builtin("skill"),
+                    session_limits={
+                        "max_ai_credits": self.request.limits.ai_credits,
+                    },
+                    model_capabilities=ModelCapabilitiesOverride(
+                        limits=ModelLimitsOverride(
+                            max_output_tokens=self.request.limits.output_tokens
+                        )
+                    ),
+                    streaming=True,
+                    memory={"enabled": False},
+                    on_event=evidence.handle,
+                )
+                async with session:
+                    await session.send(self.request.case.prompt)
+                    await evidence.wait(self.request.limits.timeout_seconds)
+        return evidence
+
+    def _grade(
+        self,
+        with_skill: SessionEvidence,
+        baseline: SessionEvidence,
+        hashes_unchanged: bool,
+    ) -> list[dict[str, Any]]:
+        """Grade the five declared reliability assertions."""
+
+        target = self.request.case.skill_name
+        target_loaded = [
+            item for item in with_skill.loaded_skills if item.name == target and item.enabled
+        ]
+        target_invocations = [item for item in with_skill.invocations if item.name == target]
+        other_invocations = [
+            item.name
+            for item in with_skill.invocations
+            if item.name.startswith("sdaf-") and item.name != target
+        ]
+        baseline_target = [item for item in baseline.invocations if item.name == target]
+        invocation_passed = (
+            len(target_loaded) == 1
+            and len(target_invocations) == 1
+            and target_invocations[0].trigger == SkillInvokedTrigger.AGENT_INVOKED
+        )
+        return [
+            self._assertion(0, invocation_passed, self._invocation_evidence(target_invocations)),
+            self._assertion(1, not other_invocations, {"other_skills": other_invocations}),
+            self._assertion(2, not baseline_target, {"target_count": len(baseline_target)}),
+            self._assertion(
+                3,
+                with_skill.successful and baseline.successful and hashes_unchanged,
+                {
+                    "with_skill_success": with_skill.successful,
+                    "baseline_success": baseline.successful,
+                    "hashes_unchanged": hashes_unchanged,
+                },
+            ),
+            self._assertion(
+                4,
+                bool(with_skill.response),
+                {"response_length": len(with_skill.response)},
+            ),
+        ]
+
+    def _assertion(
+        self,
+        index: int,
+        passed: bool,
+        evidence: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Render one assertion result using the case's declared text."""
+
+        return {
+            "text": self.request.case.assertions[index],
+            "passed": passed,
+            "evidence": evidence,
+        }
+
+    @staticmethod
+    def _invocation_evidence(items: Sequence[SkillInvokedData]) -> dict[str, Any]:
+        """Render minimal invocation evidence without skill content."""
+
+        return {
+            "count": len(items),
+            "events": [
+                {
+                    "name": item.name,
+                    "path": item.path,
+                    "plugin_name": item.plugin_name,
+                    "plugin_version": item.plugin_version,
+                    "source": item.source,
+                    "trigger": item.trigger.value if item.trigger else None,
+                }
+                for item in items
+            ],
+        }
+
+    @staticmethod
+    def _session_summary(evidence: SessionEvidence) -> dict[str, Any]:
+        """Render safe session evidence without skill content."""
+
+        return {
+            "successful": evidence.successful,
+            "loaded_skills": [
+                {"name": item.name, "enabled": item.enabled, "path": item.path}
+                for item in evidence.loaded_skills
+            ],
+            "invocations": [
+                {
+                    "name": item.name,
+                    "path": item.path,
+                    "plugin_name": item.plugin_name,
+                    "trigger": item.trigger.value if item.trigger else None,
+                }
+                for item in evidence.invocations
+            ],
+            "errors": [
+                {
+                    "type": item.error_type,
+                    "message": item.message,
+                    "code": item.error_code,
+                }
+                for item in evidence.errors
+            ],
+            "usage": [
+                {
+                    "model": item.model,
+                    "input_tokens": item.input_tokens,
+                    "output_tokens": item.output_tokens,
+                    "cost": item.cost,
+                    "duration_ms": (
+                        item.duration.total_seconds() * 1000 if item.duration else None
+                    ),
+                }
+                for item in evidence.usage
+            ],
+            "response_length": len(evidence.response),
+        }
+
+    def _write_artifacts(
+        self,
+        with_skill: SessionEvidence,
+        baseline: SessionEvidence,
+        result: dict[str, Any],
+    ) -> None:
+        """Write redacted responses, usage, grading, and summary."""
+
+        self.request.output_dir.mkdir(parents=True, exist_ok=True)
+        for name, evidence in (
+            ("with_skill", with_skill),
+            ("without_skill", baseline),
+        ):
+            arm_dir = self.request.output_dir / name
+            arm_dir.mkdir()
+            (arm_dir / "response.txt").write_text(
+                redact(evidence.response),
+                encoding="utf-8",
+                newline="\n",
+            )
+            (arm_dir / "timing.json").write_text(
+                json.dumps(self._session_summary(evidence)["usage"], indent=2) + "\n",
+                encoding="utf-8",
+                newline="\n",
+            )
+        grading = {
+            "passed": result["passed"],
+            "assertions": result["assertions"],
+        }
+        self._write_json(self.request.output_dir / "grading.json", grading)
+        self._write_json(self.request.output_dir / "result.json", result)
+
+    @staticmethod
+    def _write_json(path: Path, document: dict[str, Any]) -> None:
+        """Write one stable JSON artifact."""
+
+        path.write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+
+
+def redact(text: str) -> str:
+    """Redact simple credential assignments from response artifacts."""
+
+    return SENSITIVE_ASSIGNMENT.sub(
+        lambda match: f"{match.group(1)}{match.group(2)}[REDACTED]",
+        text,
+    )
+
+
+def load_token(environment_name: str) -> str | None:
+    """Load an optional token from the named environment variable."""
+
+    value = os.environ.get(environment_name, "").strip()
+    return value or None
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line interface."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--content-root", type=Path, default=Path.cwd())
+    modes = parser.add_mutually_exclusive_group(required=True)
+    modes.add_argument("--list", action="store_true")
+    modes.add_argument("--case")
+    parser.add_argument("--output-dir", type=Path)
+    parser.add_argument("--model", default="gpt-5-mini")
+    parser.add_argument(
+        "--max-ai-credits",
+        type=int,
+        default=int(os.environ.get("SDAF_EVAL_MAX_AI_CREDITS", DEFAULT_AI_CREDITS)),
+    )
+    parser.add_argument(
+        "--max-output-tokens",
+        type=int,
+        default=int(os.environ.get("SDAF_EVAL_MAX_OUTPUT_TOKENS", DEFAULT_OUTPUT_TOKENS)),
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=int(
+            os.environ.get(
+                "SDAF_EVAL_SESSION_TIMEOUT_SECONDS",
+                DEFAULT_TIMEOUT_SECONDS,
+            )
+        ),
+    )
+    parser.add_argument("--github-token-env", default="COPILOT_GITHUB_TOKEN")
+    return parser
+
+
+async def run_case(args: argparse.Namespace, case: EvalCase) -> int:
+    """Run one selected reliability case."""
+
+    if args.output_dir is None:
+        raise EvalError("--output-dir is required with --case")
+    limits = RunLimits(args.max_ai_credits, args.max_output_tokens, args.timeout)
+    limits.validate()
+    request = EvalRequest(
+        case=case,
+        content_root=args.content_root.resolve(),
+        output_dir=args.output_dir.resolve(),
+        model=args.model,
+        limits=limits,
+        token=load_token(args.github_token_env),
+    )
+    result = await SdafSkillEvals(request).evaluate()
+    print(json.dumps({"case_id": case.case_id, "passed": result["passed"]}))
+    return 0 if result["passed"] else 1
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """List cases or run one SDK-backed reliability comparison."""
+
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        catalog = EvalCatalog(args.content_root)
+        if args.list:
+            for case_id in catalog.case_ids():
+                print(case_id)
+            return 0
+        case = catalog.get(args.case or "")
+        return asyncio.run(run_case(args, case))
+    except (EvalError, OSError, RuntimeError, TypeError, ValueError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,0 +1,6 @@
+{
+    "name": "azure-sap-automation",
+    "version": "0.1.0",
+    "description": "AI skills for the SAP Deployment Automation Framework (SDAF): orient, pre-flight readiness, deploy the control plane / workload zone / SAP system, choose a BOM, lay out WORKSPACES/tfvars, and triage failed runs. Documented behaviour only.",
+    "contextFileName": "GEMINI.md"
+}

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-sap-automation",
     "version": "0.1.0",
-    "description": "AI skills for the SAP Deployment Automation Framework (SDAF): orient, pre-flight readiness, deploy the control plane / workload zone / SAP system, choose a BOM, lay out WORKSPACES/tfvars, and triage failed runs. Documented behaviour only.",
+    "description": "18 documented-only hub skills for the SAP Deployment Automation Framework (SDAF): orientation, readiness, workspaces/tfvars, BOM/media, plan/test semantics, control plane / workload zone / SAP system deployment, installation, QA, HA, state, safe removal, failure triage, and sovereign-cloud deltas.",
     "contextFileName": "GEMINI.md"
 }

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,6 +4,8 @@ pytest==9.1.1
 pytest-mock==3.15.1
 pytest-cov==7.1.0
 black==26.5.1
+github-copilot-sdk==1.0.9
+pylint==4.0.5
 
 # Runtime dependencies imported by the modules under test.
 ansible-core==2.16.14

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,7 +4,7 @@ pytest==9.1.1
 pytest-mock==3.15.1
 pytest-cov==7.1.0
 black==26.5.1
-github-copilot-sdk==1.0.9
+github-copilot-sdk==1.0.9; python_version >= "3.11"
 pylint==4.0.5
 
 # Runtime dependencies imported by the modules under test.

--- a/skills/sdaf-bom-selection/SKILL.md
+++ b/skills/sdaf-bom-selection/SKILL.md
@@ -10,8 +10,8 @@ description: >
   keys in `sap-parameters.yaml`. Use when a user says "which BOM do I use",
   "product BOM vs component BOM", "SAP samples BOM catalog", "BOM_CATALOG",
   "S4/2023 BOM", "HANA BOM", or "how do I pick a BOM for HANA/Oracle/DB2/ASE".
-  Do NOT use to author a new BOM, to acquire media (later wave), or to
-  troubleshoot a checksum / 404 (later wave).
+  Do NOT use to author a new BOM, to acquire media (`sdaf-media-acquisition`),
+  or to troubleshoot a checksum / 404 (`sdaf-media-diagnostics`).
 allowed-tools: shell
 license: MIT
 ---
@@ -44,8 +44,8 @@ Docs
 `docs/local/06-00-software-and-installation.md § Inputs and BOM ownership`):
 
 - **`sap-automation-samples/SAP/<name>/<name>.yaml`** — **product BOM**
-  (whole product); pick this when the flow accepts a single complete
-  definition (e.g. `sap-automation/deploy/pipelines/04-sap-software-download.yaml`).
+  (whole product); pick this when the documented flow accepts a single
+  complete definition.
 - **`sap-automation-samples/BOM/<name>/<name>.yaml`** — **component BOM**
   (app / db / kernel); pick these when the flow supports dynamic assembly
   driven by the four `sap-parameters.yaml` keys documented below. Anchor:
@@ -119,9 +119,10 @@ Do not select a BOM whose guardrails do not match the target topology.
 
 - To validate a BOM: `check_bom.sh` (runs `yamllint`, `ansible-lint`, and
   `check_bom.yml`). Referenced in `sap-automation-samples/docs/02-00-bom-samples.md
-  § Validate`. BOM authoring is a separate skill and is out of this wave.
-- To acquire media once a BOM is selected: media acquisition is a separate
-  skill and is out of this wave.
+  § Validate`. BOM authoring is outside the shipped 18-skill hub.
+- To acquire media once a BOM is selected: route to `sdaf-media-acquisition`.
+- To diagnose archive / checksum / extractor failures after selection:
+  route to `sdaf-media-diagnostics`.
 - To route BOM failures during a run:
   `docs/local/troubleshooting.md § BOM files are not found` → confirm
   `BOM_CATALOG` root, names, and files.

--- a/skills/sdaf-bom-selection/SKILL.md
+++ b/skills/sdaf-bom-selection/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: sdaf-bom-selection
+description: >
+  Pick the right SDAF BOM for a target SAP product / release / DB platform /
+  version / kernel / topology. Explains where BOMs live in the samples repo
+  (`SAP/` for whole products, `BOM/` for components), decodes the `ms`,
+  `v####`, and `latest` suffix conventions, points at the compatibility
+  guardrails (`supportedPlatforms`, `supportedDBVersions`, `supportedKernels`),
+  and reminds the operator that the download flow needs four explicit BOM
+  keys in `sap-parameters.yaml`. Use when a user says "which BOM do I use",
+  "product BOM vs component BOM", "SAP samples BOM catalog", "BOM_CATALOG",
+  "S4/2023 BOM", "HANA BOM", or "how do I pick a BOM for HANA/Oracle/DB2/ASE".
+  Do NOT use to author a new BOM, to acquire media (later wave), or to
+  troubleshoot a checksum / 404 (later wave).
+allowed-tools: shell
+license: MIT
+---
+
+# SDAF BOM Selection
+
+Context-primer. Helps a user *choose* an existing BOM from the samples
+catalog. Grounded in `docs/local/06-00-software-and-installation.md § Inputs
+and BOM ownership` and the samples-repo BOM docs
+(`sap-automation-samples/docs/02-00-bom-samples.md`).
+
+For an ordered 5-step end-to-end walkthrough (identify target → product vs
+component BOM → compatibility fields → prefer pinned name → pin samples
+commit), see [`references/bom-selection.md`](references/bom-selection.md);
+this body carries the topic-by-topic facts.
+
+## When to invoke
+
+Trigger on: "pick a BOM", "which BOM", "product BOM vs component BOM",
+"BOM_CATALOG", "SAP samples", "S4 2023 BOM", "HANA BOM", "Oracle BOM", "DB2
+BOM", "compatibility guardrails".
+
+Do NOT trigger on: authoring a new BOM, running `download_menu.sh`, media
+404 / checksum troubleshooting, or install-time BOM failures.
+
+## Where BOMs live
+
+Docs
+(`sap-automation-samples/docs/02-00-bom-samples.md § Understand SAP and BOM`;
+`docs/local/06-00-software-and-installation.md § Inputs and BOM ownership`):
+
+- **`sap-automation-samples/SAP/<name>/<name>.yaml`** — **product BOM**
+  (whole product); pick this when the flow accepts a single complete
+  definition (e.g. `sap-automation/deploy/pipelines/04-sap-software-download.yaml`).
+- **`sap-automation-samples/BOM/<name>/<name>.yaml`** — **component BOM**
+  (app / db / kernel); pick these when the flow supports dynamic assembly
+  driven by the four `sap-parameters.yaml` keys documented below. Anchor:
+  `sap-automation-samples/docs/02-00-bom-samples.md § Understand SAP and BOM`.
+- **`sap-automation-samples/SAP/archives/`** — legacy only; do not use
+  without explicit release guidance.
+
+Filename rule (docs; samples): the directory name and the YAML basename
+must match exactly, case-sensitive. A rename that breaks the pair breaks
+selection.
+
+## BOM_CATALOG must point at the samples root
+
+`docs/local/06-00-software-and-installation.md § Inputs and BOM ownership`:
+
+- Set `BOM_CATALOG` to the root of a reviewed samples checkout that
+  contains both `SAP/` and `BOM/`.
+- **Do not** set `BOM_CATALOG` to an individual BOM directory.
+- `download_menu.sh` passes this value to Ansible as `BOM_directory`.
+
+## The four BOM keys (download flow)
+
+`docs/local/06-00-software-and-installation.md § Inputs and BOM ownership`
+is explicit: the SAP-system-generated `sap-parameters.yaml` contains
+`bom_base_name`, but the wrapper **overrides it** and requires four keys:
+
+```yaml
+application_bom_name: <APPLICATION_BOM>
+database_bom_name:    <DATABASE_BOM>
+sap_kernel_bom_name:  <KERNEL_BOM>
+save_bom_as:          <COMBINED_BOM_NAME>
+```
+
+Without all four, the wrapper substitutes an empty value and the download
+fails. This is a documented constraint — surface it whenever the operator
+picks component BOMs.
+
+## Compatibility guardrails
+
+BOM YAML fields to check before picking (documented in
+`sap-automation-samples/docs/02-00-bom-samples.md § Select and run a BOM` /
+`§ Review before execution`; the same fields are present in every shipped
+BOM at `sap-automation-samples/{SAP,BOM}/<name>/<name>.yaml` — open the
+current candidate rather than a versioned example):
+
+- `supportedPlatforms`
+- `supportedDBVersions`
+- `supportedKernels`
+- `product_ids` (role-to-SAP-product-ID map)
+- `materials.dependencies` (prerequisite BOMs)
+
+For the current allowed values on any of these keys, read the target BOM
+YAML itself and the samples-repo doc anchor above — those own the strings.
+Do not select a BOM whose guardrails do not match the target topology.
+
+## Suffix decoding
+
+`sap-automation-samples/SAP/readme.md § BOM Name / BOM File` and
+`§ 02-00-bom-samples.md § Select and run a BOM`:
+
+- `ms` suffix — Microsoft-supplied BOM.
+- `v####` suffix — serial version number.
+- `latest` in a name — moving target; the docs warn that names containing
+  `latest` can change later. Prefer a pinned `v####` name, and pin the
+  samples-repo checkout commit, so a BOM selected today matches the media
+  downloaded tomorrow
+  (`sap-automation-samples/docs/02-00-bom-samples.md § Select and run a
+  BOM`).
+
+## Hand-off
+
+- To validate a BOM: `check_bom.sh` (runs `yamllint`, `ansible-lint`, and
+  `check_bom.yml`). Referenced in `sap-automation-samples/docs/02-00-bom-samples.md
+  § Validate`. BOM authoring is a separate skill and is out of this wave.
+- To acquire media once a BOM is selected: media acquisition is a separate
+  skill and is out of this wave.
+- To route BOM failures during a run:
+  `docs/local/troubleshooting.md § BOM files are not found` → confirm
+  `BOM_CATALOG` root, names, and files.
+
+## Hard rules
+
+- Documented behaviour only (D19). If asked about air-gapped / offline
+  media, an undocumented compatibility mapping, or the meaning of `XBOM`,
+  say docs are silent and stop.
+- Do not add credentials or downloaded media to the samples repo
+  (`sap-automation-samples/docs/02-00-bom-samples.md § Before you begin`).
+- Do not point `BOM_CATALOG` at a single BOM directory.
+
+## See also
+
+- `sdaf-sap-system` (its generated `sap-parameters.yaml` is where the four
+  BOM keys are set).
+- `sdaf-workspace-and-tfvars` (where the samples checkout is separate from
+  the SDAF checkout).
+- `sap-automation-samples/docs/02-00-bom-samples.md`,
+  `docs/local/06-00-software-and-installation.md`.

--- a/skills/sdaf-bom-selection/references/bom-selection.md
+++ b/skills/sdaf-bom-selection/references/bom-selection.md
@@ -1,0 +1,33 @@
+# BOM selection: ordered decision walkthrough
+
+Companion to `sdaf-bom-selection`. This file exists to hold the ordered
+5-step selection procedure — the parent SKILL.md carries the topic-by-topic
+facts, but does not sequence them into a single walkthrough. Read this file
+when the operator asks *"walk me through picking a BOM"*.
+
+1. Identify product family, release, DB platform, DB version, kernel, and
+   topology (single-node / HA / scale-out).
+   Doc: `sap-automation-samples/docs/02-00-bom-samples.md § Select and run
+   a BOM`.
+2. If the flow accepts a single BOM name, pick from `SAP/`. If the flow
+   uses the four `sap-parameters.yaml` keys (`application_bom_name`,
+   `database_bom_name`, `sap_kernel_bom_name`, `save_bom_as`), pick
+   components from `BOM/`.
+   Doc: `docs/local/06-00-software-and-installation.md § Inputs and BOM
+   ownership`.
+3. Open the candidate BOM YAML and check `supportedPlatforms`,
+   `supportedDBVersions`, `supportedKernels`. The BOM YAML itself is the
+   source of truth on currently allowed values — this walkthrough does not
+   restate them.
+   Doc: `sap-automation-samples/docs/02-00-bom-samples.md § Understand SAP
+   and BOM`.
+4. Prefer a pinned `v####` name over one containing `latest`.
+   Doc: `sap-automation-samples/SAP/readme.md § BOM Name / BOM File`.
+5. Pin the samples-repo checkout commit.
+   Doc: `sap-automation-samples/docs/02-00-bom-samples.md § Select and run
+   a BOM`.
+
+For per-topic facts (where BOMs live, the `BOM_CATALOG` rule, product vs
+component BOMs, the four keys, suffix decoding, hard rules), read the
+parent SKILL.md. This file is deliberately kept narrow to the ordered
+walkthrough so it does not drift from those facts.

--- a/skills/sdaf-control-plane-bootstrap/SKILL.md
+++ b/skills/sdaf-control-plane-bootstrap/SKILL.md
@@ -68,12 +68,11 @@ cd "$CONFIG_REPO_PATH/WORKSPACES"
     "$CONFIG_REPO_PATH/WORKSPACES/DEPLOYER/<CONTROL_PLANE>-INFRASTRUCTURE/<CONTROL_PLANE>-INFRASTRUCTURE.tfvars" \
     --library_parameter_file \
     "$CONFIG_REPO_PATH/WORKSPACES/LIBRARY/<ENVIRONMENT>-<LOCATION>-SAP_LIBRARY/<ENVIRONMENT>-<LOCATION>-SAP_LIBRARY.tfvars" \
-    --subscription "$ARM_SUBSCRIPTION_ID"
-rc=$?
-if [ $rc -ne 0 ]; then
+    --subscription "$ARM_SUBSCRIPTION_ID" || {
+  rc=$?
   echo "control-plane exit=$rc — route to sdaf-failure-triage"
-  exit $rc
-fi
+  exit "$rc"
+}
 ```
 
 Do not claim success unless the exit code is `0` AND the validation checks

--- a/skills/sdaf-control-plane-bootstrap/SKILL.md
+++ b/skills/sdaf-control-plane-bootstrap/SKILL.md
@@ -9,9 +9,8 @@ description: >
   deploy_controlplane.sh", "bootstrap SDAF from an empty subscription",
   "install the deployer" or "create the SAP library". Do NOT use for workload
   zone (see sdaf-workload-zone), SAP system (see sdaf-sap-system), removal
-  (this scenario is not implemented), or Azure Government end-to-end
-  procedures (docs silent — for the canonical disclaimer, invoke
-  sdaf-failure-triage).
+  (`sdaf-safe-removal`), or Azure Government / sovereign-cloud deltas
+  (`sdaf-sovereign-cloud`).
 allowed-tools: shell
 license: MIT
 ---
@@ -43,16 +42,6 @@ removal, or state repair.
   (`docs/local/troubleshooting.md § A required export is missing`):
   `SAP_AUTOMATION_REPO_PATH`, `CONFIG_REPO_PATH`, `ARM_SUBSCRIPTION_ID`.
 
-## Script family choice — pick one, do NOT mix
-
-v1 (`deploy/scripts/deploy_controlplane.sh`) and v2
-(`deploy/scripts/deploy_control_plane_v2.sh`) coexist. Docs decline to name
-one "current" and warn against mixing options or state-variable names —
-follow release guidance and each script's own `--help`. Anchors:
-`docs/local/03-00-control-plane.md § What the automation does`,
-`docs/local/README.md § Select a script family`. If the operator has no
-release-guidance-driven preference, say docs decline to pick and stop.
-
 ## Recipe
 
 ### Step 1 — Review the tfvars
@@ -66,7 +55,7 @@ naming matches `docs/region-codes.md § Where the region code appears`.
 Docs require an explicit review before every state-changing step
 (`docs/local/03-00-control-plane.md § Review before execution`; `§ Run`).
 
-### Step 3 — Run the control-plane deploy (v1, documented shape)
+### Step 3 — Run the documented control-plane deploy
 
 From `CONFIG_REPO_PATH`, exactly per
 `docs/local/03-00-control-plane.md § Run`:
@@ -123,8 +112,6 @@ triage):
 
 - Documented behaviour only (D19). If a knob is not in the shipped docs or
   the script's own `--help`, do not describe it.
-- Do not mix v1 and v2 options or state-variable names
-  (`docs/local/03-00-control-plane.md § What the automation does`).
 - Do not pass `--auto-approve` for reviewed local deployment
   (`docs/local/03-00-control-plane.md § Review before execution`).
 - Do not `--force` casually
@@ -136,7 +123,7 @@ triage):
 ## See also
 
 - `sdaf-workspace-and-tfvars`, `sdaf-readiness-check`,
-  `sdaf-workload-zone`, `sdaf-sap-system`, `sdaf-failure-triage`.
+  `sdaf-workload-zone`, `sdaf-sap-system`, `sdaf-safe-removal`,
+  `sdaf-sovereign-cloud`, `sdaf-failure-triage`.
 - `docs/local/03-00-control-plane.md`, `docs/local/troubleshooting.md`,
-  `docs/local/README.md § Select a script family`,
   [`.github/copilot-instructions.md`](../../.github/copilot-instructions.md).

--- a/skills/sdaf-control-plane-bootstrap/SKILL.md
+++ b/skills/sdaf-control-plane-bootstrap/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: sdaf-control-plane-bootstrap
+description: >
+  Deploy the SDAF control plane locally: prepare DEPLOYER and LIBRARY tfvars,
+  review the plan, run `deploy_controlplane.sh` per
+  `docs/local/03-00-control-plane.md § Run`, and validate the deployer +
+  library + state hand-off. Grounded in `docs/local/03-00-control-plane.md`.
+  Use when a user says "deploy the SDAF control plane", "run
+  deploy_controlplane.sh", "bootstrap SDAF from an empty subscription",
+  "install the deployer" or "create the SAP library". Do NOT use for workload
+  zone (see sdaf-workload-zone), SAP system (see sdaf-sap-system), removal
+  (this scenario is not implemented), or Azure Government end-to-end
+  procedures (docs silent — for the canonical disclaimer, invoke
+  sdaf-failure-triage).
+allowed-tools: shell
+license: MIT
+---
+
+# SDAF Control Plane Bootstrap
+
+Action-loop skill. Deploys the control plane strictly per
+`docs/local/03-00-control-plane.md` for local execution. On ADO / GitHub
+surfaces, defer stage mechanics to the surface bootstrap plugin — this skill
+covers the shared control-plane semantics.
+
+## When to invoke
+
+Trigger on: "deploy the SDAF control plane", "run deploy_controlplane.sh",
+"install the deployer", "create the SAP library", "bootstrap SDAF from empty".
+
+Do NOT trigger on: workload zone, SAP system, software download, install,
+removal, or state repair.
+
+## Preconditions (documented gates)
+
+- `sdaf-readiness-check` has passed
+  (`docs/local/02-00-prepare-execution-environment.md § Readiness verification`;
+  `docs/local/03-00-control-plane.md § Before you begin`).
+- Control-plane config files (DEPLOYER + LIBRARY tfvars) are prepared under
+  the documented `WORKSPACES` layout — see `sdaf-workspace-and-tfvars`
+  (`§ Configuration preparation`, `§ Inputs`).
+- The three required env vars are set
+  (`docs/local/troubleshooting.md § A required export is missing`):
+  `SAP_AUTOMATION_REPO_PATH`, `CONFIG_REPO_PATH`, `ARM_SUBSCRIPTION_ID`.
+
+## Script family choice — pick one, do NOT mix
+
+v1 (`deploy/scripts/deploy_controlplane.sh`) and v2
+(`deploy/scripts/deploy_control_plane_v2.sh`) coexist. Docs decline to name
+one "current" and warn against mixing options or state-variable names —
+follow release guidance and each script's own `--help`. Anchors:
+`docs/local/03-00-control-plane.md § What the automation does`,
+`docs/local/README.md § Select a script family`. If the operator has no
+release-guidance-driven preference, say docs decline to pick and stop.
+
+## Recipe
+
+### Step 1 — Review the tfvars
+
+Re-read the DEPLOYER and LIBRARY tfvars once
+(`docs/local/03-00-control-plane.md § Review before execution`). Confirm
+naming matches `docs/region-codes.md § Where the region code appears`.
+
+### Step 2 — Confirm the review gate
+
+Docs require an explicit review before every state-changing step
+(`docs/local/03-00-control-plane.md § Review before execution`; `§ Run`).
+
+### Step 3 — Run the control-plane deploy (v1, documented shape)
+
+From `CONFIG_REPO_PATH`, exactly per
+`docs/local/03-00-control-plane.md § Run`:
+
+```bash
+set -e
+cd "$CONFIG_REPO_PATH/WORKSPACES"
+"$SAP_AUTOMATION_REPO_PATH/deploy/scripts/deploy_controlplane.sh" \
+    --deployer_parameter_file \
+    "$CONFIG_REPO_PATH/WORKSPACES/DEPLOYER/<CONTROL_PLANE>-INFRASTRUCTURE/<CONTROL_PLANE>-INFRASTRUCTURE.tfvars" \
+    --library_parameter_file \
+    "$CONFIG_REPO_PATH/WORKSPACES/LIBRARY/<ENVIRONMENT>-<LOCATION>-SAP_LIBRARY/<ENVIRONMENT>-<LOCATION>-SAP_LIBRARY.tfvars" \
+    --subscription "$ARM_SUBSCRIPTION_ID"
+rc=$?
+if [ $rc -ne 0 ]; then
+  echo "control-plane exit=$rc — route to sdaf-failure-triage"
+  exit $rc
+fi
+```
+
+Do not claim success unless the exit code is `0` AND the validation checks
+in Step 5 pass. Treat `exit 2` as a validation-gate failure that must not be
+silenced.
+
+### Step 4 — Do not update SDAF between plan and apply
+
+`docs/local/01-00-prerequisites.md § Pin versions`.
+
+### Step 5 — Validate
+
+`docs/local/03-00-control-plane.md § Validate` and `§ Outcome`:
+
+- Deployer + library deployed.
+- Terraform state migrated to the library storage account (`tfstate`
+  container) — see `§ What the automation does`.
+- `.sap_deployment_automation` metadata populated (`§ What the automation
+  does`, `§ Validate`).
+- Summary written (`§ Outcome`).
+
+## If the run fails
+
+Route to **`sdaf-failure-triage`**. It walks
+`docs/local/troubleshooting.md` and hands back the specific documented
+anchor. Stage-owned preventive checks (that belong here rather than in
+triage):
+
+- Filename / directory / basename mismatch — fix before rerun
+  (`docs/local/troubleshooting.md § A parameter file is not found`).
+- Interrupted control-plane rerun with `--recover` — do so only after the
+  state agrees
+  (`docs/local/troubleshooting.md § A control-plane run stopped partway through`).
+
+## Hard rules
+
+- Documented behaviour only (D19). If a knob is not in the shipped docs or
+  the script's own `--help`, do not describe it.
+- Do not mix v1 and v2 options or state-variable names
+  (`docs/local/03-00-control-plane.md § What the automation does`).
+- Do not pass `--auto-approve` for reviewed local deployment
+  (`docs/local/03-00-control-plane.md § Review before execution`).
+- Do not `--force` casually
+  (`docs/local/03-00-control-plane.md § Safe retry`).
+- Repo-wide rules apply: **do not run `terraform fmt`** and follow the
+  Terraform / Ansible / Python guidance in
+  [`.github/copilot-instructions.md`](../../.github/copilot-instructions.md).
+
+## See also
+
+- `sdaf-workspace-and-tfvars`, `sdaf-readiness-check`,
+  `sdaf-workload-zone`, `sdaf-sap-system`, `sdaf-failure-triage`.
+- `docs/local/03-00-control-plane.md`, `docs/local/troubleshooting.md`,
+  `docs/local/README.md § Select a script family`,
+  [`.github/copilot-instructions.md`](../../.github/copilot-instructions.md).

--- a/skills/sdaf-failure-triage/SKILL.md
+++ b/skills/sdaf-failure-triage/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: sdaf-failure-triage
+description: >
+  Triage a failed or suspicious SDAF run: distinguish a real failure from a
+  green no-op or a clean plan reported as failure, map the observed symptom
+  to a documented cause in `docs/local/troubleshooting.md`, and hand off to
+  the stage-owning skill for retry. Use when a user says "SDAF run failed",
+  "my deploy exited non-zero", "the plan was clean but exit 1", "the run said
+  success but nothing was deployed", "state lock error", "unexpected
+  replacement", "control plane stopped partway", "generated hosts.yaml
+  missing", "workload-zone private endpoint failure", "workload-zone subnet policy failure",
+  or "SDAF exit 2". Do NOT use to actually deploy or to redesign the workspace
+  layout.
+allowed-tools: shell
+license: MIT
+---
+
+# SDAF Failure Triage
+
+Action-loop skill. The entry point for "it broke". Maps observed symptoms to
+the documented cause in `docs/local/troubleshooting.md` (and the stage docs'
+own `§ Validate` / `§ Configuration preparation` sections) and hands off to
+the stage-owning skill. This skill is a **router**, not the owner of any
+per-stage fix.
+
+## When to invoke
+
+Trigger on: "SDAF run failed", "the plan was clean but the run exited 1",
+"success but nothing deployed", "state lock", "unexpected replacement",
+"control plane stopped partway", "generated hosts.yaml missing", "BOM files
+not found", "removal is incomplete", "Ansible playbook failed",
+"workload-zone private endpoint failure", "workload-zone subnet policy failure", "SDAF
+exit 2".
+
+Do NOT trigger on: pre-flight readiness (`sdaf-readiness-check`), authoring
+tfvars (`sdaf-workspace-and-tfvars`), fresh deploy of a stage.
+
+## Preconditions
+
+- Collect the exit code and the last 200 lines of the run log before
+  invoking. If you have neither, ask for them; do not guess.
+
+## Recipe
+
+### Step 1 — Establish exit-code intent
+
+- `0` — Terraform / script signalled success. Still worth verifying the
+  expected artefacts exist (some symptoms below are "success but nothing
+  deployed").
+- non-zero — real failure OR a validation-gate refusal (`exit 2` from
+  `validate.sh` or a stage script). Treat `exit 2` as a validation gate
+  that was intentionally tripped, not a bug; do not silence it.
+
+### Step 2 — Map the symptom
+
+Walk [`references/symptom-map.md`](references/symptom-map.md), which lists
+every named failure class from `docs/local/troubleshooting.md` (plus the workload-zone private-endpoint / subnet-policy case owned by `sdaf-workload-zone` and anchored in `docs/local/04-00-workload-zone.md § Configuration preparation`) with its
+canonical anchor and the owning skill. Pick the first row whose symptom
+matches the observed signature.
+
+If nothing matches, walk the "canonical 'clean plan reported as failure'
+note" in `references/symptom-map.md`, which walks the stage `§ Validate`
+sections. If nothing there matches either, say docs are silent on this
+symptom and stop — do not invent a cause.
+
+### Step 3 — Route to the stage-owning skill
+
+Route to the stage-owning skill for the actual retry:
+
+| Stage / symptom | Owning skill |
+|---|---|
+| Control plane | `sdaf-control-plane-bootstrap` |
+| Workload zone (**including** the private-endpoint / subnet-policy workaround) | `sdaf-workload-zone` |
+| SAP system | `sdaf-sap-system` |
+| WORKSPACES/tfvars authoring issue | `sdaf-workspace-and-tfvars` |
+| BOM file location / selection | `sdaf-bom-selection` |
+
+### Step 4 — Confirm before retry
+
+The retry safety rules — no `--force` / no `--auto-approve` / no state
+edits / no concurrent execution / do not delete `.progress` markers — are
+enforced by the shipped repo instructions (`.github/copilot-instructions.md`)
+and by each stage skill's own recipe. This triage skill defers to the
+stage-owning skill's retry section rather than restating those rules.
+
+## Special cases (documented)
+
+### Interrupted control-plane removal reports success
+
+`docs/local/troubleshooting.md § Removal is incomplete` and
+`docs/local/07-00-operations.md § Remove resources`: an interrupted
+control-plane removal can exit "successfully" after `step=1` without
+deleting the deployer. Diagnostic path: inspect
+`.sap_deployment_automation`, persisted `step`, library destroy result, and
+remaining deployer state / resources. Do not edit `step` to bypass the
+guard. Removal itself is not implemented as an action-loop skill in this
+wave; the triage skill exists to identify this pattern and point at the
+documented diagnostic path.
+
+### `success` but nothing was deployed
+
+Cross-check the expected artefacts for the stage:
+
+- Control plane: state in library storage account, metadata under
+  `.sap_deployment_automation`, summary written
+  (`docs/local/03-00-control-plane.md § Validate`, `§ Outcome`).
+- Workload zone: `.tfvars` and backend metadata in the state account's
+  `tfvars` container, zone Key Vault deployed
+  (`docs/local/04-00-workload-zone.md § Validate`, `§ Outcome`).
+- SAP system: infra deployed and `<SID>_hosts.yaml` /
+  `sap-parameters.yaml` present
+  (`docs/local/05-00-sap-system.md § Validate`, `§ Outcome`).
+
+If artefacts are missing, treat the "success" as false and route to the
+stage-owning skill.
+
+## Hard rules
+
+- Documented behaviour only (D19). If the symptom does not match a
+  `docs/local/troubleshooting.md` section, a documented `§ Configuration
+  preparation` / `§ Validate` cross-check, or the canonical Government
+  disclaimer in `references/symptom-map.md`, say docs are silent and stop.
+- Do not silently pass a non-zero exit code.
+- Do not narrate benign log noise as a failure without a documented anchor.
+
+## What this skill does NOT do
+
+- Does not deploy or retry directly.
+- Does not repair Terraform state (state repair is out of this wave).
+- Does not restate stage-specific safety rules — the stage skills and
+  `.github/copilot-instructions.md` own those.
+- Does not reason about undocumented failure modes (e.g. Azure Government
+  end-to-end, air-gapped, `ARM_ENVIRONMENT`). The canonical Government
+  disclaimer lives in `references/symptom-map.md`.
+
+## See also
+
+- `sdaf-control-plane-bootstrap`, `sdaf-workload-zone`, `sdaf-sap-system`,
+  `sdaf-workspace-and-tfvars`, `sdaf-bom-selection`.
+- `docs/local/troubleshooting.md`, `docs/local/07-00-operations.md`,
+  `docs/local/04-00-workload-zone.md § Configuration preparation`.

--- a/skills/sdaf-failure-triage/SKILL.md
+++ b/skills/sdaf-failure-triage/SKILL.md
@@ -16,19 +16,18 @@ license: MIT
 ---
 
 # SDAF Failure Triage
-
 Action-loop skill. The entry point for "it broke". Maps observed symptoms to
 the documented cause in `docs/local/troubleshooting.md` (and the stage docs'
-own `§ Validate` / `§ Configuration preparation` sections) and hands off to
-the stage-owning skill. This skill is a **router**, not the owner of any
+own `§ Validate` / `§ Configuration preparation` sections), then hands off
+to the stage-owning skill. This skill is a **router**, not the owner of any
 per-stage fix.
 
 ## When to invoke
 
 Trigger on: "SDAF run failed", "the plan was clean but the run exited 1",
 "success but nothing deployed", "state lock", "unexpected replacement",
-"control plane stopped partway", "generated hosts.yaml missing", "BOM files
-not found", "removal is incomplete", "Ansible playbook failed",
+"control plane stopped partway", "generated hosts.yaml missing", "BOM files not
+found", "removal is incomplete", "Ansible playbook failed",
 "workload-zone private endpoint failure", "workload-zone subnet policy failure", "SDAF
 exit 2".
 
@@ -54,9 +53,10 @@ tfvars (`sdaf-workspace-and-tfvars`), fresh deploy of a stage.
 ### Step 2 — Map the symptom
 
 Walk [`references/symptom-map.md`](references/symptom-map.md), which lists
-every named failure class from `docs/local/troubleshooting.md` (plus the workload-zone private-endpoint / subnet-policy case owned by `sdaf-workload-zone` and anchored in `docs/local/04-00-workload-zone.md § Configuration preparation`) with its
-canonical anchor and the owning skill. Pick the first row whose symptom
-matches the observed signature.
+every named failure class from `docs/local/troubleshooting.md` plus the
+documented workload-zone private-endpoint / subnet-policy case, with the
+owning skill for removal/state/install/HA/media/sovereign routes. Pick the
+first row whose symptom matches the observed signature.
 
 If nothing matches, walk the "canonical 'clean plan reported as failure'
 note" in `references/symptom-map.md`, which walks the stage `§ Validate`
@@ -72,6 +72,13 @@ Route to the stage-owning skill for the actual retry:
 | Control plane | `sdaf-control-plane-bootstrap` |
 | Workload zone (**including** the private-endpoint / subnet-policy workaround) | `sdaf-workload-zone` |
 | SAP system | `sdaf-sap-system` |
+| SAP installation / numbered playbooks | `sdaf-sap-installation` |
+| Media acquisition preconditions / clean downloader path | `sdaf-media-acquisition` |
+| Media archive / checksum / extractor / BOM-processing failures | `sdaf-media-diagnostics` |
+| HA cluster evidence / `crm` / `pcs` / fencing | `sdaf-ha-diagnostics` |
+| Explicit Terraform state lock / import / remove / drift repair | `sdaf-state-management` |
+| Safe teardown / incomplete removal / control-plane step trap | `sdaf-safe-removal` |
+| Azure Government / sovereign-cloud deltas | `sdaf-sovereign-cloud` |
 | WORKSPACES/tfvars authoring issue | `sdaf-workspace-and-tfvars` |
 | BOM file location / selection | `sdaf-bom-selection` |
 
@@ -93,9 +100,8 @@ control-plane removal can exit "successfully" after `step=1` without
 deleting the deployer. Diagnostic path: inspect
 `.sap_deployment_automation`, persisted `step`, library destroy result, and
 remaining deployer state / resources. Do not edit `step` to bypass the
-guard. Removal itself is not implemented as an action-loop skill in this
-wave; the triage skill exists to identify this pattern and point at the
-documented diagnostic path.
+guard. `sdaf-safe-removal` owns the documented diagnostic path and any
+approved retry.
 
 ### `success` but nothing was deployed
 
@@ -118,24 +124,27 @@ stage-owning skill.
 
 - Documented behaviour only (D19). If the symptom does not match a
   `docs/local/troubleshooting.md` section, a documented `§ Configuration
-  preparation` / `§ Validate` cross-check, or the canonical Government
-  disclaimer in `references/symptom-map.md`, say docs are silent and stop.
+  preparation` / `§ Validate` cross-check, or a named owner row in
+  `references/symptom-map.md`, say docs are silent and stop.
 - Do not silently pass a non-zero exit code.
 - Do not narrate benign log noise as a failure without a documented anchor.
 
 ## What this skill does NOT do
 
 - Does not deploy or retry directly.
-- Does not repair Terraform state (state repair is out of this wave).
+- Does not repair Terraform state; `sdaf-state-management` owns that.
 - Does not restate stage-specific safety rules — the stage skills and
   `.github/copilot-instructions.md` own those.
-- Does not reason about undocumented failure modes (e.g. Azure Government
-  end-to-end, air-gapped, `ARM_ENVIRONMENT`). The canonical Government
-  disclaimer lives in `references/symptom-map.md`.
+- Does not replace the documented media/install/HA/removal/sovereign owners.
+- Does not reason about undocumented failure modes (e.g. end-to-end Government
+  beyond `sdaf-sovereign-cloud`, air-gapped, or undocumented `ARM_ENVIRONMENT`
+  flows).
 
 ## See also
 
 - `sdaf-control-plane-bootstrap`, `sdaf-workload-zone`, `sdaf-sap-system`,
-  `sdaf-workspace-and-tfvars`, `sdaf-bom-selection`.
+  `sdaf-sap-installation`, `sdaf-media-acquisition`, `sdaf-media-diagnostics`,
+  `sdaf-ha-diagnostics`, `sdaf-state-management`, `sdaf-safe-removal`,
+  `sdaf-sovereign-cloud`, `sdaf-workspace-and-tfvars`, `sdaf-bom-selection`.
 - `docs/local/troubleshooting.md`, `docs/local/07-00-operations.md`,
   `docs/local/04-00-workload-zone.md § Configuration preparation`.

--- a/skills/sdaf-failure-triage/references/symptom-map.md
+++ b/skills/sdaf-failure-triage/references/symptom-map.md
@@ -1,0 +1,66 @@
+# Failure symptom map (documented)
+
+Companion to `sdaf-failure-triage`. Every row cites
+`docs/local/troubleshooting.md` unless another doc is named. Rows without a
+documented anchor are deliberately absent (D19).
+
+## Symptom → documented anchor → hand-off
+
+| Observed symptom | Documented section | Hand-off |
+|---|---|---|
+| Script fails immediately; env var missing | `§ A required export is missing` | Export vars; re-run the invoking skill |
+| "Parameter file not found" | `§ A parameter file is not found` | Re-run from the tfvars' directory; basename only |
+| Terraform / Azure CLI missing | `§ Terraform or Azure CLI is not found` | `sdaf-readiness-check` (`docs/local/02-00-prepare-execution-environment.md § Readiness verification` step 1) |
+| Azure auth / authorization failure | `§ Azure authentication or authorization fails` | Fix identity outside SDAF; do not grant broad roles |
+| Host cannot reach Key Vault / Storage | `§ The execution host cannot reach Key Vault or Storage` | `sdaf-readiness-check` (`§ Readiness verification` step 3) |
+| Terraform state lock | `§ Terraform reports a state lock` | Confirm no concurrent run; do not force-unlock |
+| Unexpected replacement in plan | `§ Terraform proposes unexpected replacement` | Compare tfvars, provider lock, keys, IDs; stop before approval |
+| Control plane stopped partway through | `§ A control-plane run stopped partway through` | `sdaf-control-plane-bootstrap` — use `--recover` only after state agrees |
+| Generated `<SID>_hosts.yaml` / `sap-parameters.yaml` missing | `§ Generated Ansible files are missing` | `sdaf-sap-system` — rerun same command |
+| BOM files not found | `§ BOM files are not found` | `sdaf-bom-selection` — check `BOM_CATALOG` |
+| Workload-zone deploy fails with a private-endpoint / subnet-policy error | `docs/local/04-00-workload-zone.md § Configuration preparation` (owns the exact error string and prescribed setting for the scope it documents) | **`sdaf-workload-zone` — owns the decision boundary** |
+| Ansible playbook fails | `§ An Ansible playbook fails` | Inspect first failed task; rerun the smallest applicable playbook |
+| Removal reports success but resources remain | `§ Removal is incomplete` | Do not edit state; follow the section's diagnostic path |
+
+## Canonical Government / sovereign-cloud disclaimer
+
+**One canonical statement for the whole plugin.** Sibling skills point here
+rather than repeating it.
+
+The shipped local docs cover:
+
+- The Azure Government private-endpoint / subnet-policy workaround
+  (`docs/local/04-00-workload-zone.md § Configuration preparation`, owned by
+  `sdaf-workload-zone`).
+- The Government-region codes (`docs/region-codes.md § Supported regions`
+  includes `usgovarizona`, `usgovtexas`, `usgovvirginia`).
+
+They do **not** cover an end-to-end Azure Government deployment procedure —
+no shipped section describes `ARM_ENVIRONMENT` end-to-end, Government DNS
+zone blocks, Government-specific default VM sizes, or Government identity
+setup. Per D19 (documented-only) and open decision D19a, no skill in this
+plugin will invent Government-specific behaviour. When an operator asks for
+a procedure that fits none of the two documented cases above, say docs are
+silent and stop.
+
+## Canonical "clean plan reported as failure" note
+
+There is no shipped section named "clean plan reported as failure". When an
+operator reports this symptom:
+
+- Walk the stage's `§ Validate` and `§ Outcome` checks first
+  (`docs/local/03-00-control-plane.md`, `04-00-workload-zone.md`,
+  `05-00-sap-system.md`).
+- Then check `§ Terraform proposes unexpected replacement` and (for the
+  control plane) `§ A control-plane run stopped partway through`.
+- If neither matches, say docs are silent on a general "false failure on a
+  clean plan" class and stop.
+
+## Deliberately absent (docs silent)
+
+- A general shipped section for "false failure on a clean plan" (see the
+  note above for what to do instead).
+- Azure Government end-to-end first-run failure modes (see the canonical
+  disclaimer above).
+- Air-gapped / offline / proxy-blocked flows.
+- Any "benign log noise" catalogue.

--- a/skills/sdaf-failure-triage/references/symptom-map.md
+++ b/skills/sdaf-failure-triage/references/symptom-map.md
@@ -13,35 +13,32 @@ documented anchor are deliberately absent (D19).
 | Terraform / Azure CLI missing | `§ Terraform or Azure CLI is not found` | `sdaf-readiness-check` (`docs/local/02-00-prepare-execution-environment.md § Readiness verification` step 1) |
 | Azure auth / authorization failure | `§ Azure authentication or authorization fails` | Fix identity outside SDAF; do not grant broad roles |
 | Host cannot reach Key Vault / Storage | `§ The execution host cannot reach Key Vault or Storage` | `sdaf-readiness-check` (`§ Readiness verification` step 3) |
-| Terraform state lock | `§ Terraform reports a state lock` | Confirm no concurrent run; do not force-unlock |
+| Terraform state lock, reviewed `state list/import/remove`, or remote-state drift | `§ Terraform reports a state lock`; `docs/local/07-00-operations.md § Manage state safely` | `sdaf-state-management` |
 | Unexpected replacement in plan | `§ Terraform proposes unexpected replacement` | Compare tfvars, provider lock, keys, IDs; stop before approval |
 | Control plane stopped partway through | `§ A control-plane run stopped partway through` | `sdaf-control-plane-bootstrap` — use `--recover` only after state agrees |
 | Generated `<SID>_hosts.yaml` / `sap-parameters.yaml` missing | `§ Generated Ansible files are missing` | `sdaf-sap-system` — rerun same command |
-| BOM files not found | `§ BOM files are not found` | `sdaf-bom-selection` — check `BOM_CATALOG` |
+| BOM files not found before or during the downloader path | `§ BOM files are not found` | `sdaf-media-acquisition` — check `BOM_CATALOG`, the four BOM keys, and the reviewed samples checkout |
+| Downloader `404`, checksum mismatch, `SAPCAR` / `.EXE` extract failure, or missing `.progress/bom-processing-done` | `docs/local/06-00-software-and-installation.md § Download software`; `§ Run configuration and installation` | `sdaf-media-diagnostics` |
 | Workload-zone deploy fails with a private-endpoint / subnet-policy error | `docs/local/04-00-workload-zone.md § Configuration preparation` (owns the exact error string and prescribed setting for the scope it documents) | **`sdaf-workload-zone` — owns the decision boundary** |
-| Ansible playbook fails | `§ An Ansible playbook fails` | Inspect first failed task; rerun the smallest applicable playbook |
-| Removal reports success but resources remain | `§ Removal is incomplete` | Do not edit state; follow the section's diagnostic path |
+| Numbered install playbook fails after media is staged | `§ An Ansible playbook fails` | `sdaf-sap-installation` — capture the first failed numbered playbook, host, and `.progress` marker |
+| Live or recent HA cluster is unhealthy (`crm` / `pcs`, fencing, placement, HCMT evidence) | `docs/local/07-10-quality-assurance.md`; shipped Pacemaker/QA roles | `sdaf-ha-diagnostics` |
+| Removal reports success but resources remain | `§ Removal is incomplete` | `sdaf-safe-removal` — do not edit state; follow the section's diagnostic path |
+| Azure Government / sovereign-cloud values, `AADSTS900382`, Government DNS zones, or Government-only workload-zone policy deltas | `docs/region-codes.md § Supported regions`; `docs/local/04-00-workload-zone.md § Configuration preparation`; `skills/sdaf-sovereign-cloud/references/documented-cloud-boundaries.md` | `sdaf-sovereign-cloud` |
 
-## Canonical Government / sovereign-cloud disclaimer
+## Sovereign-cloud hand-off
 
-**One canonical statement for the whole plugin.** Sibling skills point here
-rather than repeating it.
+`sdaf-sovereign-cloud` is the canonical owner for the currently documented
+Azure Government deltas:
 
-The shipped local docs cover:
+- Government region codes (`usgovarizona`, `usgovtexas`, `usgovvirginia`);
+- Government-only GitHub OIDC / `ARM_ENVIRONMENT` / `AZURE_ENVIRONMENT` /
+  `AZURE_AUDIENCE` combinations and their documented failure signatures;
+- Government `dns_zone_names` handling; and
+- the Government-only workload-zone private-endpoint policy workaround.
 
-- The Azure Government private-endpoint / subnet-policy workaround
-  (`docs/local/04-00-workload-zone.md § Configuration preparation`, owned by
-  `sdaf-workload-zone`).
-- The Government-region codes (`docs/region-codes.md § Supported regions`
-  includes `usgovarizona`, `usgovtexas`, `usgovvirginia`).
-
-They do **not** cover an end-to-end Azure Government deployment procedure —
-no shipped section describes `ARM_ENVIRONMENT` end-to-end, Government DNS
-zone blocks, Government-specific default VM sizes, or Government identity
-setup. Per D19 (documented-only) and open decision D19a, no skill in this
-plugin will invent Government-specific behaviour. When an operator asks for
-a procedure that fits none of the two documented cases above, say docs are
-silent and stop.
+If the operator asks for an end-to-end Government, China, German, or other
+sovereign procedure beyond those cited deltas, `sdaf-sovereign-cloud`
+itself stops and says the current sources are silent.
 
 ## Canonical "clean plan reported as failure" note
 
@@ -60,7 +57,7 @@ operator reports this symptom:
 
 - A general shipped section for "false failure on a clean plan" (see the
   note above for what to do instead).
-- Azure Government end-to-end first-run failure modes (see the canonical
-  disclaimer above).
+- Undocumented sovereign-cloud procedures beyond the published
+  `sdaf-sovereign-cloud` boundaries.
 - Air-gapped / offline / proxy-blocked flows.
 - Any "benign log noise" catalogue.

--- a/skills/sdaf-ha-diagnostics/SKILL.md
+++ b/skills/sdaf-ha-diagnostics/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: sdaf-ha-diagnostics
+description: >
+  Diagnose a live or recently failed SDAF high-availability cluster without
+  changing cluster state. Start read-first: capture `crm status full` or
+  `pcs status --full`, inspect SBD or fencing evidence, confirm current
+  resource placement, and reuse existing quality-assurance or HCMT artifacts.
+  Grounded in `docs/local/07-10-quality-assurance.md`, the shipped Pacemaker
+  role vars/tasks, and the SAP Automation QA setup role. Use when a user says
+  "diagnose my HANA failover", "crm status", "pcs status", "check fencing",
+  "why is the SCS/ERS cluster unhealthy", "offline_validation/cib", or
+  "review an HCMT result zip". Do NOT use for pre-deploy topology or design
+  choices (see `sdaf-ha-topology`), fresh installation/deploy, or disruptive
+  failover/fencing exercises (see `sdaf-quality-assurance`).
+allowed-tools: shell
+license: MIT
+---
+
+# SDAF HA Diagnostics
+
+Action-loop skill. Owns **read-first, safe diagnostics** for a live or
+recently failed SDAF HA cluster. It does not choose the topology, move
+resources, clean up stonith history, or invent a recovery procedure.
+
+For the exact evidence ladder, current-code anchors, and stop-list, read
+[`references/cluster-evidence.md`](references/cluster-evidence.md).
+
+## When to invoke
+
+Trigger on: "diagnose HA cluster", "HANA failover failed", "crm status",
+"pcs status", "check fencing", "resource placement", "cluster unhealthy",
+"offline_validation/cib", "HCMT result", "SCS/ERS failover", or "read the
+current Pacemaker state".
+
+Do NOT trigger on:
+
+- pre-deploy design questions such as SBD vs Azure fence agent, ANF vs AFS,
+  ANGI eligibility, distro choice, or scale-out design — route to
+  `sdaf-ha-topology`;
+- requests to run online failover, crash, fencing, or blocked-network tests —
+  route to `sdaf-quality-assurance`;
+- a broader SDAF run failure whose primary symptom is the stage execution
+  itself — route to `sdaf-failure-triage`.
+
+## Preconditions
+
+Ask for the layer under test (HANA DB HA or SCS/ERS HA), OS family, evidence
+type (live cluster, captured bundle, or prior test run), and any existing
+`crm` / `pcs` output, QA reports, execution logs, or HCMT bundles. If cluster
+state was already changed manually, preserve who changed what and when before
+diagnosing anything else.
+
+## Recipe
+
+### Step 1 — classify the request before touching the cluster
+
+Pick one lane:
+
+1. **Live read-only diagnosis** — explain current cluster state from status,
+   placement, and existing logs.
+2. **Captured artefact review** — read an existing `offline_validation` bundle,
+   QA report, or HCMT result without acting on the running cluster.
+3. **Framework-run or disruptive validation** — route to
+   `sdaf-quality-assurance`; the online functional tests stop resources, move
+   groups, fence nodes, and crash processes.
+4. **Topology/design** — route to `sdaf-ha-topology`.
+5. **Stage/run failure** — route to `sdaf-failure-triage`.
+
+### Step 2 — collect read-only evidence first
+
+Use the evidence ladder in
+[`references/cluster-evidence.md`](references/cluster-evidence.md). Minimum
+safe evidence is:
+
+- OS-specific status: `crm status full` on SUSE or `pcs status --full` on
+  Red Hat;
+- current placement evidence such as `crm_resource --locate` for SCS/ERS;
+- existing fencing, SBD, or HANA hook-verification evidence;
+- existing QA, offline `cib`, and HCMT artefacts.
+
+Preserve raw output, host, and timestamp. Do not paraphrase away the cluster's
+own wording.
+
+### Step 3 — map the evidence to the right owner
+
+- **Stay in this skill** for read-only interpretation of current Pacemaker
+  state, placement, fencing/SBD evidence, hook traces, or existing QA/HCMT
+  artefacts.
+- **Route to `sdaf-quality-assurance`** to run configuration checks, offline HA
+  validation from captured `offline_validation/<host>/cib` bundles, or
+  disruptive online HA exercises in an approved maintenance window.
+- **Route to `sdaf-failure-triage`** for failed SDAF runs or install-phase
+  assertions such as missing fencing SPN details, cluster password, or
+  required clustering scripts.
+- **Route to `sdaf-ha-topology`** when the question is what the cluster
+  *should* look like rather than what the current evidence says.
+
+### Step 4 — stop before state changes
+
+The current codebase contains state-changing cluster actions in validation and
+post-provision tasks. This skill is **not** the place to run them.
+
+The explicit stop-list lives in the reference. From this skill do **not**
+execute `crm/pcs resource move`, `stonith_admin --cleanup`, role-defined
+cluster cleanup, `StartService`, `StartSystem ALL`, or online functional HA
+tests. If the user asks for recovery or failover action, stop at evidence
+collection and routing; do not invent or approve a repair step.
+
+## Hard rules
+
+- Read-first only. Start with existing cluster status, logs, and artefacts.
+- Documented/current-code only (D19). If the docs or shipped roles do not
+  describe a diagnostic path, say so and stop.
+- Do not invent recovery commands, failover steps, or cleanup procedures.
+- Keep topology and design separate; route those questions to
+  `sdaf-ha-topology`.
+- Treat disruptive validation as a separate workflow owned by
+  `sdaf-quality-assurance`.
+
+## What this skill does NOT do
+
+- Does not choose SBD vs Azure fence agent, storage, distro, ANGI, or
+  scale-out design.
+- Does not build, rebuild, reinstall, or actively fail over the cluster.
+- Does not treat HCMT as the first diagnostic step; it only reuses existing
+  HCMT artefacts if they are already present.
+
+## See also
+
+- `sdaf-ha-topology`
+- `sdaf-quality-assurance`
+- `sdaf-failure-triage`
+- `docs/local/07-10-quality-assurance.md`

--- a/skills/sdaf-ha-diagnostics/references/cluster-evidence.md
+++ b/skills/sdaf-ha-diagnostics/references/cluster-evidence.md
@@ -1,0 +1,29 @@
+# HA diagnostic evidence
+
+Collect evidence before proposing any state-changing action.
+
+## Cluster status
+
+| OS family | Read-only status command |
+| --- | --- |
+| SUSE | `crm status full` |
+| Red Hat | `pcs status --full` |
+
+Preserve the complete output, timestamps, node names, failed actions, resource
+placement, fencing history, and quorum state.
+
+## SAP and database evidence
+
+- Record the SAP SID and instance layout.
+- Capture current primary/secondary roles and replication status.
+- Capture the first failed operation and its timestamp.
+- Retain the SDAF QA report and execution log when available.
+- Confirm whether the request is diagnosis or an approved disruptive test.
+
+## Stop conditions
+
+Stop before cleanup, migration, fencing, resource moves, or service restarts.
+Those actions require the documented owner workflow and explicit approval.
+
+Sources: `docs/local/07-10-quality-assurance.md`,
+`docs/local/troubleshooting.md`, and `docs/supportability.md`.

--- a/skills/sdaf-ha-topology/SKILL.md
+++ b/skills/sdaf-ha-topology/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: sdaf-ha-topology
+description: >
+  Choose the documented SDAF high-availability design before SAP-system
+  deployment. Use when a user asks which HA topology to deploy, whether to use
+  AFA or SBD, AFS or ANF, HANA scale-up or scale-out, whether ANGI is allowed,
+  or which HA inputs must be set before deployment. Ground answers in the
+  current support matrix, Ansible roles, sample tfvars, and validation logic.
+  Do NOT use for live cluster diagnosis (sdaf-ha-diagnostics) or for running
+  the installers (sdaf-sap-installation).
+allowed-tools: shell
+license: MIT
+---
+
+# SDAF HA Topology
+
+Context-primer for **pre-deploy** HA design. Keep this skill short and route to
+[`references/topology-decision-guide.md`](references/topology-decision-guide.md)
+for the detailed OS/DB/storage matrices, sample-backed examples, and source
+map.
+
+## When to invoke
+
+Trigger on:
+
+- "Which SDAF HA topology should I use?"
+- "AFA or shared-disk / iSCSI quorum?"
+- "AFS or ANF for this SAP HA design?"
+- "Should HANA stay scale-up or move to scale-out?"
+- "Can I enable SAPHanaSR-angi on this OS release?"
+- "What HA inputs do I need in system tfvars before deployment?"
+
+Do NOT trigger on:
+
+- a live cluster failure, fencing event, or `crm` / `pcs` diagnosis — use
+  `sdaf-ha-diagnostics`
+- running numbered install stages or partial-install recovery — use
+  `sdaf-sap-installation`
+- generic SAP-system Terraform deployment without an HA design question — use
+  `sdaf-sap-system`
+
+## Preconditions
+
+Before answering, know or ask for:
+
+- target operating system and version
+- target database platform
+- whether HA is required for central services, the database tier, or both
+- whether the question is design-time or an already-deployed cluster problem
+
+## Decision loop
+
+1. **Confirm the support boundary first.** Start with
+   [`docs/supportability.md`](../../docs/supportability.md). A listed OS,
+   database, or storage option does **not** make every cross-combination valid.
+   If the requested combination is not explicitly backed by current docs and
+   code, say docs are silent and stop.
+2. **Split the question into layers.** Treat HA as separate design choices for:
+   - SAP central services: `scs_server_count`, `scs_high_availability`,
+     `scs_cluster_type`
+   - database tier: `database_high_availability`, `database_cluster_type`, and
+     for HANA `database_HANA_use_scaleout_scenario`
+3. **Confirm the documented platform path.** Use
+   `docs/supportability.md` and the current SAP-system input documentation.
+   Do not infer that every listed database has an SDAF-managed HA topology.
+4. **Choose quorum / fencing deliberately.** The tfvar contract exposes `AFA`,
+   `ASD`, and `ISCSI` for both SCS and DB tiers. AFA needs fencing credentials
+   unless `use_msi_for_clusters = true`. ASD / ISCSI take the SBD path, so the
+   OS release must satisfy the current role gates before cluster creation.
+5. **Choose shared storage deliberately.** Use current docs and mount logic:
+   - `AFS` for shared SAP file systems only
+   - `ANF` for applicable shared and database file systems
+   - custom `NFS` as organization-owned design, not a Microsoft-owned reference
+6. **Handle HANA-only forks explicitly.** For HANA, decide scale-up vs
+   scale-out and, separately, whether `use_hanasr_angi` is allowed on the
+   target OS. Do not apply scale-out or ANGI guidance to Oracle, DB2, ASE, or
+   SQL Server.
+7. **Route rather than guess.** If the user is asking how to deploy the chosen
+   design, hand off to `sdaf-sap-system`. If the user is asking why an existing
+   cluster failed, hand off to `sdaf-ha-diagnostics`.
+
+## Validate before deployment
+
+Use the documented SAP-system validation step as the pre-deploy gate. For HA
+answers, make sure the selected path can supply:
+
+- cluster-aware base inputs: `database_high_availability`,
+  `database_cluster_type`, `scs_high_availability`, `scs_cluster_type`,
+  `use_msi_for_clusters`, `platform`
+- for SCS HA: shared storage, `NFS_provider`, and central-services
+  load-balancer inputs
+- for AFA without MSI: fencing client ID, password, subscription, and tenant
+- for HANA / DB2 AFA database HA: the database load-balancer IP
+- for HANA scale-out: standby / observer / shared-storage inputs that match the
+  selected path
+
+## Hard safety rules
+
+- Do not infer support from one sample, one BOM, or one tfvar alone.
+- Do not promise an ASE database-HA topology from the current DB-HA playbook.
+- Do not apply HANA-only scale-out or ANGI guidance to non-HANA databases.
+- Do not use Azure Files NFS as a database-file-system answer.
+- Do not generalize Pacemaker validation guidance to Windows clustering.
+- If docs, samples, and current roles disagree, stop and call out the mismatch.
+
+## Hand-off
+
+- deploy the chosen infrastructure path -> `sdaf-sap-system`
+- run OS / DB / SAP install stages -> `sdaf-sap-installation`
+- diagnose a live cluster or fencing issue -> `sdaf-ha-diagnostics`
+- run post-deploy HA checks -> `sdaf-quality-assurance`

--- a/skills/sdaf-ha-topology/references/topology-decision-guide.md
+++ b/skills/sdaf-ha-topology/references/topology-decision-guide.md
@@ -1,0 +1,30 @@
+# HA topology operator guide
+
+Start with `docs/supportability.md`. A supported operating system, database, or
+storage option does not make every combination valid.
+
+## Decisions to confirm
+
+1. Is HA required for SAP central services, the database, or both?
+2. Which database platform and topology are being deployed?
+3. For HANA, is the design scale-up or scale-out?
+4. Which documented fencing/quorum option is approved?
+5. Which documented shared-storage option fits the workload?
+6. Does the target OS version satisfy the selected HA design?
+
+## Published boundaries
+
+- Azure Files NFS is for applicable shared SAP file systems, not database files.
+- Azure NetApp Files can support applicable shared and database file systems.
+- Custom NFS remains an organization-owned design.
+- HANA-specific scale-out or ANGI guidance does not apply to other databases.
+- Do not promise an HA topology where current support documentation is silent.
+
+## Before deployment
+
+Run the documented SAP-system validation step and confirm the selected
+configuration provides all required cluster, fencing, load-balancer, and
+shared-storage inputs.
+
+For deployment, hand off to `sdaf-sap-system`. For an existing unhealthy
+cluster, hand off to `sdaf-ha-diagnostics`.

--- a/skills/sdaf-media-acquisition/SKILL.md
+++ b/skills/sdaf-media-acquisition/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: sdaf-media-acquisition
+description: >
+  Acquire approved SAP media into the SDAF library after SAP-system
+  infrastructure exists. Drives local `deploy/ansible/download_menu.sh` per
+  `docs/local/06-00-software-and-installation.md § Download software`,
+  enforces the documented `BOM_CATALOG` root and the four required
+  `sap-parameters.yaml` BOM keys (`application_bom_name`,
+  `database_bom_name`, `sap_kernel_bom_name`, `save_bom_as`), and explains
+  the documented download and validation flow. Use for
+  "download SAP media", "run download_menu.sh", "acquire software into the
+  library", "BOM Downloader", "BOM_CATALOG", or
+  "assemble application/database/kernel BOMs for download". Do NOT use to
+  choose a BOM, troubleshoot a failed download, or run installation
+  playbooks.
+allowed-tools: shell
+license: MIT
+---
+
+# SDAF Media Acquisition
+
+Action-loop skill. Acquires approved SAP media into the library after
+SAP-system infrastructure exists. The local operator path is documented in
+`docs/local/06-00-software-and-installation.md`; shared downloader behavior
+is described in the same operator guide.
+
+## When to invoke
+
+Trigger on: "download SAP media", "acquire software into the library",
+"download_menu.sh", "BOM Downloader", "BOM_CATALOG", or
+"assemble application/database/kernel BOMs for download".
+Do NOT trigger on: choosing a BOM (`sdaf-bom-selection`), troubleshooting a
+failed or mismatched download (`sdaf-media-diagnostics`), or install playbooks.
+
+## Preconditions
+
+- SAP-system infrastructure already completed; `sap-parameters.yaml` and
+  `<SID>_hosts.yaml` exist in the system directory
+  (`docs/local/06-00-software-and-installation.md § Before you begin`; `docs/local/05-00-sap-system.md § Validate`).
+- SSH connectivity to the inventory hosts, Key Vault-generated credentials, SAP
+  download credentials, and library capacity are confirmed
+  (`docs/local/06-00-software-and-installation.md § Before you begin`).
+- The BOM choice is already reviewed; this skill does not decide product versus
+  component BOMs (`sdaf-bom-selection`; `sap-automation-samples/docs/02-00-bom-samples.md § Select and run a BOM`).
+
+## Decision: which download input shape applies?
+
+`docs/local/06-00-software-and-installation.md § Inputs and BOM ownership` is
+explicit:
+- `BOM_CATALOG` must point at the samples checkout root that contains sibling
+  `SAP/` and `BOM/` directories.
+- Local `download_menu.sh` does **not** keep the Terraform-generated
+  `bom_base_name`. It reads these four keys from `sap-parameters.yaml` and
+  constructs the effective BOM name itself:
+
+```yaml
+application_bom_name: <APPLICATION_BOM>
+database_bom_name:    <DATABASE_BOM>
+sap_kernel_bom_name:  <KERNEL_BOM>
+save_bom_as:          <COMBINED_BOM_NAME>
+```
+
+Keep these values in the exact format documented by
+`§ Inputs and BOM ownership`. The automation validates the application,
+database, kernel, and output-name combination before download.
+
+## Recipe
+
+### Step 1 — Confirm the catalog root and component names
+
+From the SAP-system directory, confirm the catalog root exactly as the local
+doc requires:
+
+```bash
+cd "$CONFIG_REPO_PATH/WORKSPACES/SYSTEM/<SAP_SYSTEM>"
+test -d "$BOM_CATALOG/SAP"
+test -d "$BOM_CATALOG/BOM"
+```
+
+Then re-read `sap-parameters.yaml` once. For the local menu path, all four
+BOM keys above must be present and must match actual samples directories/files.
+
+### Step 2 — Run the documented local acquisition flow
+
+Start the local wrapper exactly per
+`docs/local/06-00-software-and-installation.md § Download software`:
+
+```bash
+"$SAP_AUTOMATION_REPO_PATH/deploy/ansible/download_menu.sh"
+```
+
+Then select **BOM Downloader**. The documented path requires
+`sap-parameters.yaml` in the current directory and `BOM_CATALOG` in the
+environment.
+
+### Step 3 — Validate before installation
+
+Do not continue into `configuration_menu.sh` until both doc-level checks pass
+(`docs/local/06-00-software-and-installation.md § Validate`):
+- the downloader reports success for every required archive; and
+- the SAP library contains the expected software.
+Also keep the samples commit and selected BOM names with the run record
+(`sap-automation-samples/docs/02-00-bom-samples.md § Validate`).
+
+## If the run stops or rejects the input
+
+- `sap-parameters.yaml` missing, `BOM_CATALOG` unset, or `BOM_CATALOG` not a
+  directory: fix the local wrapper precondition and rerun
+  (`deploy/ansible/download_menu.sh`;
+  `docs/local/troubleshooting.md § BOM files are not found`).
+- Incompatible application/database/kernel combination: go back to
+  `sdaf-bom-selection` and review the documented compatibility fields.
+- Archive, checksum, or download-service failures belong to
+  `sdaf-media-diagnostics`, not this skill.
+
+## Hard rules
+
+- Documented behaviour only (D19). Do not invent alternate download
+  commands, proxy/offline procedures, or compatibility matrices (`docs/PLUGINS.md § Ground rules and exclusions`).
+- Do not point `BOM_CATALOG` at a single BOM directory.
+- Do not bypass checksum or compatibility failures
+  (`sap-automation-samples/docs/02-00-bom-samples.md § If it fails`).
+- Do not start installation until the downloader reports success for the
+  required archives.
+
+## See also
+
+- `sdaf-bom-selection`, `sdaf-sap-system`, `sdaf-media-diagnostics`.
+- `docs/local/06-00-software-and-installation.md`,
+  `docs/local/troubleshooting.md § BOM files are not found`,
+  `sap-automation-samples/docs/02-00-bom-samples.md`,
+  [`.github/copilot-instructions.md`](../../.github/copilot-instructions.md).

--- a/skills/sdaf-media-diagnostics/SKILL.md
+++ b/skills/sdaf-media-diagnostics/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: sdaf-media-diagnostics
+description: >
+  Diagnose SDAF software-download and BOM-processing failures after a BOM is
+  already selected. Covers the documented local media path, SAP download,
+  storage-account upload/download, checksum validation, and
+  `SAPCAR` / `.EXE` extraction. Use when a user says "download_menu failed",
+  "BOM downloader 404", "missing archive", "checksum mismatch", "SAPCAR
+  failed", "bom-processing-done missing", or "my SPS07 media run can't find
+  a file". Do NOT use to choose a BOM (see `sdaf-bom-selection`), to run a
+  clean first-time media download with no failure, or to diagnose a later
+  non-media install failure.
+allowed-tools: shell
+license: MIT
+---
+
+# SDAF Media Diagnostics
+
+Action-loop skill. Diagnoses failures on the local software path after the
+operator already chose the BOM and started either `download_menu.sh` or BOM
+processing from `configuration_menu.sh`. Grounded in
+`docs/local/06-00-software-and-installation.md`,
+`docs/local/troubleshooting.md`, and `docs/PLUGINS.md`. No invented recovery
+paths.
+
+## When to invoke
+
+Trigger on: "download_menu failed", "BOM downloader 404", "missing archive",
+"checksum mismatch", "SAPCAR failed", "bom-processing-done missing",
+"SPS07 media file missing".
+
+Do NOT trigger on: choosing a BOM/version, running a clean first download, or
+a later DB/SAP install failure after media staging.
+
+## Preconditions
+
+- Collect the exact failing command or menu step, exit code, and last 200 lines
+  of output.
+- Identify whether the failure happened in:
+  - the documented media acquisition step; or
+  - BOM processing during configuration and installation.
+- If the operator only says "SPS07" or similar product/version words, ask
+  whether this is a BOM-choice question or a concrete failing file.
+
+## Recipe
+
+### Step 1 — Classify the failing lane
+
+- **Acquisition lane** — use
+  `docs/local/06-00-software-and-installation.md § Download software` and its
+  documented inputs.
+- **Processing lane** — use
+  `§ Run configuration and installation` and its safe-retry guidance.
+- If the failure is in a later numbered install playbook rather than BOM
+  acquisition / processing, stop and route to `sdaf-sap-installation`
+  or `sdaf-failure-triage` if the install-stage owner is still ambiguous.
+
+### Step 2 — Walk the symptom map
+
+Use [`references/media-symptom-map.md`](references/media-symptom-map.md) and
+match the *exact* signature before suggesting any retry. The map covers:
+
+- missing `sap-parameters.yaml` / `BOM_CATALOG`
+- BOM not found
+- `s_user` / `s_password` or storage-account auth failures
+- archive `404` / missing blob
+- checksum mismatch
+- `SAPCAR` / `.EXE` extraction failures
+- missing `.progress/bom-processing-done`
+- offline / air-gapped asks that the repo does not document
+
+If nothing matches, say the shipped docs/code do not describe this media
+failure and stop.
+
+### Step 3 — Re-read the current BOM and documented inputs
+
+The authoritative inputs are the current `sap-parameters.yaml`, the selected
+BOM YAML, and the operator documentation:
+
+- `docs/local/06-00-software-and-installation.md § Inputs and BOM ownership` —
+  `BOM_CATALOG` must point at the samples root; `download_menu.sh` requires
+  `application_bom_name`, `database_bom_name`, `sap_kernel_bom_name`, and
+  `save_bom_as`.
+- `docs/local/06-00-software-and-installation.md § Configuration preparation`
+  — review the current BOM's URLs, archive names, checksums, and target
+  product versions.
+Do not rename files, replace URLs, or invent checksums from memory.
+
+### Step 4 — Retry only the minimal documented step
+
+- For acquisition-lane failures, fix the matched precondition or BOM/input
+  issue, then rerun **BOM Downloader** from `download_menu.sh`.
+- For processing-lane failures, rerun the smallest applicable playbook from
+  `configuration_menu.sh`;
+  `docs/local/06-00-software-and-installation.md § Safe retry` says to review
+  the failed numbered playbook, output, and progress marker first.
+- Use the documented completion evidence; do not create or delete progress
+  markers manually.
+
+## Special boundary: SPS-level questions
+
+The local docs tell operators to review BOM names, URLs, archive names,
+checksums, and target product versions, but they do **not** ship an
+SPS07-specific troubleshooting runbook. Use this rule:
+
+- "Which BOM/version do I need for SPS07?" → `sdaf-bom-selection`.
+- "The already-selected SPS07 media set is failing with a missing archive,
+  checksum, or extract error" → stay here and work the exact failing file/log
+  through the symptom map.
+
+## Hard rules
+
+- Documented behaviour only. `docs/PLUGINS.md` explicitly says air-gapped /
+  offline media is outside shipped guidance.
+- Do not invent new BOM contents, replacement URLs, checksums, or SPS mappings.
+- Do not treat a generic later install failure as a media problem without a
+  matching acquisition / processing anchor.
+- Do not delete `.progress` markers or storage blobs merely to force a rerun.
+
+## See also
+
+- `sdaf-bom-selection` — choose product vs component BOMs and compatibility
+  guardrails.
+- `sdaf-media-acquisition` — clean first-time media download once the failure
+  boundary is gone.
+- `sdaf-failure-triage` — non-media or ambiguous stage failures.
+- `docs/local/06-00-software-and-installation.md`,
+  `docs/local/troubleshooting.md`,
+  `docs/PLUGINS.md`.

--- a/skills/sdaf-media-diagnostics/references/media-symptom-map.md
+++ b/skills/sdaf-media-diagnostics/references/media-symptom-map.md
@@ -1,0 +1,17 @@
+# Media symptom map
+
+| Observed symptom | Operator check |
+| --- | --- |
+| `sap-parameters.yaml` missing | Run from the SAP-system directory and confirm generated files exist. |
+| `BOM_CATALOG` missing or invalid | Point it at the samples root containing `SAP/` and `BOM/`. |
+| BOM not found | Recheck the four BOM keys and matching sample names. |
+| SAP download credentials missing | Restore approved credentials; do not keep retrying. |
+| Storage authentication failure | Confirm the intended storage account, container, and authentication method. |
+| Archive `404` | Compare the selected BOM archive name with the library and download output. |
+| Checksum mismatch | Compare the reviewed BOM checksum with the actual archive; never invent a checksum. |
+| `SAPCAR`, `.SAR`, or `.EXE` extraction failure | Preserve stderr and verify the archive named by the BOM. |
+| BOM processing incomplete | Review the first failed processing step and its documented completion evidence. |
+
+Use `docs/local/06-00-software-and-installation.md` and
+`docs/local/troubleshooting.md`. If the signature is not documented, stop
+rather than infer an internal recovery path.

--- a/skills/sdaf-orientation-and-surface/SKILL.md
+++ b/skills/sdaf-orientation-and-surface/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: sdaf-orientation-and-surface
+description: >
+  Orient a newcomer to the SAP Deployment Automation Framework (SDAF): explain
+  the spine (control plane → workload zone → SAP system → software → install →
+  operate/remove), summarise the three execution surfaces (Local, Azure DevOps,
+  GitHub Actions), and print the install command for the matching surface
+  bootstrap plugin — as documented in this repository's `docs/PLUGINS.md` —
+  so the operator can run it manually. Use when a user says "what is SDAF",
+  "where do I start with SDAF", "which surface should I use", "SDAF Local vs
+  ADO vs GitHub", "how do I install the SDAF ADO/GitHub plugin", or "I'm new
+  to SDAF". Do NOT use for readiness pre-flight (see sdaf-readiness-check),
+  workspace/tfvars layout (see sdaf-workspace-and-tfvars), or troubleshooting
+  a failed run (see sdaf-failure-triage).
+allowed-tools: shell
+license: MIT
+---
+
+# SDAF Orientation and Surface Choice
+
+Primer skill. Answers *"what is SDAF and which execution surface should I use?"*
+and hands off to the next action-loop skill. Grounded in the shipped docs; no
+inferred procedures.
+
+## When to invoke
+
+Trigger on: "what is SDAF", "where do I start", "SDAF surface", "Local vs ADO
+vs GitHub", "SDAF plugin install command", "how do I install azure-sap-automation-devops",
+"which surface for SDAF".
+
+Do NOT trigger on: pre-flight readiness checks, tfvars/WORKSPACES authoring,
+BOM selection, failed-run triage. Route to the sibling skill instead.
+
+## The spine (order is enforced)
+
+Docs enforce this order for every surface:
+
+1. **Control plane** — deployer + SAP library, establishes remote Terraform
+   state (`docs/local/03-00-control-plane.md § Outcome`, `§ What the
+   automation does`).
+2. **Workload zone** — landscape / networking / zone Key Vault; reads
+   control-plane state (`docs/local/04-00-workload-zone.md § Outcome`).
+3. **SAP system** — VMs + inventory; reads deployer + landscape state
+   (`docs/local/05-00-sap-system.md § Outcome`).
+4. **Software download** — needs the workload-zone Key Vault credentials
+   (`docs/local/06-00-software-and-installation.md § Download software`).
+5. **Install** — OS + DB + SAP via Ansible playbooks
+   (`docs/local/06-00-software-and-installation.md § Run configuration and installation`).
+6. **Operate / recover / remove** — reverse dependency order for removal
+   (`docs/local/07-00-operations.md § Remove resources`).
+
+Never let a stage run before the prior one completed
+(`docs/local/README.md § Complete the journey`).
+
+## The three execution surfaces
+
+Docs explicitly frame the surfaces as "capability differences, not a ranking":
+there is **no declared primary** (`docs/deployment-options.md § Select an
+execution model`). They are not one-to-one equivalent.
+
+| Surface | When it fits | Doc anchor |
+|---|---|---|
+| **Local / scripted** | You run `deploy/scripts/*` directly from a workstation, deployer, or automation host. No hosted stage generator. | `docs/deployment-options.md § Local or scripted execution`; `docs/local/README.md § Run SDAF locally` |
+| **Azure DevOps** | Azure Repos/Pipelines, service connections, agent pools own the process. Wrapper pipelines exist but docs note ADO "does not currently provide verified one-to-one equivalents for all GitHub generation workflows". | `docs/deployment-options.md § Azure DevOps` |
+| **GitHub Actions** | GitHub owns the config repo and approvals. Includes stage-generation workflows and deploy workflows. | `docs/deployment-options.md § GitHub Actions` |
+
+See [`references/surface-decision.md`](references/surface-decision.md) for the
+two-question decision walkthrough and the hand-off to the next skill.
+
+## What this skill does and does NOT do
+
+**Does:** classify the request, explain the spine, help pick a surface, and
+*print* the install command for the matching bootstrap plugin — the operator
+runs it themselves.
+
+**Does NOT:** install anything. Does not run a plan/apply. Does not fabricate
+"which surface is best" — the docs decline to rank them and this skill honours
+that.
+
+## Print the surface bootstrap install command
+
+The canonical install commands for the hub and both surface plugins are
+documented in [`docs/PLUGINS.md`](../../docs/PLUGINS.md) (this repo). Print
+the block that matches the operator's chosen surface **verbatim** from that
+file, and instruct the operator to run it themselves. Do not invent
+alternatives, do not paraphrase, do not shorten.
+
+The exact command shapes at the time this skill was authored (source:
+`docs/PLUGINS.md`):
+
+**Azure DevOps** — from `docs/PLUGINS.md § Install: Azure DevOps surface plugin (`azure-sap-automation-devops`)`:
+
+```text
+# GitHub Copilot CLI
+copilot plugin marketplace add Azure/sap-automation-bootstrap
+copilot plugin install azure-sap-automation-devops@sap-automation-bootstrap
+
+# Claude Code
+/plugin marketplace add Azure/sap-automation-bootstrap
+/plugin install azure-sap-automation-devops@sap-automation-bootstrap
+
+# Gemini CLI
+gemini extensions install https://github.com/Azure/sap-automation-bootstrap
+```
+
+**GitHub Actions** — from `docs/PLUGINS.md § Install: GitHub Actions surface plugin (`azure-sap-automation-github`)`:
+
+```text
+# GitHub Copilot CLI
+copilot plugin marketplace add Azure/sap-automation-gh-bootstrap
+copilot plugin install azure-sap-automation-github@sap-automation-gh-bootstrap
+
+# Claude Code
+/plugin marketplace add Azure/sap-automation-gh-bootstrap
+/plugin install azure-sap-automation-github@sap-automation-gh-bootstrap
+
+# Gemini CLI
+gemini extensions install https://github.com/Azure/sap-automation-gh-bootstrap
+```
+
+**Local** — no surface plugin is required. Hand off directly to
+`sdaf-readiness-check`.
+
+The Copilot install form is `<plugin-name>@<marketplace-name>` where the
+marketplace name matches the repository slug (e.g.
+`sap-automation-bootstrap`), not the plugin name. If `docs/PLUGINS.md` and
+this skill body ever diverge, `docs/PLUGINS.md` is the source of truth —
+update this skill in lockstep.
+
+## Hand-off
+
+After the surface is chosen and the surface plugin (if any) is installed by
+the operator, hand off to `sdaf-readiness-check` for pre-flight, then
+`sdaf-workspace-and-tfvars` before any deploy skill.
+
+## See also
+
+- [`docs/PLUGINS.md`](../../docs/PLUGINS.md) — canonical install commands.
+- `sdaf-readiness-check`, `sdaf-workspace-and-tfvars`,
+  `sdaf-control-plane-bootstrap`.
+- `docs/local/README.md`, `docs/deployment-options.md`.

--- a/skills/sdaf-orientation-and-surface/references/surface-decision.md
+++ b/skills/sdaf-orientation-and-surface/references/surface-decision.md
@@ -23,17 +23,6 @@ Beyond that, this reference does not claim any surface is "best". If the user
 needs a capability comparison beyond what the docs assert, say so and stop —
 do not synthesize an inferred matrix (per D19: documented-only).
 
-## Q3 (only if the user asks): Script family (v1 vs v2)?
-
-Docs treat both v1 (established) and v2 as valid and decline to name one
-"current" or "legacy" (`docs/local/README.md § Select a script family`). The
-docs also warn: **do not mix v1 and v2 options or state variable names**
-(`docs/local/03-00-control-plane.md § What the automation does`,
-`docs/local/05-00-sap-system.md § What the automation does`). If the user has
-no release-guidance-driven preference, tell them the docs decline to pick and
-point them at `docs/local/README.md § Select a script family`. Do not pick for
-them.
-
 ## Hand-off
 
 | Surface chosen | Next skill | Install commands to print |

--- a/skills/sdaf-orientation-and-surface/references/surface-decision.md
+++ b/skills/sdaf-orientation-and-surface/references/surface-decision.md
@@ -1,0 +1,45 @@
+# Surface decision reference
+
+Companion to `sdaf-orientation-and-surface`. Two questions, then hand off.
+
+## Q1: Where does the config repo live?
+
+- **Azure Repos / Azure DevOps** → Azure DevOps surface.
+- **GitHub** → GitHub Actions surface.
+- **Neither (workstation / deployer / automation host)** → Local.
+
+Doc anchor: `docs/deployment-options.md § Select an execution model`.
+
+## Q2: Do you need a capability only one surface provides?
+
+Docs say the surfaces are "capability differences, not a ranking"
+(`docs/deployment-options.md § Select an execution model`). The docs also
+state ADO "does not currently provide verified one-to-one equivalents for all
+GitHub generation workflows" (`§ Azure DevOps`), and Local has "no hosted
+stage generator" (`§ Local or scripted execution`, `docs/local/README.md § Run
+SDAF locally`).
+
+Beyond that, this reference does not claim any surface is "best". If the user
+needs a capability comparison beyond what the docs assert, say so and stop —
+do not synthesize an inferred matrix (per D19: documented-only).
+
+## Q3 (only if the user asks): Script family (v1 vs v2)?
+
+Docs treat both v1 (established) and v2 as valid and decline to name one
+"current" or "legacy" (`docs/local/README.md § Select a script family`). The
+docs also warn: **do not mix v1 and v2 options or state variable names**
+(`docs/local/03-00-control-plane.md § What the automation does`,
+`docs/local/05-00-sap-system.md § What the automation does`). If the user has
+no release-guidance-driven preference, tell them the docs decline to pick and
+point them at `docs/local/README.md § Select a script family`. Do not pick for
+them.
+
+## Hand-off
+
+| Surface chosen | Next skill | Install commands to print |
+|---|---|---|
+| Azure DevOps | `sdaf-readiness-check` | `docs/PLUGINS.md § Install: Azure DevOps surface plugin (`azure-sap-automation-devops`)` |
+| GitHub Actions | `sdaf-readiness-check` | `docs/PLUGINS.md § Install: GitHub Actions surface plugin (`azure-sap-automation-github`)` |
+| Local | `sdaf-readiness-check` | none (hub-only) |
+
+The exact install commands are in [`docs/PLUGINS.md`](../../../docs/PLUGINS.md) and mirrored in the parent SKILL.md § *Print the surface bootstrap install command*.

--- a/skills/sdaf-plan-and-test-semantics/SKILL.md
+++ b/skills/sdaf-plan-and-test-semantics/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: sdaf-plan-and-test-semantics
+description: >
+  Explain SDAF plan-only / test / apply semantics without pretending they are
+  universal. Compares the documented Local commands, Azure DevOps wrapper
+  pipelines, and GitHub Actions workflows for control plane, workload zone,
+  and SAP system: local stage commands show Terraform plans and then apply
+  after approval; ADO/GitHub workload-zone and SAP-system wrappers pass
+  `TEST_ONLY` into `installer.sh` / `installer_v2.sh` and stop after the
+  plan; the current control-plane wrappers expose a `test`/dry-run input but
+  do not forward it to the control-plane scripts. Use when a user says "what
+  does test do in SDAF", "is this a real dry run", "plan-only vs apply",
+  "workflow 01 dry-run", "pipeline 02 test", or "TEST_ONLY". Do NOT use to
+  actually deploy a stage or to triage a failed run (see
+  sdaf-control-plane-bootstrap / sdaf-workload-zone / sdaf-sap-system /
+  sdaf-failure-triage).
+allowed-tools: shell
+license: MIT
+---
+
+# SDAF Plan and Test Semantics
+
+Context-primer. Answers *"what does test / plan-only / apply mean here?"*
+across surfaces. Canonical rule: **there is no SDAF-wide dry-run switch**.
+Classify by execution surface and deployment stage before answering.
+
+For the file-by-file evidence matrix, including the hosted wrapper docs and
+workflow/pipeline paths, see
+[`references/plan-test-matrix.md`](references/plan-test-matrix.md).
+
+## When to invoke
+
+Trigger on: "what does test do", "is this a dry run", "plan-only vs apply",
+"control-plane dry-run limitation", "workflow 01 dry-run", "pipeline 02
+test", "TEST_ONLY", "which SDAF stages can review a Terraform plan without
+applying".
+
+Do NOT trigger on: actually deploying a control plane / workload zone / SAP
+system, or triaging a failed run after the fact.
+
+## Rule zero — identify the surface and stage first
+
+`docs/deployment-options.md` is explicit that Local, Azure DevOps, and GitHub
+Actions are different execution models. Never answer *"test means X in
+SDAF"* without naming:
+
+- the surface (Local / ADO / GitHub); and
+- the stage (control plane / workload zone / SAP system).
+
+## The shortest correct answer
+
+| Path | What plan/test means | What apply means |
+|---|---|---|
+| **Local control plane** | No separate documented `test` switch. `deploy_controlplane.sh` displays Terraform plans and asks for approval before apply. | The same run applies after operator approval. |
+| **Local workload zone** | No separate documented local `test` path. `install_workloadzone.sh` shows the plan and waits for approval. | The same run applies after approval. |
+| **Local SAP system** | No separate documented local `test` path. `installer.sh` shows the plan and waits for approval. | The same run applies after approval. |
+| **ADO control plane (`01`)** | `test` exists on the wrapper/template, but current docs say it is **not forwarded** to the control-plane scripts. Treat it as **not plan-only**. | The queued run is state-changing. |
+| **ADO workload zone (`02`)** | `test: true` becomes `TEST_ONLY` and the hosted installer exits after Terraform plan. | Re-queue the same pipeline with `test: false`. |
+| **ADO SAP system (`03`)** | `test: true` becomes `TEST_ONLY` and the hosted installer exits after Terraform plan. | Re-queue the same pipeline with `test: false`. |
+| **GitHub control plane (`01`)** | The workflow exposes a dry-run input, but the docs say it does **not** reach either control-plane script. | Treat the run as state-changing; get a reviewed control-plane plan through a separately validated SDAF path first. |
+| **GitHub workload zone (`03`)** | Enable the test option, review the plan, then rerun with test disabled. The workflow exports `TEST_ONLY`. | Re-dispatch workflow `03` with test disabled. |
+| **GitHub SAP system (`05`)** | Enable the test option, review the plan, then rerun with test disabled. The workflow exports `TEST_ONLY`. | Re-dispatch workflow `05` with test disabled. |
+
+## Local / scripted semantics
+
+For local execution, the docs do **not** define a universal `test` flag that
+operators should export by hand. Instead, the documented stage commands
+themselves are the review gate:
+
+- `docs/local/03-00-control-plane.md § Run`: `deploy_controlplane.sh`
+  displays Terraform plans and asks for approval before apply.
+- `docs/local/04-00-workload-zone.md § Run`: `install_workloadzone.sh`
+  displays the plan and asks for approval before apply.
+- `docs/local/05-00-sap-system.md § Run`: `installer.sh` displays the plan
+  and asks for approval before apply.
+
+If the operator is on Local, answer with the documented stage command, not
+with a hosted-only `TEST_ONLY` story.
+
+## Hosted semantics
+
+This is the boundary that prevents most bad advice:
+
+For Azure DevOps or GitHub Actions, answer from the documented pipeline or
+workflow inputs and outcomes. Do not transfer Local behavior to hosted
+automation merely because both surfaces use the word `test`.
+
+## Control-plane special case
+
+The control plane is different from workload zone and SAP system:
+
+- Local control-plane docs rely on interactive plan review inside the
+  documented run.
+- Current ADO and GitHub control-plane wrappers expose a `test`/dry-run
+  input, but the reviewed docs say that input is not forwarded to the
+  control-plane scripts.
+
+So the correct answer to *"is control-plane `test` safe?"* is **no for the
+hosted wrappers as currently documented**.
+
+## Hard rules
+
+- Do not claim there is a single SDAF-wide dry-run flag.
+- Do not transfer Local behavior to hosted automation or vice versa.
+- Do not tell an operator to rely on ADO/GitHub control-plane `test` as a
+  safety gate.
+- For local operator-reviewed deployment, do not add `--auto-approve`
+  (`docs/local/03-00-control-plane.md § Review before execution`;
+  `docs/local/04-00-workload-zone.md § Review before execution`;
+  `docs/local/05-00-sap-system.md § Review before execution`).
+
+## Hand-off
+
+- Actual control-plane execution → `sdaf-control-plane-bootstrap`
+- Actual workload-zone execution → `sdaf-workload-zone`
+- Actual SAP-system execution → `sdaf-sap-system`
+- Failed / contradictory run outcomes → `sdaf-failure-triage`
+
+## See also
+
+- [`references/plan-test-matrix.md`](references/plan-test-matrix.md)
+- `sdaf-control-plane-bootstrap`, `sdaf-workload-zone`, `sdaf-sap-system`,
+  `sdaf-failure-triage`
+- `docs/deployment-options.md`, `docs/local/README.md`,
+  `docs/local/03-00-control-plane.md`, `docs/local/04-00-workload-zone.md`,
+  `docs/local/05-00-sap-system.md`

--- a/skills/sdaf-plan-and-test-semantics/SKILL.md
+++ b/skills/sdaf-plan-and-test-semantics/SKILL.md
@@ -5,13 +5,12 @@ description: >
   universal. Compares the documented Local commands, Azure DevOps wrapper
   pipelines, and GitHub Actions workflows for control plane, workload zone,
   and SAP system: local stage commands show Terraform plans and then apply
-  after approval; ADO/GitHub workload-zone and SAP-system wrappers pass
-  `TEST_ONLY` into `installer.sh` / `installer_v2.sh` and stop after the
-  plan; the current control-plane wrappers expose a `test`/dry-run input but
-  do not forward it to the control-plane scripts. Use when a user says "what
-  does test do in SDAF", "is this a real dry run", "plan-only vs apply",
-  "workflow 01 dry-run", "pipeline 02 test", or "TEST_ONLY". Do NOT use to
-  actually deploy a stage or to triage a failed run (see
+  after approval; ADO/GitHub workload-zone and SAP-system test runs stop after
+  the plan; the current hosted control-plane test options do not provide a
+  plan-only run. Use when a user says "what does test do in SDAF", "is this a
+  real dry run", "plan-only vs apply", "workflow 01 dry-run", "pipeline 02
+  test", or "TEST_ONLY". Do NOT use to actually deploy a stage or to triage a
+  failed run (see
   sdaf-control-plane-bootstrap / sdaf-workload-zone / sdaf-sap-system /
   sdaf-failure-triage).
 allowed-tools: shell

--- a/skills/sdaf-plan-and-test-semantics/references/plan-test-matrix.md
+++ b/skills/sdaf-plan-and-test-semantics/references/plan-test-matrix.md
@@ -1,0 +1,19 @@
+# Plan, test, and apply by execution surface
+
+Use the documented behavior for the operator's selected surface and stage.
+
+| Stage | Local | Azure DevOps | GitHub Actions |
+| --- | --- | --- | --- |
+| Control plane | The documented command displays plans and asks for approval before apply. | Current docs do not treat the `test` input as a verified plan-only gate. | Current docs do not treat the dry-run input as a verified plan-only gate. |
+| Workload zone | The documented command displays the plan and asks for approval. | `test: true` produces a plan-only run; rerun with test disabled to apply. | Enable the test option, review the plan, then rerun with test disabled. |
+| SAP system | The documented command displays the plan and asks for approval. | `test: true` produces a plan-only run; rerun with test disabled to apply. | Enable the test option, review the plan, then rerun with test disabled. |
+
+Sources:
+
+- `docs/deployment-options.md`
+- `docs/local/03-00-control-plane.md`
+- `docs/local/04-00-workload-zone.md`
+- `docs/local/05-00-sap-system.md`
+- The matching Azure DevOps or GitHub Actions operator guide
+
+Do not infer one surface's plan behavior from another surface.

--- a/skills/sdaf-quality-assurance/SKILL.md
+++ b/skills/sdaf-quality-assurance/SKILL.md
@@ -74,15 +74,21 @@ Do NOT trigger on: deploying the SAP-system infrastructure, generating
 3. Start with configuration checks:
 
    ```bash
+   trap 'rm -f -- "$PWD/sshkey"' EXIT
    "$SAP_AUTOMATION_REPO_PATH/deploy/ansible/quality_assurance_menu.sh"
+   rm -f -- "$PWD/sshkey"; trap - EXIT
+   test ! -e "$PWD/sshkey"
    ```
 
 4. Narrow a functional run only by exporting the selection first:
 
    ```bash
+   trap 'rm -f -- "$PWD/sshkey"' EXIT
    TEST_GROUPS="HA_SCS" \
    TEST_CASES="ascs-migration" \
    "$SAP_AUTOMATION_REPO_PATH/deploy/ansible/quality_assurance_menu.sh"
+   rm -f -- "$PWD/sshkey"; trap - EXIT
+   test ! -e "$PWD/sshkey"
    ```
 
 ## Selection rules

--- a/skills/sdaf-quality-assurance/SKILL.md
+++ b/skills/sdaf-quality-assurance/SKILL.md
@@ -104,9 +104,8 @@ stage semantics:
 - queue-time selection lives in `test_type`, `sap_functional_test_type`,
   `test_groups`, `test_cases`, and `offline_mode`;
 - the prep script validates `extra_params` as `-e key=value` only;
-- the run performs **Quality Assurance Setup** via
-  `playbook_06_03_00_sap_functional_tests.yaml`, then
-  **Quality Assurance Execution** via the selected framework playbook;
+- the run performs **Quality Assurance Setup**, then
+  **Quality Assurance Execution** for the selected framework;
 - logs and reports are collected from `SYSTEM/<config>/logs` and
   `SYSTEM/<config>/quality_assurance`.
 

--- a/skills/sdaf-quality-assurance/SKILL.md
+++ b/skills/sdaf-quality-assurance/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: sdaf-quality-assurance
+description: >
+  Validate a deployed SDAF SAP system through the SDAF-owned QA entry points:
+  the local quality-assurance menu and the documented Azure DevOps pipeline
+  13 path. Choose configuration checks vs functional
+  tests, apply `TEST_GROUPS` / `TEST_CASES` safely, interpret
+  `quality_assurance/` and `logs/`, and enforce the documented boundary that
+  the GitHub Actions wrapper is still pending. Use when a user says "run
+  quality assurance", "run configuration checks", "pipeline 13 QA", "offline
+  HA validation", or "why does the report say No test results found". Do NOT
+  use to deploy the SAP system or generate `sap-parameters.yaml` /
+  `<SID>_hosts.yaml` (see `sdaf-sap-system`), or for a generic failed-run
+  report with no QA-stage context (see `sdaf-failure-triage`).
+allowed-tools: shell
+license: MIT
+---
+
+# SDAF Quality Assurance
+
+Action-loop skill. Validate an already deployed and installed SAP system
+through SDAF's own QA surfaces only. Durable anchors and the full test matrix
+live in [`references/qa-entrypoints.md`](references/qa-entrypoints.md).
+
+## When to invoke
+Trigger on: "run quality assurance", "run configuration checks", "run SAP
+functional tests", "pipeline 13 QA", "offline HA validation", "read the QA
+report", "why does the report say No test results found", or "which
+TEST_GROUPS / TEST_CASES should I use".
+
+Do NOT trigger on: deploying the SAP-system infrastructure, generating
+`sap-parameters.yaml` or `<SID>_hosts.yaml`, software download, or a generic
+"my SDAF run failed" report that is not yet tied to the QA stage.
+
+## Surface availability
+| Surface | Availability | What to do |
+| --- | --- | --- |
+| Local / scripted | Fully documented and runnable through the quality-assurance menu | Use this skill directly. |
+| Azure DevOps | The operator documentation describes pipeline 13; the public bootstrap wrapper is still documented as proposed | Use this skill only if the operator already has a real pipeline-13 path. |
+| GitHub Actions | Wrapper workflow is still documented as pending | Say the docs mark it pending and stop; do not invent the workflow. |
+
+## Preconditions
+- The SAP system is already installed and running; QA validates a configured
+  system and does not install one.
+- The system workspace contains `sap-parameters.yaml` and
+  `<SAP_SID>_hosts.yaml`.
+- Azure sign-in works and the operator can read the workload-zone Key Vault.
+- The execution host can reach every inventory host over SSH.
+- Local runs additionally require outbound `https://github.com`, `sudo`, and
+  `ARM_CLIENT_ID` on multi-identity hosts.
+- Azure DevOps runs additionally require a self-hosted agent.
+
+## Safety and test modes
+- `ConfigurationChecks` and offline HA validation are non-disruptive.
+- Online `SAPFunctionalTests` are disruptive; require an approved maintenance
+  window.
+- Supported functional families are DB HA, SCS HA, and Azure Backup DB.
+- Exact menu / pipeline / framework playbook mapping is in the reference
+  file.
+
+## Local path
+1. Change to the system workspace:
+   ```bash
+   cd "$CONFIG_REPO_PATH/WORKSPACES/SYSTEM/<SAP_SYSTEM>"
+   ```
+
+2. Confirm required artifacts:
+
+   ```bash
+   test -f sap-parameters.yaml
+   test -f "<SAP_SID>_hosts.yaml"
+   ```
+
+3. Start with configuration checks:
+
+   ```bash
+   "$SAP_AUTOMATION_REPO_PATH/deploy/ansible/quality_assurance_menu.sh"
+   ```
+
+4. Narrow a functional run only by exporting the selection first:
+
+   ```bash
+   TEST_GROUPS="HA_SCS" \
+   TEST_CASES="ascs-migration" \
+   "$SAP_AUTOMATION_REPO_PATH/deploy/ansible/quality_assurance_menu.sh"
+   ```
+
+## Selection rules
+- `TEST_GROUPS` is one exact group name.
+- `TEST_CASES` is a comma-separated list of framework `task_name` values, not
+  display names; e.g. `ascs-migration`, not `Manual ASCS Migration`.
+- Always set `TEST_GROUPS` when setting `TEST_CASES`.
+- The preparation playbook writes the resolved selection to
+  `artifacts/qa_test_selection.json`; use it to confirm the requested scope.
+- Validate group and case names against the pinned framework version from
+  `deploy/ansible/vars/ansible-input-api.yaml`.
+- Offline HA runs additionally require `offline_validation/<inventory host>/cib`;
+  otherwise stop before the playbook.
+
+## Azure DevOps contract
+When an SDAF ADO environment already exposes pipeline 13, this skill owns the
+stage semantics:
+
+- queue-time selection lives in `test_type`, `sap_functional_test_type`,
+  `test_groups`, `test_cases`, and `offline_mode`;
+- the prep script validates `extra_params` as `-e key=value` only;
+- the run performs **Quality Assurance Setup** via
+  `playbook_06_03_00_sap_functional_tests.yaml`, then
+  **Quality Assurance Execution** via the selected framework playbook;
+- logs and reports are collected from `SYSTEM/<config>/logs` and
+  `SYSTEM/<config>/quality_assurance`.
+
+If the operator cannot point to an actual wired pipeline-13 path, stop at the
+documented availability boundary rather than assuming the proposed wrapper is
+present.
+
+## Validate
+
+Confirm all of the following:
+
+- `quality_assurance/` contains the HTML report.
+- `logs/<test_group_invocation_id>.log` exists; it is the machine-readable
+  JSONL result record.
+- `logs/execution_<timestamp>.log` exists and matches the completion banner.
+- `No test results found.` means no results log was produced, not that the run
+  passed.
+- For functional tests, the cluster returned to its expected state before the
+  maintenance window closed.
+
+## Routing boundaries
+
+- Need to deploy the system first or generate `sap-parameters.yaml` /
+  `<SID>_hosts.yaml` → `sdaf-sap-system`.
+- Generic failed-run triage or a non-QA symptom → `sdaf-failure-triage`.
+- Asked for a GitHub Actions QA wrapper → say the docs mark it pending and
+  stop.
+- Do not infer undocumented STAF-side behaviour or additional surfaces.
+
+## See also
+
+- [`references/qa-entrypoints.md`](references/qa-entrypoints.md)
+- `sdaf-sap-system`, `sdaf-failure-triage`
+- `docs/local/07-10-quality-assurance.md`, `docs/deployment-options.md`,
+  `docs/documentation-source-map.md`, `docs/supportability.md`

--- a/skills/sdaf-quality-assurance/references/qa-entrypoints.md
+++ b/skills/sdaf-quality-assurance/references/qa-entrypoints.md
@@ -1,0 +1,31 @@
+# Quality-assurance operator reference
+
+## Available surfaces
+
+- **Local:** use `docs/local/07-10-quality-assurance.md`.
+- **Azure DevOps:** use the documented pipeline 13 path only when it exists in
+  the operator's project.
+- **GitHub Actions:** the current operator documentation marks the wrapper as
+  pending; do not invent a workflow.
+
+## Test modes
+
+| Intent | Test type | Functional type | Offline |
+| --- | --- | --- | --- |
+| Configuration checks | `ConfigurationChecks` | n/a | `false` |
+| Database HA | `SAPFunctionalTests` | `DatabaseHighAvailability` | `false` |
+| Central-services HA | `SAPFunctionalTests` | `CentralServicesHighAvailability` | `false` |
+| Azure Backup database | `SAPFunctionalTests` | `AzureBackupDatabase` | `false` |
+| Database HA evidence review | `SAPFunctionalTests` | `DatabaseHighAvailability` | `true` |
+| Central-services HA evidence review | `SAPFunctionalTests` | `CentralServicesHighAvailability` | `true` |
+
+## Operator safeguards
+
+- Configuration validation does not install SAP.
+- HA functional tests are disruptive and require an approved maintenance window.
+- `TEST_CASES` must be scoped by the matching test group.
+- An empty match or `No test results found.` is not success.
+- Retain the generated logs, reports, and selected-case evidence.
+
+Sources: `docs/local/07-10-quality-assurance.md`,
+`docs/supportability.md`, and `docs/deployment-options.md`.

--- a/skills/sdaf-readiness-check/SKILL.md
+++ b/skills/sdaf-readiness-check/SKILL.md
@@ -2,15 +2,15 @@
 name: sdaf-readiness-check
 description: >
   Pre-flight an SDAF host, subscription, and configuration set BEFORE any
-  deploy. Runs the required Linux checks (`check_workstation.sh`,
-  `validate.sh`) and, when `pwsh` is already available, offers the optional
+  deploy. Runs the required Linux toolchain check (`check_workstation.sh`) and,
+  when `pwsh` is already available, offers the optional
   `Test-SDAFReadiness.ps1` and `Test-SDAFURLs.ps1` diagnostics as documented in
   `docs/local/02-00-prepare-execution-environment.md § Readiness verification`.
   Also walks the documented "Before you begin" gates from
   `docs/local/01-00-prerequisites.md`. Use when a user says "pre-flight SDAF",
-  "check SDAF readiness", "validate my tfvars", "am I ready to deploy the
-  control plane", "run validate.sh", "run Test-SDAFReadiness", "check
-  endpoints" or "check SDAF prerequisites". Do NOT use to actually deploy
+  "check SDAF readiness", "review my tfvars", "am I ready to deploy the
+  control plane", "run Test-SDAFReadiness", "check endpoints" or "check SDAF
+  prerequisites". Do NOT use to actually deploy
   (see sdaf-control-plane-bootstrap / sdaf-workload-zone / sdaf-sap-system)
   or to triage a failed run (see sdaf-failure-triage).
 allowed-tools: shell
@@ -26,8 +26,8 @@ docs and shipped scripts do not describe.
 
 ## When to invoke
 
-Trigger on: "pre-flight", "readiness", "validate tfvars", "before I deploy",
-"Test-SDAFReadiness", "Test-SDAFURLs", "validate.sh", "check endpoints",
+Trigger on: "pre-flight", "readiness", "review tfvars", "before I deploy",
+"Test-SDAFReadiness", "Test-SDAFURLs", "check endpoints",
 "prerequisites for SDAF".
 
 Do NOT trigger on: deploying a stage; installing SDAF; troubleshooting a run
@@ -69,9 +69,6 @@ is the shipped procedure. Preserve its required/optional distinction:
    `Test-SDAFReadiness.ps1` — additional host-readiness diagnostic.
 3. **Optional when `pwsh` is already available:** `Test-SDAFURLs.ps1` —
    additional outbound-endpoint diagnostic.
-4. **Required on Linux:** `validate.sh` — per-workspace `.tfvars` sanity,
-   once per workspace the
-   operator plans to deploy.
 
 Do not install or require PowerShell merely to complete the supported Linux
 path. For every check that is run, read the *shipped script's* output as the
@@ -79,6 +76,10 @@ authority on what it checks; do not narrate behaviour beyond what the script
 prints. See
 [`references/host-readiness.md`](references/host-readiness.md) for the
 minimal notes needed to route failures.
+
+Do not run `validate.sh` against current workspace `.tfvars`; it expects the
+legacy JSON parameter shape, while current `.tfvars` use Terraform HCL. Review
+configuration through the documented stage-specific plan and review gate.
 
 Exit-code discipline for each invocation:
 
@@ -117,7 +118,7 @@ the doc anchor named in `references/host-readiness.md`.
 ## See also
 
 - `sdaf-orientation-and-surface` — surface choice, prints install commands.
-- `sdaf-workspace-and-tfvars` — the layout `validate.sh` presupposes.
+- `sdaf-workspace-and-tfvars` — current workspace layout and naming.
 - `sdaf-control-plane-bootstrap` — the first deploy step.
 - `sdaf-failure-triage` — for a run that has already failed.
 - `docs/local/01-00-prerequisites.md`,

--- a/skills/sdaf-readiness-check/SKILL.md
+++ b/skills/sdaf-readiness-check/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: sdaf-readiness-check
+description: >
+  Pre-flight an SDAF host, subscription, and configuration set BEFORE any
+  deploy. Drives the shipped readiness helpers (`check_workstation.sh`,
+  `Test-SDAFReadiness.ps1`, `Test-SDAFURLs.ps1`, `validate.sh`) as documented
+  in `docs/local/02-00-prepare-execution-environment.md § Readiness
+  verification`, and walks the documented "Before you begin" gates from
+  `docs/local/01-00-prerequisites.md`. Use when a user says "pre-flight SDAF",
+  "check SDAF readiness", "validate my tfvars", "am I ready to deploy the
+  control plane", "run validate.sh", "run Test-SDAFReadiness", "check
+  endpoints" or "check SDAF prerequisites". Do NOT use to actually deploy
+  (see sdaf-control-plane-bootstrap / sdaf-workload-zone / sdaf-sap-system)
+  or to triage a failed run (see sdaf-failure-triage).
+allowed-tools: shell
+license: MIT
+---
+
+# SDAF Readiness Check
+
+Action-loop skill. Drives the shipped readiness helpers per the documented
+`Readiness verification` subsection, and honours the documented pre-deploy
+gates. Reports what was checked and what failed; refuses to invent checks the
+docs and shipped scripts do not describe.
+
+## When to invoke
+
+Trigger on: "pre-flight", "readiness", "validate tfvars", "before I deploy",
+"Test-SDAFReadiness", "Test-SDAFURLs", "validate.sh", "check endpoints",
+"prerequisites for SDAF".
+
+Do NOT trigger on: deploying a stage; installing SDAF; troubleshooting a run
+that already failed (use `sdaf-failure-triage`).
+
+## Preconditions
+
+- The SDAF checkout is available (env `SAP_AUTOMATION_REPO_PATH`).
+- The config workspace is available (env `CONFIG_REPO_PATH`).
+- Target subscription is picked (env `ARM_SUBSCRIPTION_ID`).
+
+If any of the three env vars is unset, stop and print
+`docs/local/troubleshooting.md § A required export is missing`.
+
+## Recipe
+
+### Step 1 — Documented "Before you begin" gates
+
+Walk the operator through the two doc-defined gates in this order:
+
+- `docs/local/01-00-prerequisites.md § Before you begin`, `§ Pin versions`,
+  `§ Plan identity and access`, `§ Review networking, DNS, and quota`,
+  `§ Review configuration ownership`, `§ Review gate`.
+- `docs/local/02-00-prepare-execution-environment.md § Before you begin`,
+  `§ Prepare the host`, `§ Prepare configuration`,
+  `§ Protect secrets and transient files`, `§ Review gate`.
+
+Do NOT summarise the identity role set from memory; the docs point at the
+identity-and-access section rather than restating the role set inline. Point
+the operator at that section and stop.
+
+### Step 2 — Run the documented readiness scripts
+
+`docs/local/02-00-prepare-execution-environment.md § Readiness verification`
+is the shipped procedure. Walk its four numbered steps in order:
+
+1. `check_workstation.sh` — toolchain versions.
+2. `Test-SDAFReadiness.ps1` — overall host readiness.
+3. `Test-SDAFURLs.ps1` — outbound endpoint reachability.
+4. `validate.sh` — per-workspace `.tfvars` sanity, once per workspace the
+   operator plans to deploy.
+
+Read the *shipped script's* output (and `Get-Help` for the PowerShell
+scripts) as the authority on what each checks; do not narrate behaviour
+beyond what the script prints. See
+[`references/host-readiness.md`](references/host-readiness.md) for the
+minimal notes needed to route failures.
+
+Exit-code discipline for each invocation:
+
+- `0` — the script signalled success. Read the output anyway; a printed
+  warning is a real signal.
+- non-zero — a failure or a validation-gate refusal. Do not claim the check
+  passed. Route the failure by the section named in
+  [`references/host-readiness.md`](references/host-readiness.md).
+
+### Step 3 — Route any failure before deploying
+
+If any of the four steps in the shipped `§ Readiness verification`
+subsection reports a failure, do not proceed to deploy. Route via
+`sdaf-failure-triage` if the failure symptom is ambiguous, or directly to
+the doc anchor named in `references/host-readiness.md`.
+
+## Hard rules
+
+- **Do not** infer or reconstruct undocumented behaviour of any readiness
+  script (D19). If the docs, `Get-Help`, or shipped script output are silent,
+  say so and stop.
+- **Do not** grant broad Azure roles "to bypass an error"
+  (`docs/local/troubleshooting.md § Azure authentication or authorization fails`).
+- **Do not** claim success without checking the shipped script's exit code.
+- **Do not** replace the shipped scripts with an ad-hoc reimplementation.
+
+## What this skill does NOT do
+
+- Does not deploy anything.
+- Does not rotate credentials, mint identities, or grant roles.
+- Does not attempt to diagnose network paths beyond running the shipped URL
+  check.
+- Does not summarise identity-role sets from memory (docs point to code /
+  the identity-and-access section).
+
+## See also
+
+- `sdaf-orientation-and-surface` — surface choice, prints install commands.
+- `sdaf-workspace-and-tfvars` — the layout `validate.sh` presupposes.
+- `sdaf-control-plane-bootstrap` — the first deploy step.
+- `sdaf-failure-triage` — for a run that has already failed.
+- `docs/local/01-00-prerequisites.md`,
+  `docs/local/02-00-prepare-execution-environment.md § Readiness verification`,
+  `docs/local/troubleshooting.md`.

--- a/skills/sdaf-readiness-check/SKILL.md
+++ b/skills/sdaf-readiness-check/SKILL.md
@@ -2,10 +2,11 @@
 name: sdaf-readiness-check
 description: >
   Pre-flight an SDAF host, subscription, and configuration set BEFORE any
-  deploy. Drives the shipped readiness helpers (`check_workstation.sh`,
-  `Test-SDAFReadiness.ps1`, `Test-SDAFURLs.ps1`, `validate.sh`) as documented
-  in `docs/local/02-00-prepare-execution-environment.md § Readiness
-  verification`, and walks the documented "Before you begin" gates from
+  deploy. Runs the required Linux checks (`check_workstation.sh`,
+  `validate.sh`) and, when `pwsh` is already available, offers the optional
+  `Test-SDAFReadiness.ps1` and `Test-SDAFURLs.ps1` diagnostics as documented in
+  `docs/local/02-00-prepare-execution-environment.md § Readiness verification`.
+  Also walks the documented "Before you begin" gates from
   `docs/local/01-00-prerequisites.md`. Use when a user says "pre-flight SDAF",
   "check SDAF readiness", "validate my tfvars", "am I ready to deploy the
   control plane", "run validate.sh", "run Test-SDAFReadiness", "check
@@ -58,20 +59,24 @@ Do NOT summarise the identity role set from memory; the docs point at the
 identity-and-access section rather than restating the role set inline. Point
 the operator at that section and stop.
 
-### Step 2 — Run the documented readiness scripts
+### Step 2 — Run the documented readiness checks
 
 `docs/local/02-00-prepare-execution-environment.md § Readiness verification`
-is the shipped procedure. Walk its four numbered steps in order:
+is the shipped procedure. Preserve its required/optional distinction:
 
-1. `check_workstation.sh` — toolchain versions.
-2. `Test-SDAFReadiness.ps1` — overall host readiness.
-3. `Test-SDAFURLs.ps1` — outbound endpoint reachability.
-4. `validate.sh` — per-workspace `.tfvars` sanity, once per workspace the
+1. **Required on Linux:** `check_workstation.sh` — toolchain versions.
+2. **Optional when `pwsh` is already available:**
+   `Test-SDAFReadiness.ps1` — additional host-readiness diagnostic.
+3. **Optional when `pwsh` is already available:** `Test-SDAFURLs.ps1` —
+   additional outbound-endpoint diagnostic.
+4. **Required on Linux:** `validate.sh` — per-workspace `.tfvars` sanity,
+   once per workspace the
    operator plans to deploy.
 
-Read the *shipped script's* output (and `Get-Help` for the PowerShell
-scripts) as the authority on what each checks; do not narrate behaviour
-beyond what the script prints. See
+Do not install or require PowerShell merely to complete the supported Linux
+path. For every check that is run, read the *shipped script's* output as the
+authority on what it checks; do not narrate behaviour beyond what the script
+prints. See
 [`references/host-readiness.md`](references/host-readiness.md) for the
 minimal notes needed to route failures.
 
@@ -85,8 +90,8 @@ Exit-code discipline for each invocation:
 
 ### Step 3 — Route any failure before deploying
 
-If any of the four steps in the shipped `§ Readiness verification`
-subsection reports a failure, do not proceed to deploy. Route via
+If a required check, or an optional diagnostic the operator chose to run,
+reports a failure, do not proceed to deploy. Route via
 `sdaf-failure-triage` if the failure symptom is ambiguous, or directly to
 the doc anchor named in `references/host-readiness.md`.
 

--- a/skills/sdaf-readiness-check/references/host-readiness.md
+++ b/skills/sdaf-readiness-check/references/host-readiness.md
@@ -1,0 +1,57 @@
+# Host readiness reference
+
+Companion to `sdaf-readiness-check`. Records what the docs actually say and
+does not go further. Every script below is described in
+`docs/local/02-00-prepare-execution-environment.md § Readiness verification`;
+read that section and each script's own output as the authority.
+
+## check_workstation.sh
+
+- Location: `deploy/scripts/helpers/check_workstation.sh`.
+- Documented in: `docs/local/02-00-prepare-execution-environment.md § Readiness
+  verification` step 1 (and step 9 of `§ Prepare the host`).
+- Prints versions of `az`, `terraform`, `ansible`, `jq`. Non-zero exit or a
+  reported missing tool → route to
+  `docs/local/troubleshooting.md § Terraform or Azure CLI is not found`.
+
+## Test-SDAFReadiness.ps1
+
+- Location: `deploy/scripts/Test-SDAFReadiness.ps1`.
+- Documented in: `docs/local/02-00-prepare-execution-environment.md § Readiness
+  verification` step 2.
+- Doc says: reports readiness of the execution host for an SDAF deployment;
+  each item it flags must be resolved before deploying. For flags, run
+  `Get-Help ...\Test-SDAFReadiness.ps1 -Full` — do not narrate behaviour
+  beyond what `Get-Help` or the script's own output shows.
+
+## Test-SDAFURLs.ps1
+
+- Location: `deploy/scripts/Test-SDAFURLs.ps1`.
+- Documented in: `docs/local/02-00-prepare-execution-environment.md § Readiness
+  verification` step 3.
+- Doc says: reports whether the endpoints SDAF contacts at deploy time are
+  reachable from this host. Failure hand-off:
+  `docs/local/troubleshooting.md § The execution host cannot reach Key Vault or Storage`.
+- For flags, use `Get-Help`.
+
+## validate.sh
+
+- Location: `deploy/scripts/validate.sh`.
+- Documented in: `docs/local/02-00-prepare-execution-environment.md § Readiness
+  verification` step 4.
+- Doc says: inspects a workspace `.tfvars` file's presence and expected
+  fields; non-zero exit or printed error means the file is not ready.
+- Invocation constraint: run from the directory containing the tfvars, pass
+  the basename only — see
+  `docs/local/troubleshooting.md § A parameter file is not found`.
+
+## Required environment variables
+
+Every SDAF run requires the three variables enumerated in the troubleshooting
+guide (`§ A required export is missing`):
+
+- `SAP_AUTOMATION_REPO_PATH`
+- `CONFIG_REPO_PATH`
+- `ARM_SUBSCRIPTION_ID`
+
+If any is missing, this skill stops and points at that section.

--- a/skills/sdaf-readiness-check/references/host-readiness.md
+++ b/skills/sdaf-readiness-check/references/host-readiness.md
@@ -19,20 +19,19 @@ read that section and each script's own output as the authority.
 - Location: `deploy/scripts/Test-SDAFReadiness.ps1`.
 - Documented in: `docs/local/02-00-prepare-execution-environment.md § Readiness
   verification` step 2.
-- Doc says: reports readiness of the execution host for an SDAF deployment;
-  each item it flags must be resolved before deploying. For flags, run
-  `Get-Help ...\Test-SDAFReadiness.ps1 -Full` — do not narrate behaviour
-  beyond what `Get-Help` or the script's own output shows.
+- Optional diagnostic only when `pwsh` is already available. Do not require or
+  install PowerShell to complete the supported Linux readiness path.
+- Resolve each item it flags before deploying. Do not narrate behaviour beyond
+  the script's own output.
 
 ## Test-SDAFURLs.ps1
 
 - Location: `deploy/scripts/Test-SDAFURLs.ps1`.
 - Documented in: `docs/local/02-00-prepare-execution-environment.md § Readiness
   verification` step 3.
-- Doc says: reports whether the endpoints SDAF contacts at deploy time are
-  reachable from this host. Failure hand-off:
+- Optional diagnostic only when `pwsh` is already available.
+- Failure hand-off:
   `docs/local/troubleshooting.md § The execution host cannot reach Key Vault or Storage`.
-- For flags, use `Get-Help`.
 
 ## validate.sh
 

--- a/skills/sdaf-readiness-check/references/host-readiness.md
+++ b/skills/sdaf-readiness-check/references/host-readiness.md
@@ -33,17 +33,6 @@ read that section and each script's own output as the authority.
 - Failure hand-off:
   `docs/local/troubleshooting.md § The execution host cannot reach Key Vault or Storage`.
 
-## validate.sh
-
-- Location: `deploy/scripts/validate.sh`.
-- Documented in: `docs/local/02-00-prepare-execution-environment.md § Readiness
-  verification` step 4.
-- Doc says: inspects a workspace `.tfvars` file's presence and expected
-  fields; non-zero exit or printed error means the file is not ready.
-- Invocation constraint: run from the directory containing the tfvars, pass
-  the basename only — see
-  `docs/local/troubleshooting.md § A parameter file is not found`.
-
 ## Required environment variables
 
 Every SDAF run requires the three variables enumerated in the troubleshooting

--- a/skills/sdaf-safe-removal/SKILL.md
+++ b/skills/sdaf-safe-removal/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: sdaf-safe-removal
+description: >
+  Remove SDAF resources safely in reverse dependency order: stop SAP/database
+  services, back up data and state evidence, remove SAP systems before the
+  workload zone, remove workload zones before the control plane, and validate
+  incomplete teardown before any retry or ARM fallback. Grounded in
+  `docs/local/07-00-operations.md`, `docs/local/troubleshooting.md`,
+  `deploy/scripts/remover.sh`, `deploy/scripts/remove_controlplane.sh`, and the
+  Azure DevOps ARM-fallback pipeline. Use when a user asks to remove an SAP
+  system, workload zone, or control plane, to run `remover.sh` or
+  `remove_controlplane.sh`, or to explain why a control-plane removal exited 0
+  while the deployer still exists. Do NOT use for explicit state `list` /
+  `import` / `remove` operations (see `sdaf-state-management`) or generic
+  failed-run triage (see `sdaf-failure-triage`).
+allowed-tools: shell
+license: MIT
+---
+
+# SDAF Safe Removal
+
+Action-loop skill. Remove SDAF-managed resources only in the documented reverse dependency order and only after a reviewed destroy plan.
+
+## When to invoke
+
+Trigger on: "remove an SAP system", "remove the workload zone", "remove the control plane", "safe teardown", "run remover.sh", "run remove_controlplane.sh", "destroy left resources behind", "the control-plane removal said success but the deployer is still there".
+
+Do NOT trigger on: explicit Terraform state surgery, generic failed-run triage, or greenfield deployment.
+
+## Preconditions
+
+- Approved removal scope, maintenance window, identity, and retention plan (`docs/local/07-00-operations.md § Inputs`, `§ Prepare an operational change`).
+- SAP and database services stopped per product procedures, and business data, configuration, keys, logs, and state evidence backed up (`§ Remove resources`).
+- Keep the approved SDAF commit, configuration revision, remote-state account, state keys, `.sap_deployment_automation` metadata, and destroy output (`§ Before you begin`, `§ Retain logs and evidence`).
+- Run the stage script from the directory that contains the parameter file and pass the basename only (`docs/local/troubleshooting.md § A parameter file is not found`).
+
+## Reverse-order guard
+
+Apply this order on every teardown (`docs/local/07-00-operations.md § Remove resources`):
+
+1. Remove each SAP system.
+2. Remove workload-zone resources only after every dependent SAP system is removed.
+3. Remove the control plane only after every dependent workload zone is removed.
+4. Remove retained shared or external resources separately according to their ownership.
+
+Do not continue to a broader scope until the narrower dependency is gone and the destroy output has been reviewed.
+
+## Run one approved removal stage at a time
+
+### Remove an SAP system
+
+From `WORKSPACES/SYSTEM/<SAP_SYSTEM>`, exactly per `docs/local/07-00-operations.md § Remove an SAP system`:
+
+```bash
+cd "$CONFIG_REPO_PATH/WORKSPACES/SYSTEM/<SAP_SYSTEM>"
+ARM_SUBSCRIPTION_ID="<WORKLOAD_SUBSCRIPTION_ID>" \
+"$SAP_AUTOMATION_REPO_PATH/deploy/scripts/remover.sh" \
+  --type sap_system \
+  --parameterfile "<SAP_SYSTEM>.tfvars" \
+  --control_plane_name "<CONTROL_PLANE>" \
+  --deployer_tfstate_key "<DEPLOYER_STATE_KEY>" \
+  --landscape_tfstate_key "<LANDSCAPE_STATE_KEY>" \
+  --storageaccountname "<STATE_STORAGE_ACCOUNT>" \
+  --state_subscription "<STATE_SUBSCRIPTION_ID>"
+```
+
+Review the destroy plan and confirm only after backups and approvals are complete.
+
+### Remove a workload zone
+
+Only after every dependent SAP system is removed. From `WORKSPACES/LANDSCAPE/<WORKLOAD_ZONE>-INFRASTRUCTURE`, exactly per `docs/local/07-00-operations.md § Remove a workload zone`:
+
+```bash
+cd "$CONFIG_REPO_PATH/WORKSPACES/LANDSCAPE/<WORKLOAD_ZONE>-INFRASTRUCTURE"
+ARM_SUBSCRIPTION_ID="<WORKLOAD_SUBSCRIPTION_ID>" \
+"$SAP_AUTOMATION_REPO_PATH/deploy/scripts/remover.sh" \
+  --type sap_landscape \
+  --parameterfile "<WORKLOAD_ZONE>-INFRASTRUCTURE.tfvars" \
+  --control_plane_name "<CONTROL_PLANE>" \
+  --deployer_tfstate_key "<DEPLOYER_STATE_KEY>" \
+  --storageaccountname "<STATE_STORAGE_ACCOUNT>" \
+  --state_subscription "<STATE_SUBSCRIPTION_ID>"
+```
+
+Confirm the workload-zone state and any retained shared resources match the approved removal scope before approval.
+
+### Remove the control plane
+
+Only after every dependent workload zone is removed. From `WORKSPACES`, exactly per `docs/local/07-00-operations.md § Remove the control plane`:
+
+```bash
+cd "$CONFIG_REPO_PATH/WORKSPACES"
+"$SAP_AUTOMATION_REPO_PATH/deploy/scripts/remove_controlplane.sh" \
+  --deployer_parameter_file \
+  "$CONFIG_REPO_PATH/WORKSPACES/DEPLOYER/<CONTROL_PLANE>-INFRASTRUCTURE/<CONTROL_PLANE>-INFRASTRUCTURE.tfvars" \
+  --library_parameter_file \
+  "$CONFIG_REPO_PATH/WORKSPACES/LIBRARY/<ENVIRONMENT>-<LOCATION>-SAP_LIBRARY/<ENVIRONMENT>-<LOCATION>-SAP_LIBRARY.tfvars"
+```
+
+Review each destroy operation. Use `--keep_agent` only when the deployment agent retention was explicitly approved and you understand the resulting partial removal (`docs/local/07-00-operations.md § Remove the control plane`).
+
+## If removal is incomplete
+
+`docs/local/troubleshooting.md § Removal is incomplete` is canonical:
+
+1. Preserve the destroy output.
+2. Confirm the dependency order was respected.
+3. Compare remaining Azure resources with the Terraform state list.
+4. Resolve locks, permissions, policies, and delete protections.
+5. For an SAP-system or workload-zone removal, rerun the same command and re-review the destroy plan.
+
+### Control-plane partial-removal trap
+
+Do **not** use the generic rerun rule for an interrupted control-plane removal. Inspect `$CONFIG_REPO_PATH/.sap_deployment_automation`, its persisted `step`, the library destroy result, and the remaining deployer state and resources (`docs/local/07-00-operations.md § Retry deterministically`, `docs/local/troubleshooting.md § Removal is incomplete`).
+
+After the library destroy, `remove_controlplane.sh` persists `step=1`; a later invocation can exit successfully without destroying the deployer. Do not treat that exit as completion, do not edit the step to bypass the guard, and do not switch to ad-hoc resource-group deletion. Obtain expert review for a component-specific recovery path.
+
+## ARM fallback — last resort, Azure DevOps only
+
+The only repo-documented ARM fallback here is the Azure DevOps pipeline `deploy/pipelines/11-remover-arm-fallback.yaml`. Its header says it removes SAP systems, the workload zone, and the region via ARM resource-group deletion, and that it is a fallback **only** when Terraform destroy does not remove everything.
+
+Use that pipeline only after:
+
+- the normal reverse-order Terraform removal path was attempted,
+- the destroy output was captured and reviewed,
+- the approved scope still matches the remaining resource groups, and
+- the operator explicitly approves a resource-group deletion fallback.
+
+This repo does not document a local-script or GitHub Actions ARM-fallback procedure. Do not invent one.
+
+## Hard rules
+
+- Do not pass `--auto-approve` (`docs/local/07-00-operations.md § Review before execution`).
+- Do not remove the remote-state account or edit state to hide a failure (`docs/local/troubleshooting.md § Removal is incomplete`).
+- Do not run ad-hoc `az group delete`, direct ARM deletion, or explicit Terraform state `list` / `import` / `remove` commands in place of the documented sequence; the state-operation boundary belongs to `sdaf-state-management`.
+- Do not treat a control-plane rerun that exits `0` after `step=1` as completed removal.
+- Documented behaviour only; if the docs or shipped scripts are silent, stop.
+- Repo-wide rules apply: follow [`.github/copilot-instructions.md`](../../.github/copilot-instructions.md).
+
+## See also
+
+- `sdaf-state-management`, `sdaf-failure-triage`, `sdaf-control-plane-bootstrap`, `sdaf-workload-zone`, `sdaf-sap-system`.
+- `docs/local/07-00-operations.md`, `docs/local/troubleshooting.md`, `docs/local/README.md`, `deploy/pipelines/11-remover-arm-fallback.yaml`, `deploy/scripts/remover.sh`, `deploy/scripts/remove_controlplane.sh`.

--- a/skills/sdaf-safe-removal/SKILL.md
+++ b/skills/sdaf-safe-removal/SKILL.md
@@ -117,7 +117,10 @@ After the library destroy, `remove_controlplane.sh` persists `step=1`; a later i
 
 ## ARM fallback — last resort, Azure DevOps only
 
-The only repo-documented ARM fallback here is the Azure DevOps pipeline `deploy/pipelines/11-remover-arm-fallback.yaml`. Its header says it removes SAP systems, the workload zone, and the region via ARM resource-group deletion, and that it is a fallback **only** when Terraform destroy does not remove everything.
+The only documented ARM fallback here is the Azure DevOps removal fallback.
+It removes SAP systems, the workload zone, and the region through ARM
+resource-group deletion and is a fallback **only** when Terraform destroy does
+not remove everything.
 
 Use that pipeline only after:
 
@@ -140,4 +143,5 @@ This repo does not document a local-script or GitHub Actions ARM-fallback proced
 ## See also
 
 - `sdaf-state-management`, `sdaf-failure-triage`, `sdaf-control-plane-bootstrap`, `sdaf-workload-zone`, `sdaf-sap-system`.
-- `docs/local/07-00-operations.md`, `docs/local/troubleshooting.md`, `docs/local/README.md`, `deploy/pipelines/11-remover-arm-fallback.yaml`, `deploy/scripts/remover.sh`, `deploy/scripts/remove_controlplane.sh`.
+- `docs/local/07-00-operations.md`, `docs/local/troubleshooting.md`, and
+  `docs/local/README.md`.

--- a/skills/sdaf-sap-installation/SKILL.md
+++ b/skills/sdaf-sap-installation/SKILL.md
@@ -44,16 +44,20 @@ installation run.
 From the system directory, exactly per `docs/local/06-00-software-and-installation.md`:
 ```bash
 cd "$CONFIG_REPO_PATH/WORKSPACES/SYSTEM/<SAP_SYSTEM>"
+cleanup_sshkey() {
+  rm -f -- "$PWD/sshkey"
+}
+trap cleanup_sshkey EXIT
 "$SAP_AUTOMATION_REPO_PATH/deploy/ansible/configuration_menu.sh"
+cleanup_sshkey
+trap - EXIT
+test ! -e "$PWD/sshkey"
 ```
 Then:
 1. Select **Validate parameters** first.
 2. Select one reviewed playbook or grouped sequence from [`references/install-stage-map.md`](references/install-stage-map.md).
-3. After the menu exits, remove the retrieved private key immediately:
-   ```bash
-   rm -f -- "$PWD/sshkey"
-   test ! -e "$PWD/sshkey"
-   ```
+3. Keep the cleanup trap in place around the menu invocation. It removes the
+   retrieved private key when the menu succeeds, fails, or is interrupted.
 Use the reference to select the smallest documented stage and verify its
 completion evidence.
 

--- a/skills/sdaf-sap-installation/SKILL.md
+++ b/skills/sdaf-sap-installation/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: sdaf-sap-installation
+description: >
+  Guide SDAF operating-system, database, and SAP installation after the SAP-system workspace and reviewed media are ready. Covers the local
+  `configuration_menu.sh` path, the Azure DevOps `05-DB-and-SAP-installation` booleans, `.progress`-based recovery, and the boundary between
+  infrastructure deployment, media acquisition, and software installation. Use for "run the SAP install playbooks", "which installation stage
+  should I select", "resume after a partial DB/SAP playbook run", "run configuration_menu.sh", or "queue 05-DB-and-SAP-installation with the
+  right booleans". Do NOT use for `sdaf-sap-system`, `sdaf-media-acquisition`, `sdaf-media-diagnostics`, or `sdaf-quality-assurance`.
+allowed-tools: shell
+license: MIT
+---
+# SDAF SAP Installation
+Action-loop skill. Owns OS + DB + SAP installation **after** `sdaf-sap-system` has produced `sap-parameters.yaml` and `<SID>_hosts.yaml` and after the reviewed software set is available.
+
+Preserve these boundaries:
+- `sdaf-sap-system` owns infrastructure deployment and generated inventory.
+- `sdaf-media-acquisition` / `sdaf-media-diagnostics` own `download_menu.sh`, BOM download, and library-media problems.
+- `sdaf-sap-installation` owns the documented local installation menu and the
+  Azure DevOps installation-stage selections.
+
+Use [`references/install-stage-map.md`](references/install-stage-map.md) for
+the operator-facing stage and recovery map.
+
+## When to invoke
+Trigger on: "run configuration_menu.sh", "install OS/DB/SAP", "05-DB-and-SAP-installation", "which playbook should I select", "resume after db-load", "SCS install", "PAS install", or ".progress markers".
+
+Do NOT trigger on: SAP-system infrastructure deployment, library media download, GitHub workflow sequencing, STAF quality-assurance, HA diagnostics, or a generic failure report that has not yet been identified as an install-stage issue.
+
+## Preconditions
+- `sdaf-sap-system` has completed and the system directory contains `sap-parameters.yaml` and `<SID>_hosts.yaml` (`docs/local/05-00-sap-system.md § Validate`, `docs/local/06-00-software-and-installation.md § Before you begin`).
+- SSH connectivity to every inventory host works, the workload-zone Key Vault contains the generated credentials, and the SAP library has capacity.
+- SAP licenses, download credentials, backups, and the maintenance window are approved for the intended stage.
+- If the operator still needs the four component BOM keys or `download_menu.sh`, stop and hand off to `sdaf-media-acquisition`.
+
+## Recipe
+### 1) Preserve ordering
+Order is fixed: deploy SAP-system infrastructure → acquire media into the SAP library → run installation stages against the generated inventory. Do not collapse those into one "install everything" action.
+
+Library media acquisition and host-side media preparation are separate
+documented stages. Do not treat downloading media into the library as an
+installation run.
+
+### 2) Local execution
+From the system directory, exactly per `docs/local/06-00-software-and-installation.md`:
+```bash
+cd "$CONFIG_REPO_PATH/WORKSPACES/SYSTEM/<SAP_SYSTEM>"
+"$SAP_AUTOMATION_REPO_PATH/deploy/ansible/configuration_menu.sh"
+```
+Then:
+1. Select **Validate parameters** first.
+2. Select one reviewed playbook or grouped sequence from [`references/install-stage-map.md`](references/install-stage-map.md).
+3. After the menu exits, remove the retrieved private key immediately:
+   ```bash
+   rm -f -- "$PWD/sshkey"
+   test ! -e "$PWD/sshkey"
+   ```
+Use the reference to select the smallest documented stage and verify its
+completion evidence.
+
+### 3) Azure DevOps execution
+Use the documented Azure DevOps installation pipeline. Enable only the
+reviewed installation stages; do not default to every stage.
+
+If the question is really about GitHub workflow order or the blocked workflow 07 path, stop and say that workflow-order mechanics live in the separate GitHub Actions surface plugin `azure-sap-automation-github`. Use the documented install/use pattern in `docs/PLUGINS.md § Install a surface plugin (Azure DevOps or GitHub Actions)` or ask `sdaf-orientation-and-surface` to print that install block; do not invent ad-hoc workflow commands here.
+
+### 4) Validate and recover
+Success means the selected playbooks completed, the expected `.progress` markers exist, services are healthy, logs are retained, and the local `sshkey` has been removed.
+
+If the run stops partway:
+1. Record the **first failed numbered playbook**, target host, and exit code.
+2. Check the owned `.progress` marker in the stage map.
+3. Correct the failed prerequisite or task.
+4. Rerun the **smallest applicable playbook or Azure DevOps boolean**, not the whole install spine by default.
+
+Hand-offs:
+- Missing `sap-parameters.yaml` / `<SID>_hosts.yaml` → `sdaf-sap-system`
+- Missing library media, wrong BOM names, or downloader issues → `sdaf-media-acquisition` / `sdaf-media-diagnostics`
+- Ambiguous or cross-stage failure classification → `sdaf-failure-triage`
+
+## Hard rules
+- Documented behaviour only (D19). If the docs or checked-in wrappers do not describe a flag, menu path, or recovery step, do not invent it.
+- Do not start installation before the SAP-system-generated files exist.
+- Do not skip **Validate parameters**.
+- Do not use **All Playbooks** or "all booleans enabled" as the default rerun path on an existing system.
+- Do not delete `.progress` markers merely to force a rerun.
+- Do not leave `sshkey` in the workspace after local execution.
+- Do not conflate library media acquisition with host-side BOM processing.
+- Follow [`.github/copilot-instructions.md`](../../.github/copilot-instructions.md).
+
+## See also
+- [`sdaf-sap-system`](../sdaf-sap-system/SKILL.md)
+- `sdaf-media-acquisition`
+- `sdaf-media-diagnostics`
+- [`sdaf-failure-triage`](../sdaf-failure-triage/SKILL.md)
+- `sdaf-quality-assurance`
+- `docs/local/06-00-software-and-installation.md`
+- `docs/local/troubleshooting.md`

--- a/skills/sdaf-sap-installation/references/install-stage-map.md
+++ b/skills/sdaf-sap-installation/references/install-stage-map.md
@@ -1,0 +1,29 @@
+# SAP installation stage map
+
+Use this map to select the smallest documented installation stage.
+
+| Intent | Local selection | Azure DevOps selection |
+| --- | --- | --- |
+| Validate inputs | Validate parameters | Validation stage |
+| Configure base OS | Core Operating System Configuration | Base OS configuration |
+| Configure SAP OS | SAP Operating System Configuration | SAP OS configuration |
+| Prepare reviewed media on hosts | Local software download | BOM processing |
+| Install central services | SCS Installation & High Availability Configuration | SCS installation |
+| Install database | Database installation | Database install |
+| Load database | Database Load | Database load |
+| Configure database HA | Database High Availability Configuration | HA configuration |
+| Install PAS | Primary Application Server installation | PAS installation |
+| Install additional app servers | Application Server installations | Application-server installation |
+| Install Web Dispatcher | Web Dispatcher installations | Web Dispatcher installation |
+
+## Recovery guidance
+
+- Always validate parameters first.
+- Preserve the first failed stage, host, exit code, and logs.
+- Review the documented completion marker for the selected stage.
+- Correct the failed prerequisite, then rerun only the smallest applicable stage.
+- Do not use every stage as the default retry.
+- Remove temporary private-key material after local execution.
+
+Sources: `docs/local/06-00-software-and-installation.md` and the documented
+Azure DevOps installation guide.

--- a/skills/sdaf-sap-system/SKILL.md
+++ b/skills/sdaf-sap-system/SKILL.md
@@ -7,8 +7,8 @@ description: >
   risk, and validates the generated `<SID>_hosts.yaml` /
   `sap-parameters.yaml`. Use when a user says "deploy an SAP system", "run
   installer.sh sap_system", "SAP system infrastructure", "generate the SAP
-  system inventory". Do NOT use for OS/DB/SAP install (Ansible menus),
-  workload zone (see sdaf-workload-zone), or software download.
+  system inventory". Do NOT use for OS/DB/SAP install (`sdaf-sap-installation`),
+  workload zone (see sdaf-workload-zone), or software download (`sdaf-media-acquisition`).
 allowed-tools: shell
 license: MIT
 ---
@@ -17,7 +17,7 @@ license: MIT
 
 Action-loop skill. Deploys the SAP-system infrastructure strictly per
 `docs/local/05-00-sap-system.md`. Installation of OS + DB + SAP is a separate
-concern and is not implemented in this wave.
+concern owned by `sdaf-sap-installation`.
 
 ## When to invoke
 
@@ -37,20 +37,6 @@ removal.
 - Host quota / image / topology reviewed
   (`docs/local/05-00-sap-system.md § Before you begin`, `§ Inputs`).
 
-## Script family choice — do NOT mix v1 and v2
-
-- **v1 (established):** `deploy/scripts/installer.sh` with `--type
-  sap_system`. Invocation shape is documented in
-  `docs/local/05-00-sap-system.md § Run`.
-- **v2:** `deploy/scripts/installer_v2.sh`. Docs
-  (`docs/local/05-00-sap-system.md § What the automation does`) note v2 has
-  different options and state-variable names but do not provide a separate
-  invocation-shape example under `§ Run`. Follow release guidance and the
-  script's own `--help`; do not port v1 flags one-for-one.
-
-**Do not mix v1 and v2 options.** If the operator has no
-release-guidance-driven preference, say docs decline to pick and stop.
-
 ## Recipe
 
 ### Step 1 — Review replacement risk
@@ -60,7 +46,7 @@ resource replacement
 (`docs/local/05-00-sap-system.md § Review before execution`; see also
 `docs/local/troubleshooting.md § Terraform proposes unexpected replacement`).
 
-### Step 2 — Run the installer (v1, documented shape)
+### Step 2 — Run the documented installer
 
 From the system parameter directory, exactly per
 `docs/local/05-00-sap-system.md § Run`:
@@ -83,9 +69,6 @@ if [ $rc -ne 0 ]; then
   exit $rc
 fi
 ```
-
-For v2, follow release guidance and `--help`; do not paste v1 flags into
-`installer_v2.sh`.
 
 ### Step 3 — Validate
 
@@ -110,7 +93,6 @@ here rather than in triage):
 
 - Documented behaviour only (D19).
 - Do not deploy before the workload zone exists.
-- Do not mix v1 and v2 options or state-variable names.
 - Do not pass `--auto-approve`
   (`docs/local/05-00-sap-system.md § Review before execution`).
 - Repo-wide rules apply: **do not run `terraform fmt`** and follow the
@@ -126,6 +108,7 @@ here rather than in triage):
 ## See also
 
 - `sdaf-workload-zone`, `sdaf-workspace-and-tfvars`,
-  `sdaf-bom-selection`, `sdaf-failure-triage`.
+  `sdaf-bom-selection`, `sdaf-media-acquisition`,
+  `sdaf-sap-installation`, `sdaf-failure-triage`.
 - `docs/local/05-00-sap-system.md`, `docs/local/troubleshooting.md`,
   [`.github/copilot-instructions.md`](../../.github/copilot-instructions.md).

--- a/skills/sdaf-sap-system/SKILL.md
+++ b/skills/sdaf-sap-system/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: sdaf-sap-system
+description: >
+  Deploy SDAF SAP system infrastructure (VMs, disks, load balancers, HA
+  inputs) after the workload zone exists. Drives `installer.sh --type
+  sap_system` per `docs/local/05-00-sap-system.md § Run`, reviews replacement
+  risk, and validates the generated `<SID>_hosts.yaml` /
+  `sap-parameters.yaml`. Use when a user says "deploy an SAP system", "run
+  installer.sh sap_system", "SAP system infrastructure", "generate the SAP
+  system inventory". Do NOT use for OS/DB/SAP install (Ansible menus),
+  workload zone (see sdaf-workload-zone), or software download.
+allowed-tools: shell
+license: MIT
+---
+
+# SDAF SAP System
+
+Action-loop skill. Deploys the SAP-system infrastructure strictly per
+`docs/local/05-00-sap-system.md`. Installation of OS + DB + SAP is a separate
+concern and is not implemented in this wave.
+
+## When to invoke
+
+Trigger on: "deploy an SAP system", "run installer.sh sap_system", "SAP
+system infra", "generated hosts.yaml", "generated sap-parameters.yaml".
+
+Do NOT trigger on: control plane, workload zone, software download, install,
+removal.
+
+## Preconditions
+
+- Workload zone deployed
+  (`docs/local/05-00-sap-system.md § Before you begin`; SAP system reads
+  deployer + landscape remote state per `§ What the automation does`).
+- SYSTEM tfvars prepared under the documented WORKSPACES layout — see
+  `sdaf-workspace-and-tfvars`.
+- Host quota / image / topology reviewed
+  (`docs/local/05-00-sap-system.md § Before you begin`, `§ Inputs`).
+
+## Script family choice — do NOT mix v1 and v2
+
+- **v1 (established):** `deploy/scripts/installer.sh` with `--type
+  sap_system`. Invocation shape is documented in
+  `docs/local/05-00-sap-system.md § Run`.
+- **v2:** `deploy/scripts/installer_v2.sh`. Docs
+  (`docs/local/05-00-sap-system.md § What the automation does`) note v2 has
+  different options and state-variable names but do not provide a separate
+  invocation-shape example under `§ Run`. Follow release guidance and the
+  script's own `--help`; do not port v1 flags one-for-one.
+
+**Do not mix v1 and v2 options.** If the operator has no
+release-guidance-driven preference, say docs decline to pick and stop.
+
+## Recipe
+
+### Step 1 — Review replacement risk
+
+Re-read the SYSTEM tfvars once, checking for anything that will cause a
+resource replacement
+(`docs/local/05-00-sap-system.md § Review before execution`; see also
+`docs/local/troubleshooting.md § Terraform proposes unexpected replacement`).
+
+### Step 2 — Run the installer (v1, documented shape)
+
+From the system parameter directory, exactly per
+`docs/local/05-00-sap-system.md § Run`:
+
+```bash
+set -e
+cd "$CONFIG_REPO_PATH/WORKSPACES/SYSTEM/<SAP_SYSTEM>"
+ARM_SUBSCRIPTION_ID="<WORKLOAD_SUBSCRIPTION_ID>" \
+"$SAP_AUTOMATION_REPO_PATH/deploy/scripts/installer.sh" \
+    --type sap_system \
+    --parameterfile "<SAP_SYSTEM>.tfvars" \
+    --control_plane_name "<CONTROL_PLANE>" \
+    --deployer_tfstate_key "<DEPLOYER_STATE_KEY>" \
+    --landscape_tfstate_key "<LANDSCAPE_STATE_KEY>" \
+    --storageaccountname "<STATE_STORAGE_ACCOUNT>" \
+    --state_subscription "<STATE_SUBSCRIPTION_ID>"
+rc=$?
+if [ $rc -ne 0 ]; then
+  echo "SAP system exit=$rc — route to sdaf-failure-triage"
+  exit $rc
+fi
+```
+
+For v2, follow release guidance and `--help`; do not paste v1 flags into
+`installer_v2.sh`.
+
+### Step 3 — Validate
+
+`docs/local/05-00-sap-system.md § Validate` and `§ Outcome`:
+
+- SAP-system infra deployed.
+- Generated `<SID>_hosts.yaml` and `sap-parameters.yaml` exist (`docs/local/05-00-sap-system.md § Validate`, `§ Outcome`).
+- Config and metadata uploaded to the state account's `tfvars` container
+  (`§ What the automation does`).
+
+## If the run fails
+
+Route to **`sdaf-failure-triage`**. Stage-owned preventive checks (kept
+here rather than in triage):
+
+- Filename / directory / basename mismatch — fix before rerun
+  (`docs/local/troubleshooting.md § A parameter file is not found`).
+- Do not delete `.progress` markers to force a rerun
+  (`docs/local/06-00-software-and-installation.md § Safe retry`).
+
+## Hard rules
+
+- Documented behaviour only (D19).
+- Do not deploy before the workload zone exists.
+- Do not mix v1 and v2 options or state-variable names.
+- Do not pass `--auto-approve`
+  (`docs/local/05-00-sap-system.md § Review before execution`).
+- Repo-wide rules apply: **do not run `terraform fmt`** and follow the
+  Terraform / Ansible / Python guidance in
+  [`.github/copilot-instructions.md`](../../.github/copilot-instructions.md).
+
+## What this skill does NOT do
+
+- Does not run OS / DB / SAP installation playbooks.
+- Does not download SAP media.
+- Does not tear down or repair state.
+
+## See also
+
+- `sdaf-workload-zone`, `sdaf-workspace-and-tfvars`,
+  `sdaf-bom-selection`, `sdaf-failure-triage`.
+- `docs/local/05-00-sap-system.md`, `docs/local/troubleshooting.md`,
+  [`.github/copilot-instructions.md`](../../.github/copilot-instructions.md).

--- a/skills/sdaf-sap-system/SKILL.md
+++ b/skills/sdaf-sap-system/SKILL.md
@@ -62,12 +62,11 @@ ARM_SUBSCRIPTION_ID="<WORKLOAD_SUBSCRIPTION_ID>" \
     --deployer_tfstate_key "<DEPLOYER_STATE_KEY>" \
     --landscape_tfstate_key "<LANDSCAPE_STATE_KEY>" \
     --storageaccountname "<STATE_STORAGE_ACCOUNT>" \
-    --state_subscription "<STATE_SUBSCRIPTION_ID>"
-rc=$?
-if [ $rc -ne 0 ]; then
+    --state_subscription "<STATE_SUBSCRIPTION_ID>" || {
+  rc=$?
   echo "SAP system exit=$rc — route to sdaf-failure-triage"
-  exit $rc
-fi
+  exit "$rc"
+}
 ```
 
 ### Step 3 — Validate

--- a/skills/sdaf-sovereign-cloud/SKILL.md
+++ b/skills/sdaf-sovereign-cloud/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: sdaf-sovereign-cloud
+description: >
+  Explain the current SDAF sovereign-cloud deltas without inventing a generic
+  "all sovereigns" runbook. Focus on Azure Government only: the GitHub Actions
+  cloud values `ARM_ENVIRONMENT=usgovernment`,
+  `AZURE_ENVIRONMENT=AzureUSGovernment`, and
+  `AZURE_AUDIENCE=api://AzureADTokenExchangeUSGov`; the Government
+  `dns_zone_names` block; `USAR` / `USTE` / `USVI`; the 3.22+ image boundary;
+  and the documented Government login, client-secret, SKU, and
+  private-endpoint failure signatures. Use when a user says "Azure
+  Government", "sovereign cloud", "ARM_ENVIRONMENT", "AZURE_AUDIENCE",
+  "AADSTS900382", "USVI", or "Government DNS zones". Do NOT use for generic
+  stage execution or to infer Azure China / German procedures from
+  cloud-name literals alone.
+allowed-tools: shell
+license: MIT
+---
+
+# SDAF Sovereign Cloud
+
+Context-primer. Explains the currently sourced sovereign-cloud deltas for SDAF
+without promising parity across every surface or Azure cloud. The operator path
+in scope is Azure Government. For exact anchors, commands, and ownership
+boundaries, see
+[`references/documented-cloud-boundaries.md`](references/documented-cloud-boundaries.md).
+
+## When to invoke
+
+Trigger on: "Azure Government", "sovereign cloud", "ARM_ENVIRONMENT",
+"AZURE_AUDIENCE", "AADSTS900382", "USVI", "Government dns_zone_names", "wrong
+azure/login cloud", "Government VM size not available".
+
+Do NOT trigger on: generic control-plane/workload-zone/SAP-system deployment,
+a general private-endpoint policy design decision, or unsupported-cloud
+enablement.
+
+## Scope boundary
+
+Teach only Azure Government deltas that current SDAF docs or code explicitly
+name.
+
+- `CHANGELOG/v3.22.0.0` is the first release note in this repo that explicitly
+  names Azure Government support in the GitHub Actions setup flow and adds
+  `USAR`, `USTE`, and `USVI`.
+- The GitHub setup utility defines sovereign OIDC values only for
+  `AzureUSGovernment` and rejects unknown clouds.
+- Local shell code also maps `AzureChinaCloud` and `AzureGermanCloud`, but
+  that alone is not an end-to-end operator runbook.
+
+If the operator asks for China, German, or another sovereign path, say the
+current sources in scope do not publish that runbook and stop.
+
+## Cloud values that must move together
+
+For the GitHub Actions surface, set these together:
+
+- `ARM_ENVIRONMENT = usgovernment`
+- `AZURE_ENVIRONMENT = AzureUSGovernment`
+- `AZURE_AUDIENCE = api://AzureADTokenExchangeUSGov`
+
+Workflow `00` copies these values to the control-plane environment; workflow
+`02` propagates them to workload environments.
+
+Do not set only one or two of them:
+
+- `AZURE_ENVIRONMENT` and `AZURE_AUDIENCE` steer `azure/login`.
+- `ARM_ENVIRONMENT` steers the `azurerm` provider.
+- If Terraform later fails with `AADSTS900382`, first check that every
+  Terraform step is exporting `ARM_ENVIRONMENT` with the ARM credentials.
+
+## Region and configuration boundaries
+
+Government region codes are documented in `docs/region-codes.md`:
+
+- `usgovarizona` → `USAR`
+- `usgovtexas` → `USTE`
+- `usgovvirginia` → `USVI`
+
+If a GitHub control-plane run shows `Invalid index` with an empty `Region:`,
+treat the pinned `DOCKER_IMAGE` as the first boundary check. The documented
+image gate for Government region codes is SDAF `3.22+`.
+
+For Azure Government generated `WORKSPACES` files, uncomment the Government
+`dns_zone_names` block. For Public Azure, leave it commented. Do not enable
+multiple DNS blocks.
+
+For an Azure Government workload-zone deployment that fails with
+`PrivateEndpointCannotBeCreatedInSubnetThatHasNetworkPoliciesEnabled`, set:
+
+```terraform
+private_endpoint_network_policies = "Disabled"
+```
+
+Do not generalize that workaround to other clouds. If the operator needs the
+broader workload-zone/network-policy decision, hand off to
+`sdaf-workload-zone`.
+
+## Common documented Azure Government failure signatures
+
+- `AADSTS900382` during Terraform init/apply: Terraform is still targeting the
+  wrong cloud endpoint. Check `ARM_ENVIRONMENT` first.
+- `azure/login` succeeds against the wrong cloud: the workflow is missing
+  `AZURE_ENVIRONMENT` and/or `AZURE_AUDIENCE`.
+- `AADSTS7000215` or `AADSTS700016`: Terraform is not using the workflow's
+  OIDC token. When `USE_MSI=false`, `ARM_CLIENT_SECRET` must exist and be
+  valid in the running environment.
+- `SkuNotAvailable`: query the subscription's offered sizes in the target
+  region and set the stage-specific size variable; for the control plane, that
+  variable is `deployer_size`.
+
+## Hand-off
+
+- GitHub Actions bootstrap or workflow mechanics: use the GitHub surface plugin
+  or the referenced GitHub bootstrap docs.
+- Local control-plane execution: `sdaf-control-plane-bootstrap`.
+- Workload-zone execution or the broader network-policy choice:
+  `sdaf-workload-zone`.
+- SAP-system deployment: `sdaf-sap-system`.
+- Symptoms outside the documented Government cases above:
+  `sdaf-failure-triage`.
+
+## Hard rules
+
+- Do not infer an end-to-end China or German runbook from cloud-name literals
+  alone.
+- Do not apply Azure Government `dns_zone_names` or subnet-policy settings to
+  Public Azure by default.
+- Do not treat `ARM_ENVIRONMENT` as sufficient for `azure/login`, or
+  `AZURE_ENVIRONMENT` / `AZURE_AUDIENCE` as sufficient for Terraform.
+- Do not claim Local/ADO/GitHub sovereign-cloud parity unless the cited source
+  for that surface says so.
+- If the question depends on an uncited cloud, surface, or workaround, say the
+  current sources are silent and stop.

--- a/skills/sdaf-sovereign-cloud/references/documented-cloud-boundaries.md
+++ b/skills/sdaf-sovereign-cloud/references/documented-cloud-boundaries.md
@@ -1,0 +1,28 @@
+# Documented sovereign-cloud boundaries
+
+The current operator guidance covers Azure Government only.
+
+## Values that move together
+
+- `ARM_ENVIRONMENT=usgovernment`
+- `AZURE_ENVIRONMENT=AzureUSGovernment`
+- `AZURE_AUDIENCE=api://AzureADTokenExchangeUSGov`
+
+## Documented region codes
+
+- `usgovarizona` → `USAR`
+- `usgovtexas` → `USTE`
+- `usgovvirginia` → `USVI`
+
+## Operator checks
+
+- Use an SDAF image/version that includes Azure Government support.
+- Apply the documented Government DNS-zone block only to Government workspaces.
+- Apply the private-endpoint policy workaround only for the documented Azure
+  Government error.
+- For `SkuNotAvailable`, list sizes offered in the target subscription and region.
+- For OIDC failures, confirm cloud, audience, environment, and subject settings
+  from the GitHub Actions operator documentation.
+
+China, German, and other sovereign-cloud procedures remain out of scope until
+published operator documentation exists.

--- a/skills/sdaf-state-management/SKILL.md
+++ b/skills/sdaf-state-management/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: sdaf-state-management
+description: >
+  Inspect and repair SDAF Terraform state safely before any reviewed
+  import/remove. Grounded in `docs/local/07-00-operations.md § Manage state
+  safely`, `docs/local/troubleshooting.md § Terraform reports a state lock`,
+  and `deploy/scripts/advanced_state_management.sh`. Use when a user says
+  "advanced_state_management.sh", "terraform state list", "state import",
+  "state rm", "repair SDAF state", "remote state disagrees with Azure", or
+  "who owns this state lock". Do NOT use for teardown, reverse-order destroy,
+  ARM fallback, or an unclassified failed run.
+allowed-tools: shell
+license: MIT
+---
+
+# SDAF State Management
+
+Action-loop skill. Canonical owner of the warning that
+`advanced_state_management.sh` re-inits on every op. Uses only the reviewed
+`list` / `import` / `remove` path documented in the repo and the checked-out
+script's own `--help`; refuses to invent a generic unlock or teardown path.
+
+## When to invoke
+
+Trigger on: `advanced_state_management.sh`, "terraform state list", "state import",
+"state rm", "repair remote state", "backend metadata", "resources.lst", "state lock
+owner", "remote tfstate disagrees with Azure".
+
+Do NOT trigger on: destroy / teardown / ARM fallback / reverse-order removal,
+`remover.sh`, `remove_controlplane.sh`, hosted removal wrappers, or a failed run
+whose symptom is still ambiguous.
+
+## Preconditions
+
+- The operator has an approved state operation (`docs/local/07-00-operations.md
+  § Prepare an operational change`).
+- `SAP_AUTOMATION_REPO_PATH`, `CONFIG_REPO_PATH`, and `ARM_SUBSCRIPTION_ID` are
+  set, or the missing-export gate is fixed first.
+- The target root is known: `sap_deployer`, `sap_library`, `sap_landscape`, or
+  `sap_system`.
+- The parameter file, state subscription, storage account, and key identify the
+  intended backend.
+- For `import` or `remove`, the exact Terraform address and Azure resource ID
+  are known. If not, stop and inspect first.
+
+## Recipe
+### Step 1 — Confirm the boundary before touching state
+- **This skill owns** reviewed state inspection and repair through
+  `deploy/scripts/advanced_state_management.sh`.
+- **`sdaf-safe-removal` owns** Terraform destroy, reverse-order teardown,
+  and removal through the documented SDAF operations.
+- **`sdaf-failure-triage` owns** an ambiguous failed run before the operator has
+  established whether the problem is readiness, deploy, removal, or state.
+
+If the user is trying to delete resources or finish an incomplete teardown,
+route to `sdaf-safe-removal`. Do not hide removal problems with state edits.
+
+### Step 2 — Reconcile backend identity and back up first
+Walk the checklist in [`references/state-safety.md`](references/state-safety.md):
+
+- Remote state is authoritative after control-plane bootstrap; local
+  `.terraform/terraform.tfstate` is backend metadata, not the source of truth.
+- Back up the target remote-state blob and local backend metadata before **any**
+  reviewed state operation.
+- Confirm the local metadata, the supplied subscription/storage account/key, and
+  any `.sap_deployment_automation` metadata all point at the same backend. The
+  script can infer backend values when arguments are omitted; inspect before
+  trusting.
+- Preserve lock details and prove no other workflow, pipeline, operator, or process
+  still owns the blob.
+
+### Step 3 — Inspect first with the documented `list` path
+Before changing anything, confirm the checked-out script contract:
+
+```bash
+"$SAP_AUTOMATION_REPO_PATH/deploy/scripts/advanced_state_management.sh" --help
+```
+
+Then start with the non-destructive *intent* from the documented `list`
+example in `docs/local/07-00-operations.md § Manage state safely`:
+
+```bash
+cd "$CONFIG_REPO_PATH/WORKSPACES/SYSTEM/<SAP_SYSTEM>"
+"$SAP_AUTOMATION_REPO_PATH/deploy/scripts/advanced_state_management.sh" \
+  --parameterfile "<SAP_SYSTEM>.tfvars" \
+  --type sap_system \
+  --operation list \
+  --subscription "<STATE_SUBSCRIPTION_ID>" \
+  --storage_account_name "<STATE_STORAGE_ACCOUNT>" \
+  --terraform_keyfile "<SAP_SYSTEM>.terraform.tfstate" \
+  --workload_zone_name "<WORKLOAD_ZONE>" \
+  --control_plane_name "<CONTROL_PLANE>"
+```
+
+The script initializes the matching root module, writes `resources.lst`, and
+only then lists resources. Treat any unexpected copy/migrate prompt as a stop
+condition; reconcile the backend first and rerun only after review.
+
+### Step 4 — Treat `import` / `remove` as reviewed repairs, never discovery
+- `state rm` stops Terraform from managing a resource; it does **not** delete
+  the Azure resource.
+- The script validates `--azure_resource_id` with `az resource show --ids`
+  before import. If that lookup fails, stop.
+- `import` and `remove` are only valid once `resources.lst`, the Terraform address,
+  and the Azure resource ID all match the reviewed target.
+- Do not shorten, pattern-match, or guess a Terraform address or Azure resource
+  ID.
+- Do not use `state rm` to bypass a replacement, to make an incomplete removal
+  look clean, or as a substitute for a destroy plan. Those are boundary
+  violations: route to `sdaf-failure-triage` or `sdaf-safe-removal`.
+
+If the docs, script output, Azure resource lookup, and stored metadata do not
+line up cleanly, say docs are insufficient for a safe reviewed edit and stop.
+
+### Step 5 — Re-list, retain evidence, then hand off
+After any reviewed import/remove:
+
+- rerun `--operation list` to confirm the new association;
+- retain the command, output, state account, container, and blob names; and
+- hand back to the owning stage skill for a fresh plan, or to `sdaf-safe-removal`
+  if the next reviewed step is an actual teardown.
+
+## Hard rules
+- Documented behaviour only (D19). If the docs and checked-out script are silent,
+  stop.
+- Never synthesize destructive state edits, generic unlock commands, or an
+  undeclared hosted recovery wrapper.
+- Do not treat `list` as read-only; initialization can still migrate or upgrade
+  backend/provider state.
+- Do not run two execution models concurrently against the same state.
+- Do not treat local backend metadata as the authoritative state record.
+
+## What this skill does NOT do
+- Does not perform teardown, destroy, ARM fallback, or generic failed-run triage.
+- Does not invent a `terraform force-unlock` procedure or approve import/remove
+  without backups and exact identifiers.
+
+## See also
+- `sdaf-safe-removal`, `sdaf-failure-triage`, `sdaf-control-plane-bootstrap`,
+  `sdaf-workload-zone`, `sdaf-sap-system`.
+- `docs/local/07-00-operations.md`, `docs/local/troubleshooting.md`, and
+  [`references/state-safety.md`](references/state-safety.md).

--- a/skills/sdaf-state-management/references/state-safety.md
+++ b/skills/sdaf-state-management/references/state-safety.md
@@ -1,0 +1,23 @@
+# State-management safety
+
+Use `docs/local/07-00-operations.md § Manage state safely` and
+`docs/local/troubleshooting.md § Terraform reports a state lock`.
+
+## Required sequence
+
+1. Back up the authoritative remote-state blob.
+2. Back up local backend metadata.
+3. Confirm subscription, resource group, storage account, container, and key.
+4. Preserve lock details and prove no concurrent process owns the state.
+5. Review the checked-out state-management command's help.
+6. List state before considering import or remove.
+7. Confirm the exact Terraform address and Azure resource ID.
+8. Re-list state after an approved repair and retain all evidence.
+
+## Boundaries
+
+- State removal stops Terraform managing an object; it does not delete Azure resources.
+- Teardown belongs to `sdaf-safe-removal`.
+- An ambiguous failed run belongs to `sdaf-failure-triage`.
+- Never use state edits to hide an unexpected replacement or incomplete removal.
+- If documentation, state output, and Azure identity do not agree, stop.

--- a/skills/sdaf-workload-zone/SKILL.md
+++ b/skills/sdaf-workload-zone/SKILL.md
@@ -66,12 +66,11 @@ cd "$CONFIG_REPO_PATH/WORKSPACES/LANDSCAPE/<WORKLOAD_ZONE>-INFRASTRUCTURE"
     --deployer_tfstate_key "<DEPLOYER_STATE_KEY>" \
     --storageaccountname "<STATE_STORAGE_ACCOUNT>" \
     --state_subscription "<STATE_SUBSCRIPTION_ID>" \
-    --subscription "<WORKLOAD_SUBSCRIPTION_ID>"
-rc=$?
-if [ $rc -ne 0 ]; then
+    --subscription "<WORKLOAD_SUBSCRIPTION_ID>" || {
+  rc=$?
   echo "workload-zone exit=$rc — route to sdaf-failure-triage"
-  exit $rc
-fi
+  exit "$rc"
+}
 ```
 
 Run from the directory that contains the tfvars; pass the basename only

--- a/skills/sdaf-workload-zone/SKILL.md
+++ b/skills/sdaf-workload-zone/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: sdaf-workload-zone
+description: >
+  Deploy an SDAF workload zone (landscape network, peering, zone Key Vault)
+  after the control plane exists. Drives `install_workloadzone.sh` per
+  `docs/local/04-00-workload-zone.md`, reviews the plan, and validates the
+  state blob and summary. This skill owns the decision boundary for
+  workload-zone private-endpoint / subnet-policy conflicts — inspect the
+  actual Azure error and the workload-zone tfvars against
+  `docs/local/04-00-workload-zone.md § Configuration preparation` before
+  changing settings, and do not auto-apply a cloud-specific workaround
+  outside its documented scope. Use when a user says "deploy a workload
+  zone", "deploy the landscape", "run install_workloadzone.sh", "connect the
+  workload zone to control-plane state", "workload-zone private endpoint
+  failure", or "workload-zone subnet policy failure". Do NOT use for the
+  control plane (see sdaf-control-plane-bootstrap) or SAP system (see
+  sdaf-sap-system).
+allowed-tools: shell
+license: MIT
+---
+
+# SDAF Workload Zone
+
+Action-loop skill. Deploys the workload zone per
+`docs/local/04-00-workload-zone.md`. Canonical owner of workload-zone
+private-endpoint / subnet-policy decisions — the failure-triage skill
+routes those symptoms here.
+
+## When to invoke
+
+Trigger on: "deploy a workload zone", "deploy the landscape", "run
+install_workloadzone.sh", "workload-zone Key Vault", "workload-zone private
+endpoint failure", "workload-zone subnet policy failure".
+
+Do NOT trigger on: control plane, SAP system, install, removal.
+
+## Preconditions
+
+- Control plane deployed (`docs/local/04-00-workload-zone.md § Before you
+  begin`; the WZ reads control-plane / deployer state per
+  `§ What the automation does`).
+- Landscape tfvars prepared under the documented WORKSPACES layout — see
+  `sdaf-workspace-and-tfvars` (`§ Configuration preparation`, `§ Inputs`).
+- Remote-state / storage / connectivity / quota reviewed
+  (`§ Before you begin`).
+
+## Recipe
+
+### Step 1 — Review the plan
+
+Re-read the landscape tfvars once and cross-check network, storage, Key
+Vault, and peering
+(`docs/local/04-00-workload-zone.md § Review before execution`).
+
+### Step 2 — Run install_workloadzone.sh (documented shape)
+
+From the landscape parameter directory, exactly per
+`docs/local/04-00-workload-zone.md § Run`:
+
+```bash
+set -e
+cd "$CONFIG_REPO_PATH/WORKSPACES/LANDSCAPE/<WORKLOAD_ZONE>-INFRASTRUCTURE"
+"$SAP_AUTOMATION_REPO_PATH/deploy/scripts/install_workloadzone.sh" \
+    --parameterfile "<WORKLOAD_ZONE>-INFRASTRUCTURE.tfvars" \
+    --control_plane_name "<CONTROL_PLANE>" \
+    --deployer_tfstate_key "<DEPLOYER_STATE_KEY>" \
+    --storageaccountname "<STATE_STORAGE_ACCOUNT>" \
+    --state_subscription "<STATE_SUBSCRIPTION_ID>" \
+    --subscription "<WORKLOAD_SUBSCRIPTION_ID>"
+rc=$?
+if [ $rc -ne 0 ]; then
+  echo "workload-zone exit=$rc — route to sdaf-failure-triage"
+  exit $rc
+fi
+```
+
+Run from the directory that contains the tfvars; pass the basename only
+(`docs/local/troubleshooting.md § A parameter file is not found`).
+
+### Step 3 — Validate
+
+`docs/local/04-00-workload-zone.md § Validate` and `§ Outcome`:
+
+- Workload-zone `.tfvars` and backend metadata written to the state
+  account's `tfvars` container (`§ What the automation does`).
+- Zone Key Vault deployed (`§ Outcome`).
+- Summary written.
+
+## Decision: workload-zone private-endpoint and subnet-policy failures
+
+**Canonical owner.** The failure-triage skill routes any workload-zone
+private-endpoint or subnet-policy failure here rather than restating the
+fix inline.
+
+**Decision boundary — apply on every occurrence, do not shortcut:**
+
+1. Read the exact Azure error text from the run log. Do not assume the
+   error class from the operator's paraphrase.
+2. Read the current values of the workload-zone private-endpoint and
+   subnet-policy settings in the tfvars actually being applied.
+3. Read `docs/local/04-00-workload-zone.md § Configuration preparation` for
+   the current documented setting names, allowed values, and the specific
+   cloud / condition under which the doc prescribes a change. Treat that
+   section as the source of truth — it may evolve; this skill deliberately
+   does not restate the setting name, allowed values, or the exact error
+   string, so it cannot go stale against the doc.
+4. Change only what the doc prescribes for the cloud you are deploying in.
+   **Do not auto-apply a cloud-specific workaround (e.g. an Azure
+   Government setting) to any other cloud** — the same doc section warns
+   against that.
+5. Re-review the plan (Step 1) before rerunning Step 2.
+
+If the log's error text, the tfvars values, and the doc section do not
+line up cleanly, say docs are silent on the specific combination and stop.
+Do not synthesize a fix from analogous settings elsewhere.
+
+## If the run fails
+
+Route to **`sdaf-failure-triage`**, which walks the full symptom map. The
+workload-zone-*owned* preventive checks that stay here rather than in
+triage:
+
+- Filename / directory / basename mismatch — fix before rerun
+  (`docs/local/troubleshooting.md § A parameter file is not found`).
+- Private-endpoint / subnet-policy failures — walk the decision boundary
+  above.
+
+## Hard rules
+
+- Documented behaviour only (D19).
+- Do not run before the control plane exists.
+- Do not pass `--auto-approve`
+  (`docs/local/04-00-workload-zone.md § Review before execution`).
+- Do not `--force` casually
+  (`docs/local/04-00-workload-zone.md § Safe retry`).
+- Do not auto-apply a cloud-specific workaround outside the cloud the doc
+  scopes it to (see the decision boundary above).
+- Repo-wide rules apply: **do not run `terraform fmt`** and follow the
+  Terraform / Ansible / Python guidance in
+  [`.github/copilot-instructions.md`](../../.github/copilot-instructions.md).
+
+## See also
+
+- `sdaf-control-plane-bootstrap`, `sdaf-workspace-and-tfvars`,
+  `sdaf-sap-system`, `sdaf-failure-triage`.
+- `docs/local/04-00-workload-zone.md`, `docs/local/troubleshooting.md`,
+  [`.github/copilot-instructions.md`](../../.github/copilot-instructions.md).

--- a/skills/sdaf-workspace-and-tfvars/SKILL.md
+++ b/skills/sdaf-workspace-and-tfvars/SKILL.md
@@ -54,8 +54,8 @@ and the pattern:
 
 - `<ENV>` — DEV / QA / PRD / MGMT / LAB.
 - `<CODE>` — the uppercase region code from `docs/region-codes.md § Supported
-  regions` (63 supported regions; unmapped regions fall back to `unkn` per
-  `§ Unmapped regions fall back to unkn`).
+  regions`; unmapped regions fall back to `unkn` per
+  `§ Unmapped regions fall back to unkn`.
 - `<DEPLOYER>` — deployer identifier (e.g. `DEP00`, `DEP01`).
 - `<VNET>` — network identifier (e.g. `SAP01`, `SAP02`).
 - `<SID>` — SAP SID (e.g. `X00`, `HA2`, `WIN`).

--- a/skills/sdaf-workspace-and-tfvars/SKILL.md
+++ b/skills/sdaf-workspace-and-tfvars/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: sdaf-workspace-and-tfvars
+description: >
+  Explain and validate the SDAF `WORKSPACES` layout (DEPLOYER / LIBRARY /
+  LANDSCAPE / SYSTEM), the region-code naming convention, and how the four
+  tfvars files hang off it. Grounded in `docs/local/README.md § Configuration
+  and state layout`, `docs/region-codes.md`, and the samples repo
+  `sap-automation-samples/docs/01-00-terraform-samples.md`. Use when a user
+  says "how do I lay out WORKSPACES", "which tfvars go where", "SDAF naming
+  convention", "region code", "control-plane vs library vs landscape vs system
+  tfvars", or "location_short". Do NOT use to deploy anything or to select a
+  BOM (see sdaf-bom-selection).
+allowed-tools: shell
+license: MIT
+---
+
+# SDAF Workspaces and tfvars
+
+Context-primer. Answers *"where does each tfvars go, and what must the
+directory names look like?"* — grounded in the shipped docs. Hands off to the
+matching deploy skill.
+
+## When to invoke
+
+Trigger on: "WORKSPACES layout", "which tfvars", "region code", "SDAF naming
+convention", "location_short", "unkn fallback", "DEPLOYER/LIBRARY/LANDSCAPE/
+SYSTEM".
+
+Do NOT trigger on: deploying, running validate.sh (that's
+`sdaf-readiness-check`), selecting a BOM (`sdaf-bom-selection`).
+
+## The four workspaces
+
+Docs (`docs/local/README.md § Configuration and state layout`) show a
+`WORKSPACES/` tree **outside** the SDAF checkout with four leaves. Each leaf
+holds a same-named `.tfvars` file:
+
+```
+WORKSPACES/
+├── DEPLOYER/<ENV>-<CODE>-<DEPLOYER>-INFRASTRUCTURE/<same>.tfvars
+├── LIBRARY/<ENV>-<CODE>-SAP_LIBRARY/<same>.tfvars
+├── LANDSCAPE/<ENV>-<CODE>-<VNET>-INFRASTRUCTURE/<same>.tfvars
+└── SYSTEM/<ENV>-<CODE>-<VNET>-<SID>/<same>.tfvars
+```
+
+Sources: `docs/local/README.md § Configuration and state layout`;
+sample layout also documented in
+`sap-automation-samples/docs/01-00-terraform-samples.md § Inputs`.
+
+## Naming convention
+
+`docs/region-codes.md § Where the region code appears` defines the tokens
+and the pattern:
+
+- `<ENV>` — DEV / QA / PRD / MGMT / LAB.
+- `<CODE>` — the uppercase region code from `docs/region-codes.md § Supported
+  regions` (63 supported regions; unmapped regions fall back to `unkn` per
+  `§ Unmapped regions fall back to unkn`).
+- `<DEPLOYER>` — deployer identifier (e.g. `DEP00`, `DEP01`).
+- `<VNET>` — network identifier (e.g. `SAP01`, `SAP02`).
+- `<SID>` — SAP SID (e.g. `X00`, `HA2`, `WIN`).
+
+Documented examples:
+- `MGMT-WEEU-DEP01-INFRASTRUCTURE`
+- `MGMT-WEEU-SAP_LIBRARY`
+- `DEV-WEEU-SAP01-INFRASTRUCTURE`
+- `DEV-WEEU-SAP01-X00`
+
+See [`references/naming-and-region-codes.md`](references/naming-and-region-codes.md)
+for the doc-cited example set plus the "region codes appear in six places"
+note.
+
+## Filename must match the containing directory
+
+Every documented example uses the same name for the directory and the
+`.tfvars` file inside it. Deploy scripts require you to `cd` into the
+directory containing the tfvars and pass the basename only
+(`docs/local/troubleshooting.md § A parameter file is not found`). Mismatch
+between directory name / file name / declared environment/region/network/SID
+is one of the shipped stage-script validation gates.
+
+Do not "fix" a mismatch by editing state — re-name to match, or fix the
+tfvars content.
+
+## Relationship of the four workspaces
+
+- **DEPLOYER + LIBRARY** together form the control plane; the library
+  stores remote Terraform state.
+- **LANDSCAPE** (workload zone) reads control-plane / deployer state.
+- **SYSTEM** reads deployer + landscape state.
+
+The enforced deploy order (control plane → workload zone → SAP system) is
+stated in `sdaf-orientation-and-surface § The spine (order is enforced)`,
+which is the canonical statement. Doc anchors: `docs/local/README.md
+§ Complete the journey`; each stage doc's `§ What the automation does` /
+`§ Outcome`.
+
+## GitHub-Actions-generated SYSTEM tfvars
+
+For the GitHub Actions surface, docs say `04-create-system-environment.yml`
+generates and commits the SAP-system `WORKSPACES`
+(`docs/documentation-source-map.md § Lifecycle capability sources`). Do not
+hand-author the SYSTEM tfvars in that flow; treat the generation step as the
+source of truth.
+
+## Hand-off
+
+- To validate a prepared workspace: `sdaf-readiness-check` (drives
+  `validate.sh`).
+- To deploy: `sdaf-control-plane-bootstrap` → `sdaf-workload-zone` →
+  `sdaf-sap-system`.
+- To pick a BOM referenced from SYSTEM tfvars: `sdaf-bom-selection`.
+
+## See also
+
+- `sdaf-readiness-check`, `sdaf-control-plane-bootstrap`,
+  `sdaf-workload-zone`, `sdaf-sap-system`, `sdaf-bom-selection`.
+- `docs/local/README.md`, `docs/region-codes.md`,
+  `sap-automation-samples/docs/01-00-terraform-samples.md`.

--- a/skills/sdaf-workspace-and-tfvars/references/naming-and-region-codes.md
+++ b/skills/sdaf-workspace-and-tfvars/references/naming-and-region-codes.md
@@ -50,6 +50,5 @@ another".
 `docs/region-codes.md § Supported regions` includes `usgovarizona`,
 `usgovtexas`, `usgovvirginia`. For everything beyond the mapping itself
 (end-to-end Government procedures, `ARM_ENVIRONMENT`, Government DNS zone
-blocks) see the canonical statement in
-the canonical statement owned by `sdaf-failure-triage` (invoke that skill
-for the current disclaimer text).
+blocks, GitHub OIDC values, Government-only `dns_zone_names`, workload-zone
+private-endpoint policy deltas), route to `sdaf-sovereign-cloud`.

--- a/skills/sdaf-workspace-and-tfvars/references/naming-and-region-codes.md
+++ b/skills/sdaf-workspace-and-tfvars/references/naming-and-region-codes.md
@@ -1,0 +1,55 @@
+# Naming and region codes (documented)
+
+Companion to `sdaf-workspace-and-tfvars`.
+
+## Pattern per stage
+
+Sourced from `docs/region-codes.md § Where the region code appears`:
+
+- Control plane deployer: `<ENV>-<CODE>-<DEPLOYER>-INFRASTRUCTURE`
+- SAP library: `<ENV>-<CODE>-SAP_LIBRARY`
+- Workload zone: `<ENV>-<CODE>-<VNET>-INFRASTRUCTURE`
+- SAP system: `<ENV>-<CODE>-<VNET>-<SID>`
+
+## Documented examples
+
+From `docs/region-codes.md` and the samples repo
+`sap-automation-samples/Terraform/WORKSPACES/{DEPLOYER,LIBRARY,LANDSCAPE,
+SYSTEM}/readme.md`:
+
+- Control plane: `MGMT-WEEU-DEP00-INFRASTRUCTURE`, `MGMT-WEEU-DEP01-INFRASTRUCTURE`
+- Library: `MGMT-WEEU-SAP_LIBRARY`
+- Landscape: `DEV-WEEU-SAP01-INFRASTRUCTURE`, `QA-WEEU-SAP02-INFRASTRUCTURE`,
+  `PRD-WEEU-SAP03-INFRASTRUCTURE`
+- System: `DEV-WEEU-SAP01-X00`, `DEV-WEEU-SAP01-HAN`, `DEV-WEEU-SAP01-HA2`,
+  `DEV-WEEU-SAP01-ORA`, `DEV-WEEU-SAP01-DB2`, `DEV-WEEU-SAP01-WIN`,
+  `QA-WEEU-SAP02-Q00/Q01/Q02`, `PRD-WEEU-SAP03-P00/P01/P02`,
+  `LAB-SECE-SAP04-L00`
+
+The full sample system matrix (SID → DB platform / HA / OS) is not shipped
+as a single documented table; the readmes list them per directory.
+
+## Unmapped regions
+
+`docs/region-codes.md § Unmapped regions fall back to unkn`: if the region
+is not in the supported set, the code is `unkn`. That means a workspace can
+be authored against `unkn` but you should confirm the region is intended
+before deploying.
+
+## "Region code is duplicated in six files"
+
+`docs/region-codes.md` states the mapping is implemented across multiple
+files and a region is only fully supported when it is present in all of
+them. When adding a region, keep the six locations in sync per
+`docs/region-codes.md § Add a region`. This is a contributor concern; the
+operator-facing symptom is a region that "works in one place but not
+another".
+
+## Government / sovereign region codes
+
+`docs/region-codes.md § Supported regions` includes `usgovarizona`,
+`usgovtexas`, `usgovvirginia`. For everything beyond the mapping itself
+(end-to-end Government procedures, `ARM_ENVIRONMENT`, Government DNS zone
+blocks) see the canonical statement in
+the canonical statement owned by `sdaf-failure-triage` (invoke that skill
+for the current disclaimer text).


### PR DESCRIPTION
## Summary

Adds the optional `azure-sap-automation` AI-skill hub for SDAF, with 18 operator-focused skills available to GitHub Copilot CLI, Claude Code, and Gemini CLI.

## Changes

- Adds 18 documented-behavior SDAF skills covering orientation, readiness, deployment stages, HA, media, QA, state, recovery, and safe removal.
- Adds Copilot, Claude, and Gemini plugin manifests plus installation and operator documentation.
- Adds one consolidated 54-case reliability catalogue and a Python 3.11 evaluator built directly on the official GitHub Copilot SDK and native skill events.
- Adds the `Skill validation` workflow for pinned three-CLI installation checks and pull-request behavioral evaluations, including safe handling for fork PRs.
- Adds local-execution readiness guidance without making PowerShell a Linux-host prerequisite.

## Validation

- Python 3.11 SDK install and runtime download
- Black and full Pylint (`10.00/10`)
- Python compile and 54-case catalogue validation
- 18 skill frontmatter/size checks and Bash snippet parsing
- Pinned Claude, Gemini, and Copilot plugin installation in WSL; all three expose the expected 18 skills
- Python 3.10 dependency compatibility for the repository's existing CI
- Workflow YAML and clean-diff checks

Behavioral evals use a target-enabled session and a target-disabled baseline. Failed assertions fail the corresponding matrix job and retain native SDK event evidence as workflow artifacts.

## Maintainer configuration

Behavioral evaluations use GitHub Actions' short-lived `GITHUB_TOKEN` with `copilot-requests: write`. No stored personal token is required. The Azure organization must enable **Allow use of Copilot CLI billed to the organization** under organization **Settings → Copilot → Policies → Copilot CLI**.