### PR TITLE
Add trusted skill evaluation runner

### DIFF
--- a/.github/workflows/skill-validation.yml
+++ b/.github/workflows/skill-validation.yml
@@ -1,0 +1,133 @@
+name: Skill validation
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+    paths:
+      - ".claude-plugin/**"
+      - ".github/plugin/**"
+      - ".github/workflows/skill-validation.yml"
+      - "CLAUDE.md"
+      - "evals/evals.json"
+      - "GEMINI.md"
+      - "gemini-extension.json"
+      - "requirements-test.txt"
+      - "skills/**"
+      - "evals/evals.py"
+
+permissions:
+  contents: read
+  pull-requests: read
+
+env:
+  SDAF_EVAL_MAX_AI_CREDITS: "30"
+  SDAF_EVAL_MAX_OUTPUT_TOKENS: "1024"
+  SDAF_EVAL_SESSION_TIMEOUT_SECONDS: "120"
+
+jobs:
+  prepare:
+    name: Prepare routing-eval matrix
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      cases: ${{ steps.cases.outputs.value }}
+      head_repo: ${{ steps.pr.outputs.head_repo }}
+      head_sha: ${{ steps.pr.outputs.head_sha }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          persist-credentials: false
+
+      - name: Resolve content revision
+        id: pr
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "head_repo=${{ github.event.pull_request.head.repo.full_name }}" \
+            >> "$GITHUB_OUTPUT"
+          echo "head_sha=${{ github.event.pull_request.head.sha }}" \
+            >> "$GITHUB_OUTPUT"
+
+      - name: Checkout skill content as data
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ${{ steps.pr.outputs.head_repo }}
+          ref: ${{ steps.pr.outputs.head_sha }}
+          path: content
+          persist-credentials: false
+
+      - name: Build 54-case matrix
+        id: cases
+        shell: bash
+        run: |
+          set -euo pipefail
+          jq -e '
+            [.skills[].evals[].id] as $ids
+            | ($ids | length) == 54
+              and ($ids | unique | length) == 54
+              and all($ids[];
+                test("^[a-z0-9]+(-[a-z0-9]+)*$"))
+          ' content/evals/evals.json > /dev/null
+          cases="$(jq -c '[.skills[].evals[].id]' content/evals/evals.json)"
+          echo "value=$cases" >> "$GITHUB_OUTPUT"
+
+  evaluate:
+    name: Evaluate ${{ matrix.case }}
+    needs: prepare
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      copilot-requests: write
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix:
+        case: ${{ fromJSON(needs.prepare.outputs.cases) }}
+    steps:
+      - name: Checkout trusted runner
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          persist-credentials: false
+
+      - name: Checkout skill content as data
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ${{ needs.prepare.outputs.head_repo }}
+          ref: ${{ needs.prepare.outputs.head_sha }}
+          path: content
+          persist-credentials: false
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install trusted eval dependencies
+        run: |
+          python -m pip install -r requirements-test.txt
+          python -m copilot download-runtime
+
+      - name: Run with-skill and baseline comparison
+        env:
+          CASE_ID: ${{ matrix.case }}
+          COPILOT_GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          python evals/evals.py
+          --content-root "$PWD/content"
+          --case "$CASE_ID"
+          --output-dir "$RUNNER_TEMP/skill-eval/$CASE_ID"
+          --max-ai-credits "$SDAF_EVAL_MAX_AI_CREDITS"
+          --max-output-tokens "$SDAF_EVAL_MAX_OUTPUT_TOKENS"
+          --timeout "$SDAF_EVAL_SESSION_TIMEOUT_SECONDS"
+
+      - name: Upload reliability evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: skill-reliability-${{ matrix.case }}-${{ github.run_id }}
+          path: ${{ runner.temp }}/skill-eval/${{ matrix.case }}
+          if-no-files-found: error
+          retention-days: 30

--- a/evals/evals.py
+++ b/evals/evals.py
@@ -1,0 +1,639 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Evaluate SDAF skill invocation through the official GitHub Copilot SDK."""
+
+from __future__ import annotations
+import argparse
+import asyncio
+import hashlib
+import json
+import os
+import re
+import sys
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Sequence
+from copilot import (
+    CopilotClient,
+    ModelCapabilitiesOverride,
+    ModelLimitsOverride,
+    SessionEvent,
+    SessionEventType,
+    ToolSet,
+)
+from copilot.session_events import (
+    AssistantMessageData,
+    AssistantUsageData,
+    SessionErrorData,
+    SessionIdleData,
+    SessionSkillsLoadedData,
+    SkillInvokedData,
+    SkillInvokedTrigger,
+    SkillsLoadedSkill,
+)
+
+CASE_ID_PATTERN = re.compile(r"\A[a-z0-9]+(?:-[a-z0-9]+)*\Z")
+ASSERTION_COUNT = 5
+DEFAULT_AI_CREDITS = 30
+DEFAULT_OUTPUT_TOKENS = 1024
+DEFAULT_TIMEOUT_SECONDS = 120
+SENSITIVE_ASSIGNMENT = re.compile(
+    r'(?im)(["\']?(?:authorization|token|password|secret|client[_-]?secret|'
+    r'(?:x-)?api[_-]?key)["\']?\s*[:=]\s*)(["\']?)([^"\'\s,}\]]+)'
+)
+
+
+class EvalError(RuntimeError):
+    """Represent an invalid eval configuration or failed SDK run."""
+
+
+@dataclass(frozen=True, slots=True)
+class EvalCase:
+    """Store one validated reliability prompt."""
+
+    case_id: str
+    skill_name: str
+    prompt: str
+    expected_output: str
+    assertions: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class RunLimits:
+    """Store bounded SDK session settings."""
+
+    ai_credits: int
+    output_tokens: int
+    timeout_seconds: int
+
+    def validate(self) -> None:
+        """Reject unsafe or unsupported limit values."""
+
+        if not 30 <= self.ai_credits <= 100:
+            raise EvalError("max AI credits must be between 30 and 100")
+        if not 128 <= self.output_tokens <= 2048:
+            raise EvalError("max output tokens must be between 128 and 2048")
+        if not 30 <= self.timeout_seconds <= 300:
+            raise EvalError("session timeout must be between 30 and 300 seconds")
+
+
+@dataclass(frozen=True, slots=True)
+class EvalRequest:
+    """Store the inputs for one with-skill and baseline comparison."""
+
+    case: EvalCase
+    content_root: Path
+    output_dir: Path
+    model: str
+    limits: RunLimits
+
+
+class EvalCatalog:
+    """Load and validate the consolidated SDAF reliability corpus."""
+
+    def __init__(self, content_root: Path) -> None:
+        """Load cases from ``evals/evals.json`` below the content root."""
+
+        self.content_root = content_root.resolve()
+        self.skill_names = self._load_skill_names()
+        self.cases = self._load_cases()
+
+    def case_ids(self) -> tuple[str, ...]:
+        """Return all validated case IDs in stable order."""
+
+        return tuple(sorted(self.cases))
+
+    def get(self, case_id: str) -> EvalCase:
+        """Return one validated case or raise a clear configuration error."""
+
+        try:
+            return self.cases[case_id]
+        except KeyError as error:
+            raise EvalError(f"unknown case: {case_id!r}") from error
+
+    def _load_skill_names(self) -> frozenset[str]:
+        """Return names backed by safe production skill documents."""
+
+        skill_root = self.content_root / "skills"
+        if not skill_root.is_dir():
+            raise EvalError(f"missing skills directory: {skill_root}")
+        names: set[str] = set()
+        for skill_file in sorted(skill_root.glob("*/SKILL.md")):
+            self._require_safe_file(skill_file, skill_root)
+            names.add(skill_file.parent.name)
+        if len(names) != 18:
+            raise EvalError(f"expected 18 skills, found {len(names)}")
+        return frozenset(names)
+
+    def _load_cases(self) -> dict[str, EvalCase]:
+        """Parse 18 skill groups and 54 unique cases."""
+
+        eval_file = self.content_root / "evals" / "evals.json"
+        self._require_safe_file(eval_file, self.content_root / "evals")
+        try:
+            document = json.loads(eval_file.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as error:
+            raise EvalError(f"cannot read {eval_file}: {error}") from error
+        groups = document.get("skills") if isinstance(document, dict) else None
+        if not isinstance(groups, list) or len(groups) != 18:
+            raise EvalError("evals/evals.json must contain exactly 18 skill groups")
+        cases: dict[str, EvalCase] = {}
+        owners: set[str] = set()
+        for group in groups:
+            self._load_group(group, owners, cases)
+        if owners != set(self.skill_names):
+            raise EvalError("eval skill groups must exactly match production skills")
+        if len(cases) != 54:
+            raise EvalError(f"expected 54 eval cases, found {len(cases)}")
+        return cases
+
+    def _load_group(
+        self,
+        group: Any,
+        owners: set[str],
+        cases: dict[str, EvalCase],
+    ) -> None:
+        """Validate one skill group and add its cases."""
+
+        if not isinstance(group, dict) or set(group) != {"skill_name", "evals"}:
+            raise EvalError("each eval skill group must contain skill_name and evals")
+        owner = self._text(group["skill_name"], "skill_name")
+        if owner not in self.skill_names or owner in owners:
+            raise EvalError(f"invalid or duplicate eval skill group: {owner}")
+        owners.add(owner)
+        raw_cases = group["evals"]
+        if not isinstance(raw_cases, list) or len(raw_cases) != 3:
+            raise EvalError(f"{owner} must contain exactly three eval cases")
+        for raw_case in raw_cases:
+            case = self._parse_case(owner, raw_case)
+            if case.case_id in cases:
+                raise EvalError(f"duplicate eval case ID: {case.case_id}")
+            cases[case.case_id] = case
+
+    def _parse_case(self, owner: str, value: Any) -> EvalCase:
+        """Validate one eval case."""
+
+        expected_fields = {
+            "id",
+            "prompt",
+            "expected_output",
+            "assertions",
+            "x-sdaf-routing",
+        }
+        if not isinstance(value, dict) or set(value) != expected_fields:
+            raise EvalError(f"{owner} case fields do not match the reliability schema")
+        case_id = self._text(value["id"], f"{owner}.id")
+        if not CASE_ID_PATTERN.fullmatch(case_id):
+            raise EvalError(f"invalid case ID: {case_id}")
+        routing = value["x-sdaf-routing"]
+        if routing != {"expected_skill": owner}:
+            raise EvalError(f"{case_id} expected_skill must be {owner}")
+        assertions = value["assertions"]
+        if (
+            not isinstance(assertions, list)
+            or len(assertions) != ASSERTION_COUNT
+            or not all(isinstance(item, str) and item.strip() for item in assertions)
+        ):
+            raise EvalError(f"{case_id} must contain five non-empty assertions")
+        return EvalCase(
+            case_id=case_id,
+            skill_name=owner,
+            prompt=self._text(value["prompt"], f"{case_id}.prompt"),
+            expected_output=self._text(
+                value["expected_output"],
+                f"{case_id}.expected_output",
+            ),
+            assertions=tuple(assertions),
+        )
+
+    @staticmethod
+    def _text(value: Any, location: str) -> str:
+        """Return one required non-empty string."""
+
+        if not isinstance(value, str) or not value.strip():
+            raise EvalError(f"{location} must be a non-empty string")
+        return value
+
+    @staticmethod
+    def _require_safe_file(path: Path, root: Path) -> None:
+        """Reject missing files, links, hardlinks, and root escapes."""
+
+        try:
+            info = path.lstat()
+        except OSError as error:
+            raise EvalError(f"cannot inspect {path}: {error}") from error
+        if path.is_symlink() or info.st_nlink != 1 or not path.is_file():
+            raise EvalError(f"unsafe eval input file: {path}")
+        try:
+            path.resolve().relative_to(root.resolve())
+        except ValueError as error:
+            raise EvalError(f"eval input escapes its root: {path}") from error
+
+
+class SessionEvidence:
+    """Collect official typed Copilot SDK events for one session."""
+
+    def __init__(self) -> None:
+        """Initialize empty evidence and an idle completion signal."""
+
+        self.loaded_skills: tuple[SkillsLoadedSkill, ...] = ()
+        self.invocations: list[SkillInvokedData] = []
+        self.messages: list[AssistantMessageData] = []
+        self.usage: list[AssistantUsageData] = []
+        self.errors: list[SessionErrorData] = []
+        self.idle: SessionIdleData | None = None
+        self._done = asyncio.Event()
+
+    def handle(self, event: SessionEvent) -> None:
+        """Collect one event using the SDK's event discriminator and types."""
+
+        if event.type == SessionEventType.SESSION_SKILLS_LOADED:
+            if isinstance(event.data, SessionSkillsLoadedData):
+                self.loaded_skills = tuple(event.data.skills)
+        elif event.type == SessionEventType.SKILL_INVOKED:
+            if isinstance(event.data, SkillInvokedData):
+                self.invocations.append(event.data)
+        elif event.type == SessionEventType.ASSISTANT_MESSAGE:
+            if isinstance(event.data, AssistantMessageData):
+                self.messages.append(event.data)
+        elif event.type == SessionEventType.ASSISTANT_USAGE:
+            if isinstance(event.data, AssistantUsageData):
+                self.usage.append(event.data)
+        elif event.type == SessionEventType.SESSION_ERROR:
+            if isinstance(event.data, SessionErrorData):
+                self.errors.append(event.data)
+        elif event.type == SessionEventType.SESSION_IDLE:
+            if isinstance(event.data, SessionIdleData):
+                self.idle = event.data
+                self._done.set()
+
+    async def wait(self, timeout_seconds: int) -> None:
+        """Wait until the SDK reports the session is idle."""
+
+        await asyncio.wait_for(self._done.wait(), timeout=timeout_seconds)
+
+    @property
+    def response(self) -> str:
+        """Return the last non-empty complete assistant message."""
+
+        responses = [item.content.strip() for item in self.messages if item.content.strip()]
+        return responses[-1] if responses else ""
+
+    @property
+    def successful(self) -> bool:
+        """Return whether the session reached idle without an error."""
+
+        return self.idle is not None and not self.idle.aborted and not self.errors
+
+
+class SdafSkillEvals:
+    """Run one case with the target enabled and disabled."""
+
+    def __init__(self, request: EvalRequest) -> None:
+        """Initialize one case evaluator."""
+
+        self.request = request
+        self.skills_dir = request.content_root / "skills"
+        self.skill_hashes = self.source_hashes()
+
+    async def evaluate(self) -> dict[str, Any]:
+        """Run both isolated sessions and return the complete result."""
+
+        started = datetime.now(timezone.utc)
+        with_skill = await self._run_session(disable_target=False)
+        baseline = await self._run_session(disable_target=True)
+        unchanged = self.skill_hashes == self.source_hashes()
+        grades = self._grade(with_skill, baseline, unchanged)
+        result = {
+            "schema_version": 1,
+            "case_id": self.request.case.case_id,
+            "expected_skill": self.request.case.skill_name,
+            "expected_output": self.request.case.expected_output,
+            "passed": all(item["passed"] for item in grades),
+            "assertions": grades,
+            "with_skill": self._session_summary(with_skill),
+            "without_skill": self._session_summary(baseline),
+            "production_hashes_unchanged": unchanged,
+            "started_at": started.isoformat(),
+            "ended_at": datetime.now(timezone.utc).isoformat(),
+        }
+        self._write_artifacts(with_skill, baseline, result)
+        return result
+
+    def source_hashes(self) -> dict[str, str]:
+        """Hash all source skill files before and after sessions."""
+
+        return {
+            str(path.relative_to(self.request.content_root)): hashlib.sha256(
+                path.read_bytes()
+            ).hexdigest()
+            for path in sorted(self.skills_dir.glob("*/SKILL.md"))
+        }
+
+    async def _run_session(self, disable_target: bool) -> SessionEvidence:
+        """Run one isolated SDK session."""
+
+        evidence = SessionEvidence()
+        with tempfile.TemporaryDirectory(prefix="sdaf-skill-eval-") as directory:
+            temp_root = Path(directory)
+            home = temp_root / "copilot-home"
+            workspace = temp_root / "workspace"
+            home.mkdir()
+            workspace.mkdir()
+            authentication = load_authentication_environment()
+            async with CopilotClient(
+                working_directory=str(workspace),
+                base_directory=str(home),
+                env=authentication or None,
+                use_logged_in_user=not authentication,
+                log_level="error",
+                mode="empty",
+                session_idle_timeout_seconds=self.request.limits.timeout_seconds,
+            ) as client:
+                session = await client.create_session(
+                    model=self.request.model,
+                    working_directory=str(workspace),
+                    enable_config_discovery=False,
+                    enable_on_demand_instruction_discovery=False,
+                    enable_file_hooks=False,
+                    enable_host_git_operations=False,
+                    enable_session_store=False,
+                    enable_skills=True,
+                    skill_directories=[str(self.skills_dir.resolve())],
+                    disabled_skills=([self.request.case.skill_name] if disable_target else None),
+                    available_tools=ToolSet().add_builtin("skill"),
+                    session_limits={
+                        "max_ai_credits": self.request.limits.ai_credits,
+                    },
+                    model_capabilities=ModelCapabilitiesOverride(
+                        limits=ModelLimitsOverride(
+                            max_output_tokens=self.request.limits.output_tokens
+                        )
+                    ),
+                    streaming=True,
+                    memory={"enabled": False},
+                    on_event=evidence.handle,
+                )
+                async with session:
+                    await session.send(self.request.case.prompt)
+                    await evidence.wait(self.request.limits.timeout_seconds)
+        return evidence
+
+    def _grade(
+        self,
+        with_skill: SessionEvidence,
+        baseline: SessionEvidence,
+        hashes_unchanged: bool,
+    ) -> list[dict[str, Any]]:
+        """Grade the five declared reliability assertions."""
+
+        target = self.request.case.skill_name
+        target_loaded = [
+            item for item in with_skill.loaded_skills if item.name == target and item.enabled
+        ]
+        target_invocations = [item for item in with_skill.invocations if item.name == target]
+        other_invocations = [
+            item.name
+            for item in with_skill.invocations
+            if item.name.startswith("sdaf-") and item.name != target
+        ]
+        baseline_target = [item for item in baseline.invocations if item.name == target]
+        invocation_passed = (
+            len(target_loaded) == 1
+            and len(target_invocations) == 1
+            and target_invocations[0].trigger == SkillInvokedTrigger.AGENT_INVOKED
+        )
+        return [
+            self._assertion(0, invocation_passed, self._invocation_evidence(target_invocations)),
+            self._assertion(1, not other_invocations, {"other_skills": other_invocations}),
+            self._assertion(2, not baseline_target, {"target_count": len(baseline_target)}),
+            self._assertion(
+                3,
+                with_skill.successful and baseline.successful and hashes_unchanged,
+                {
+                    "with_skill_success": with_skill.successful,
+                    "baseline_success": baseline.successful,
+                    "hashes_unchanged": hashes_unchanged,
+                },
+            ),
+            self._assertion(
+                4,
+                bool(with_skill.response),
+                {"response_length": len(with_skill.response)},
+            ),
+        ]
+
+    def _assertion(
+        self,
+        index: int,
+        passed: bool,
+        evidence: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Render one assertion result using the case's declared text."""
+
+        return {
+            "text": self.request.case.assertions[index],
+            "passed": passed,
+            "evidence": evidence,
+        }
+
+    @staticmethod
+    def _invocation_evidence(items: Sequence[SkillInvokedData]) -> dict[str, Any]:
+        """Render minimal invocation evidence without skill content."""
+
+        return {
+            "count": len(items),
+            "events": [
+                {
+                    "name": item.name,
+                    "path": item.path,
+                    "plugin_name": item.plugin_name,
+                    "plugin_version": item.plugin_version,
+                    "source": item.source,
+                    "trigger": item.trigger.value if item.trigger else None,
+                }
+                for item in items
+            ],
+        }
+
+    @staticmethod
+    def _session_summary(evidence: SessionEvidence) -> dict[str, Any]:
+        """Render safe session evidence without skill content."""
+
+        return {
+            "successful": evidence.successful,
+            "loaded_skills": [
+                {"name": item.name, "enabled": item.enabled, "path": item.path}
+                for item in evidence.loaded_skills
+            ],
+            "invocations": [
+                {
+                    "name": item.name,
+                    "path": item.path,
+                    "plugin_name": item.plugin_name,
+                    "trigger": item.trigger.value if item.trigger else None,
+                }
+                for item in evidence.invocations
+            ],
+            "errors": [
+                {
+                    "type": item.error_type,
+                    "message": item.message,
+                    "code": item.error_code,
+                }
+                for item in evidence.errors
+            ],
+            "usage": [
+                {
+                    "model": item.model,
+                    "input_tokens": item.input_tokens,
+                    "output_tokens": item.output_tokens,
+                    "cost": item.cost,
+                    "duration_ms": (
+                        item.duration.total_seconds() * 1000 if item.duration else None
+                    ),
+                }
+                for item in evidence.usage
+            ],
+            "response_length": len(evidence.response),
+        }
+
+    def _write_artifacts(
+        self,
+        with_skill: SessionEvidence,
+        baseline: SessionEvidence,
+        result: dict[str, Any],
+    ) -> None:
+        """Write redacted responses, usage, grading, and summary."""
+
+        self.request.output_dir.mkdir(parents=True, exist_ok=True)
+        for name, evidence in (
+            ("with_skill", with_skill),
+            ("without_skill", baseline),
+        ):
+            arm_dir = self.request.output_dir / name
+            arm_dir.mkdir()
+            (arm_dir / "response.txt").write_text(
+                redact(evidence.response),
+                encoding="utf-8",
+                newline="\n",
+            )
+            (arm_dir / "timing.json").write_text(
+                json.dumps(self._session_summary(evidence)["usage"], indent=2) + "\n",
+                encoding="utf-8",
+                newline="\n",
+            )
+        grading = {
+            "passed": result["passed"],
+            "assertions": result["assertions"],
+        }
+        self._write_json(self.request.output_dir / "grading.json", grading)
+        self._write_json(self.request.output_dir / "result.json", result)
+
+    @staticmethod
+    def _write_json(path: Path, document: dict[str, Any]) -> None:
+        """Write one stable JSON artifact."""
+
+        path.write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+
+
+def redact(text: str) -> str:
+    """Redact simple credential assignments from response artifacts."""
+
+    return SENSITIVE_ASSIGNMENT.sub(
+        lambda match: f"{match.group(1)}{match.group(2)}[REDACTED]",
+        text,
+    )
+
+
+def load_authentication_environment() -> dict[str, str]:
+    """Return supported token variables for the child Copilot runtime."""
+
+    return {
+        name: value
+        for name in ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN")
+        if (value := os.environ.get(name, "").strip())
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line interface."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--content-root", type=Path, default=Path.cwd())
+    modes = parser.add_mutually_exclusive_group(required=True)
+    modes.add_argument("--list", action="store_true")
+    modes.add_argument("--case")
+    parser.add_argument("--output-dir", type=Path)
+    parser.add_argument("--model", default="gpt-5-mini")
+    parser.add_argument(
+        "--max-ai-credits",
+        type=int,
+        default=int(os.environ.get("SDAF_EVAL_MAX_AI_CREDITS", DEFAULT_AI_CREDITS)),
+    )
+    parser.add_argument(
+        "--max-output-tokens",
+        type=int,
+        default=int(os.environ.get("SDAF_EVAL_MAX_OUTPUT_TOKENS", DEFAULT_OUTPUT_TOKENS)),
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=int(
+            os.environ.get(
+                "SDAF_EVAL_SESSION_TIMEOUT_SECONDS",
+                DEFAULT_TIMEOUT_SECONDS,
+            )
+        ),
+    )
+    return parser
+
+
+async def run_case(args: argparse.Namespace, case: EvalCase) -> int:
+    """Run one selected reliability case."""
+
+    if args.output_dir is None:
+        raise EvalError("--output-dir is required with --case")
+    limits = RunLimits(args.max_ai_credits, args.max_output_tokens, args.timeout)
+    limits.validate()
+    request = EvalRequest(
+        case=case,
+        content_root=args.content_root.resolve(),
+        output_dir=args.output_dir.resolve(),
+        model=args.model,
+        limits=limits,
+    )
+    result = await SdafSkillEvals(request).evaluate()
+    print(json.dumps({"case_id": case.case_id, "passed": result["passed"]}))
+    return 0 if result["passed"] else 1
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """List cases or run one SDK-backed reliability comparison."""
+
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        catalog = EvalCatalog(args.content_root)
+        if args.list:
+            for case_id in catalog.case_ids():
+                print(case_id)
+            return 0
+        case = catalog.get(args.case or "")
+        return asyncio.run(run_case(args, case))
+    except (EvalError, OSError, RuntimeError, TypeError, ValueError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,6 +4,8 @@ pytest==9.1.1
 pytest-mock==3.15.1
 pytest-cov==7.1.0
 black==26.5.1
+github-copilot-sdk==1.0.9; python_version >= "3.11"
+pylint==4.0.5
 
 # Runtime dependencies imported by the modules under test.
 ansible-core==2.16.14


### PR DESCRIPTION
## Summary

Adds the trusted Copilot SDK evaluation runner required to validate skill content from fork pull requests. This is the test-infrastructure prerequisite for #1265; it does not add any SDAF skills, prompts, or plugin manifests.

## Changes

- Adds the `pull_request_target` skill-evaluation workflow for relevant fork updates.
- Adds the Python 3.11 Copilot SDK evaluator.
- Adds conditional SDK and Pylint test dependencies.

## Security boundary

- Workflow and evaluator execute from the reviewed target-branch SHA.
- Checkout credentials are disabled.
- Fork `skills/` and `evals/evals.json` are checked out only under `content/` and treated as data.
- Case IDs are validated as 54 unique safe slugs before matrix expansion.
- `copilot-requests: write` is granted only to the evaluate job.
- No fork-provided Python, workflow, or dependency file is executed.

## Validation

- Black check passed.
- Full Pylint passed at 10.00/10.
- Python compilation passed.
- Workflow YAML, embedded shell, matrix schema, and trust-boundary assertions passed.
- `git diff --check` passed.

## Follow-up

After this PR merges into `release/august-2026`, update #1265 against the release branch. Its fork-provided skills and eval catalogue will then run through this trusted evaluator automatically.