### PR TITLE
Refactor application tier /usr/sap storage handling and AFS mounts

### DIFF
--- a/Webapp/SDAF/Models/SystemModel.cs
+++ b/Webapp/SDAF/Models/SystemModel.cs
@@ -755,6 +755,8 @@ namespace SDAFWebApp.Models
 
         public bool? use_random_id_for_storageaccounts { get; set; } = true;
 
+        public bool? AFS_usr_sap { get; set; }
+
         [PrivateEndpointIdValidator]
         public string sapmnt_private_endpoint_id { get; set; }
 

--- a/Webapp/SDAF/ParameterDetails/SystemDetails.json
+++ b/Webapp/SDAF/ParameterDetails/SystemDetails.json
@@ -2182,6 +2182,15 @@
         "Display": 2
       },
       {
+        "Name": "AFS_usr_sap",
+        "Required": false,
+        "Description": "If defined, places /usr/sap for the application tier on the Azure Files sapmnt storage. Each application server, including the PAS, mounts its own directory on the share. Leave unchecked to keep /usr/sap on local storage.",
+        "Type": "checkbox",
+        "Options": [],
+        "Overrules": "",
+        "Display": 2
+      },
+      {
         "Name": "ANF_HANA_use_AVG",
         "Required": false,
         "Description": "defines if the ANF volume(s) will be created in an Application Volume Group",

--- a/Webapp/SDAF/ParameterDetails/SystemTemplate.txt
+++ b/Webapp/SDAF/ParameterDetails/SystemTemplate.txt
@@ -507,6 +507,12 @@ $$sapmnt_private_endpoint_id$$
 # use_random_id_for_storageaccounts defines if the sapmnt storage account name will have a random suffix
 $$use_random_id_for_storageaccounts$$
 
+# AFS_usr_sap, if defined, places /usr/sap for the application tier on the Azure Files sapmnt storage.
+# Each application server, including the PAS, mounts its own directory on the share.
+# When not defined, the PAS and all additional application servers use local storage.
+# This setting is independent of use_simple_mount and of where /sapmnt is placed.
+$$AFS_usr_sap$$
+
 #########################################################################################
 #                                                                                       #
 #  ANF                                                                                  #

--- a/deploy/ansible/roles-sap-os/2.6-sap-mounts/defaults/main.yaml
+++ b/deploy/ansible/roles-sap-os/2.6-sap-mounts/defaults/main.yaml
@@ -8,4 +8,6 @@ use_AFS:                               "{{ NFS_provider == 'AFS' }}"
 scs_virtual_hostname:                  "{{ custom_scs_virtual_hostname | default(sap_sid | lower ~ 'scs' ~ scs_instance_number ~ 'cl1', true) }}"
 
 nfs_fs_type:                           "{% if use_eit_for_afs %}aznfs{% else %}nfs4{% endif %}"
+
+usr_sap_on_shared_storage:             false
 ...

--- a/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.1-anf-mounts.yaml
+++ b/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.1-anf-mounts.yaml
@@ -132,43 +132,12 @@
 
 # /*---------------------------------------------------------------------------8
 # |                                                                            |
-# |         Prepare for the /usr/sap mounts                                    |
-# |         Create temporary directory structure                               |
-# |         Mount the share, create the directory structure on share           |
-# |         Unmount and clean up temporary directory structure                 |
+# |         /usr/sap for the application tier is handled by                    |
+# |         2.6.10-usrsap-app-mounts.yaml, which is provider agnostic and      |
+# |         applies the same rule to the PAS and to every additional           |
+# |         application server.                                                |
 # |                                                                            |
 # +------------------------------------4--------------------------------------*/
-
-- name:                                "2.6.1 ANF Mount - install:Get the Server name list"
-  ansible.builtin.set_fact:
-    first_app_server_temp:             "{{ first_app_server_temp | default([]) + [item] }}"
-  with_items:
-    - "{{ query('inventory_hostnames', '{{ sap_sid | upper }}_PAS') }}"
-    - "{{ query('inventory_hostnames', '{{ sap_sid | upper }}_DB') }}"
-
-# 'target_nodes':      ['app','pas'], - will be set to only pas as we do not
-# have the ability to set the different app instance numbers for multiple nodes
-# todo: fix this so that we validate that the app_instance_number is not the
-# same as the pas_instance_number. If it is the same, then we should only
-# mount the pas instance.
-- name:                                "2.6.1 ANF Mount - usr/sap"
-  ansible.builtin.include_tasks:       2.6.1.1-anf-mount.yaml
-  loop:
-    - {
-      'type':              'usrsap',
-      'temppath':          'tmpusersap',
-      'mount':             '{{ usr_sap_mountpoint }}',
-      'opts':              'rw,hard,rsize=65536,wsize=65536,sec=sys,vers=4.1,tcp',
-      'path':              '/usr/sap',
-      'set_chattr_on_dir': false,
-      'target_nodes':      ['pas'],
-      'create_temp_folders': false
-    }
-  vars:
-    primary_host:                     "{{ first_app_server_temp | first }}"
-  when:
-    - tier == 'sapos'
-    - usr_sap_mountpoint is defined
 
 # /*---------------------------------------------------------------------------8
 # |                                                                            |

--- a/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.1-anf-mounts.yaml
+++ b/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.1-anf-mounts.yaml
@@ -8,10 +8,6 @@
 # +------------------------------------4--------------------------------------*/
 ---
 
-- name:                                "2.6.1 ANF Mount - Set the NFS Service name"
-  ansible.builtin.set_fact:
-    nfs_service:                       "{% if distribution_id in ['redhat8', 'redhat9', 'redhat10'] %}nfs-server{% else %}{% if distribution_id == 'redhat7' %}nfs{% else %}{% if distribution_id in ['oraclelinux8', 'oraclelinux9'] %}rpcbind{% else %}nfsserver{% endif %}{% endif %}{% endif %}"
-
 - name:                                "2.6.1 ANF Mount - Set the NFSmount options"
   ansible.builtin.set_fact:
     mnt_options:                       'rw,nfsvers=4.1,hard,timeo=600,rsize=262144,wsize=262144,noatime,lock,_netdev,sec=sys'
@@ -39,104 +35,13 @@
     all_sap_mounts:                    "{% if MULTI_SIDS is defined %}{{ MULTI_SIDS }}{% else %}{{ all_sap_mounts | default([]) + [this_sid] }}{% endif %}"
     db_hosts:                          "{{ query('inventory_hostnames', '{{ sap_sid | upper }}_DB') }}"
 
-- name:                                "2.6.1 ANF Mount - Ensure the NFS service is stopped"
-  ansible.builtin.systemd:
-    name:                              "{{ nfs_service }}"
-    state:                             stopped
-  when:
-    - "'scs' in supported_tiers"
-    - sap_mnt is not defined
-    - sap_trans is not defined
-
 # /*---------------------------------------------------------------------------8
 # |                                                                            |
 # |                            Mount the ANF Volumes                           |
-# | Make sure to set the NFS domain in /etc/idmapd.conf on the VM to match the |
-# | default domain configuration on Azure NetApp Files: defaultv4iddomain.com. |
-# | and the mapping is set to nobody                                           |
+# |                                                                            |
+# | NFSv4 identity mapping and the nfs_service fact are prepared ahead of every |
+# | mount by 2.6.9-nfs-idmap-prep.yaml, imported from main.yaml.                |
 # | We use tier in tasks as well, to treat any special scenarios that may arise|
-# +------------------------------------4--------------------------------------*/
-# For additional information refer to the below URLs
-# https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/sap-hana-high-availability-netapp-files-suse#mount-the-azure-netapp-files-volume
-# https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/sap-hana-high-availability-netapp-files-red-hat#mount-the-azure-netapp-files-volume
-- name:                                "2.6.1 ANF Mount - Set idmapd.conf path"
-  ansible.builtin.set_fact:
-    idmapd_path:                       "{{ '/usr/etc/idmapd.conf' if (ansible_distribution_major_version | int >= 16 and ansible_os_family | upper == 'SUSE') else '/etc/idmapd.conf' }}"
-
-- name:                                "2.6.1 ANF Mount - NFS Domain Setting (ANF)"
-  block:
-    - name:                            "2.6.1 ANF Mount - Domain is configured as
-                                        the default Azure NetApp Files domain"
-      ansible.builtin.lineinfile:
-        path:                          "{{ idmapd_path }}"
-        regexp:                        '^[ #]*Domain = '
-        line:                          'Domain = defaultv4iddomain.com'
-        insertafter:                   '[General]'
-      when:
-        - tier == 'sapos'
-      register:                        id_mapping_changed
-
-    - name:                            "2.6.1 ANF Mount - Make sure that user
-                                        mapping is set to 'nobody'"
-      ansible.builtin.lineinfile:
-        path:                          "{{ idmapd_path }}"
-        regexp:                        '^[ #]*Nobody-User = '
-        line:                          'Nobody-User = nobody'
-        insertafter:                   '^[ #]*Nobody-User = '
-      when:
-        - tier == 'sapos'
-      register:                        id_mapping_changed
-
-    - name:                            "2.6.1 ANF Mount - Make sure that group
-                                        mapping is set to 'nobody'"
-      ansible.builtin.lineinfile:
-        path:                          "{{ idmapd_path }}"
-        regexp:                        '^[ #]*Nobody-Group = '
-        line:                          'Nobody-Group = nobody'
-        insertafter:                   '^[ #]*Nobody-Group = '
-      when:
-        - tier == 'sapos'
-      register:                        id_mapping_changed
-  when:
-    - tier == 'sapos'
-
-- name:                                "2.6.1 ANF Mount - Set nfs4_disable_idmapping to Y"
-  ansible.builtin.lineinfile:
-    path:                              /etc/modprobe.d/nfs.conf
-    line:                              'options nfs nfs4_disable_idmapping=Y'
-    create:                            true
-    mode:                              0644
-  when:
-    - tier == 'sapos'
-
-- name:                                "2.6.1 ANF Mount - Ensure the services are restarted"
-  block:
-    - name:                            "AF Mount: Ensure the rpcbind service is restarted"
-      ansible.builtin.systemd:
-        name:                          rpcbind
-        state:                         restarted
-    - name:                            "2.6.1 ANF Mount - Ensure the NFS ID Map service is restarted"
-      ansible.builtin.systemd:
-        name:                          "nfs-idmapd"
-        daemon-reload:                 true
-        state:                         restarted
-    - name:                            "2.6.1 ANF Mount - Pause for 5 seconds"
-      ansible.builtin.pause:
-        seconds:                       5
-    - name:                            "2.6.1 ANF Mount - Ensure the NFS service is restarted"
-      ansible.builtin.systemd:
-        name:                          "{{ nfs_service }}"
-        state:                         restarted
-  when:
-    - id_mapping_changed is changed
-
-# /*---------------------------------------------------------------------------8
-# |                                                                            |
-# |         /usr/sap for the application tier is handled by                    |
-# |         2.6.10-usrsap-app-mounts.yaml, which is provider agnostic and      |
-# |         applies the same rule to the PAS and to every additional           |
-# |         application server.                                                |
-# |                                                                            |
 # +------------------------------------4--------------------------------------*/
 
 # /*---------------------------------------------------------------------------8

--- a/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.10-usrsap-app-mounts.yaml
+++ b/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.10-usrsap-app-mounts.yaml
@@ -30,9 +30,15 @@
 # itself the root.
 - name:                                "2.6.10 usr/sap Mount - Set the preparation facts"
   ansible.builtin.set_fact:
-    usr_sap_prep_root:                 "{% if NFS_provider == 'AFS' %}{{ sap_mnt }}{% else %}{{ usr_sap_mountpoint }}{% endif %}"
-    usr_sap_prep_folder:               "{% if NFS_provider == 'AFS' %}usrsap{{ sap_sid | upper }}/{{ ansible_hostname }}{% else %}{{ ansible_hostname }}{% endif %}"
+    usr_sap_prep_root:                 "{% if NFS_provider == 'AFS' %}{{ sap_mnt | default('') }}{% else %}{{ usr_sap_mountpoint }}{% endif %}"
+    usr_sap_prep_folder:               "{% if NFS_provider == 'AFS' %}usrsapapp{{ sap_sid | upper }}/{{ ansible_hostname }}{% else %}{{ ansible_hostname }}{% endif %}"
     usr_sap_server_path:               "{{ usr_sap_mountpoint }}/{{ ansible_hostname }}"
+
+- name:                                "2.6.10 usr/sap Mount - Validate the preparation root"
+  ansible.builtin.assert:
+    that:
+      - usr_sap_prep_root | length > 0
+    fail_msg:                          "usr_sap_mountpoint is set but the share root could not be resolved. For AFS 'sap_mnt' must also be defined in sap-parameters.yaml"
 
 - name:                                "2.6.10 usr/sap Mount - Show the mount information"
   ansible.builtin.debug:
@@ -59,49 +65,54 @@
         group:                         sapsys
         mode:                          '0755'
 
-    - name:                            "2.6.10 usr/sap Mount - Mount the share root (preparation)"
+    - name:                            "2.6.10 usr/sap Mount - Prepare the per server directory"
       block:
         - name:                        "2.6.10 usr/sap Mount - Mount the share root (preparation)"
+          block:
+            - name:                    "2.6.10 usr/sap Mount - Mount the share root (preparation)"
+              ansible.posix.mount:
+                src:                   "{{ usr_sap_prep_root }}"
+                path:                  "/saptmp_usrsap"
+                fstype:                "{{ usr_sap_fstype }}"
+                opts:                  "{{ usr_sap_opts }}"
+                state:                 mounted
+          rescue:
+            - name:                    "2.6.10 usr/sap Mount - Pause for 15 seconds"
+              ansible.builtin.pause:
+                seconds:               15
+
+            - name:                    "2.6.10 usr/sap Mount - Mount the share root (preparation)"
+              ansible.posix.mount:
+                src:                   "{{ usr_sap_prep_root }}"
+                path:                  "/saptmp_usrsap"
+                fstype:                "{{ usr_sap_fstype }}"
+                opts:                  "{{ usr_sap_opts }}"
+                state:                 mounted
+
+        - name:                        "2.6.10 usr/sap Mount - Create the per server directory"
+          ansible.builtin.file:
+            path:                      "/saptmp_usrsap/{{ usr_sap_prep_folder }}"
+            state:                     directory
+            owner:                     "{{ usr_sap_owner }}"
+            group:                     sapsys
+            mode:                      '0755'
+
+      always:
+        - name:                        "2.6.10 usr/sap Mount - Unmount the share root (preparation)"
+          ansible.posix.mount:
+            src:                       "{{ usr_sap_prep_root }}"
+            path:                      "/saptmp_usrsap"
+            state:                     unmounted
+          failed_when:                 false
+
+        - name:                        "2.6.10 usr/sap Mount - Cleanup fstab and directory (preparation)"
           ansible.posix.mount:
             src:                       "{{ usr_sap_prep_root }}"
             path:                      "/saptmp_usrsap"
             fstype:                    "{{ usr_sap_fstype }}"
             opts:                      "{{ usr_sap_opts }}"
-            state:                     mounted
-      rescue:
-        - name:                        "2.6.10 usr/sap Mount - Pause for 15 seconds"
-          ansible.builtin.pause:
-            seconds:                   15
-
-        - name:                        "2.6.10 usr/sap Mount - Mount the share root (preparation)"
-          ansible.posix.mount:
-            src:                       "{{ usr_sap_prep_root }}"
-            path:                      "/saptmp_usrsap"
-            fstype:                    "{{ usr_sap_fstype }}"
-            opts:                      "{{ usr_sap_opts }}"
-            state:                     mounted
-
-    - name:                            "2.6.10 usr/sap Mount - Create the per server directory"
-      ansible.builtin.file:
-        path:                          "/saptmp_usrsap/{{ usr_sap_prep_folder }}"
-        state:                         directory
-        owner:                         "{{ usr_sap_owner }}"
-        group:                         sapsys
-        mode:                          '0755'
-
-    - name:                            "2.6.10 usr/sap Mount - Unmount the share root (preparation)"
-      ansible.posix.mount:
-        src:                           "{{ usr_sap_prep_root }}"
-        path:                          "/saptmp_usrsap"
-        state:                         unmounted
-
-    - name:                            "2.6.10 usr/sap Mount - Cleanup fstab and directory (preparation)"
-      ansible.posix.mount:
-        src:                           "{{ usr_sap_prep_root }}"
-        path:                          "/saptmp_usrsap"
-        fstype:                        "{{ usr_sap_fstype }}"
-        opts:                          "{{ usr_sap_opts }}"
-        state:                         absent
+            state:                     absent
+          failed_when:                 false
 
 # /*---------------------------------------------------------------------------8
 # |                                                                            |

--- a/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.10-usrsap-app-mounts.yaml
+++ b/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.10-usrsap-app-mounts.yaml
@@ -1,0 +1,142 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+---
+# /*---------------------------------------------------------------------------8
+# |                                                                            |
+# |         Mount /usr/sap from shared storage on the application tier         |
+# |                                                                            |
+# |         This is the single implementation for every NFS provider.          |
+# |         It is driven exclusively by the explicit usr_sap_mountpoint         |
+# |         opt-in and applies identically to the PAS and to every              |
+# |         additional application server - the PAS is an application          |
+# |         server and must follow the same filesystem rules.                  |
+# |                                                                            |
+# |         Each application server mounts its own directory on the share,     |
+# |         because all additional application servers share a single          |
+# |         app_instance_number and would otherwise collide in the same        |
+# |         instance directory.                                                |
+# |                                                                            |
+# +------------------------------------4--------------------------------------*/
+
+- name:                                "2.6.10 usr/sap Mount - Set the mount options"
+  ansible.builtin.set_fact:
+    usr_sap_fstype:                    "{% if NFS_provider == 'AFS' %}{% if use_eit_for_afs %}aznfs{% else %}nfs{% endif %}{% else %}nfs4{% endif %}"
+    usr_sap_opts:                      "{% if NFS_provider == 'AFS' %}noresvport,nfsvers=4.1,sec=sys,hard{% if use_eit_for_afs %},proto=tcp,_netdev{% endif %}{% else %}rw,hard,rsize=65536,wsize=65536,sec=sys,vers=4.1,tcp{% endif %}"
+    usr_sap_owner:                      "{% if platform == 'SYBASE' %}{{ asesidadm_uid }}{% else %}{{ sidadm_uid }}{% endif %}"
+
+# For AFS the /usr/sap directories live on the sapmnt storage, so the share root
+# is mounted to create the per server directory. For ANF the /usr/sap volume is
+# itself the root.
+- name:                                "2.6.10 usr/sap Mount - Set the preparation facts"
+  ansible.builtin.set_fact:
+    usr_sap_prep_root:                 "{% if NFS_provider == 'AFS' %}{{ sap_mnt }}{% else %}{{ usr_sap_mountpoint }}{% endif %}"
+    usr_sap_prep_folder:               "{% if NFS_provider == 'AFS' %}usrsap{{ sap_sid | upper }}/{{ ansible_hostname }}{% else %}{{ ansible_hostname }}{% endif %}"
+    usr_sap_server_path:               "{{ usr_sap_mountpoint }}/{{ ansible_hostname }}"
+
+- name:                                "2.6.10 usr/sap Mount - Show the mount information"
+  ansible.builtin.debug:
+    msg:
+      - "Mounting /usr/sap from:  {{ usr_sap_server_path }}"
+      - "Preparation root:        {{ usr_sap_prep_root }}"
+      - "Preparation folder:      {{ usr_sap_prep_folder }}"
+      - "File system type:        {{ usr_sap_fstype }}"
+    verbosity:                         2
+
+# /*---------------------------------------------------------------------------8
+# |                                                                            |
+# |         Create the per server directory on the share                       |
+# |         Mount the share root, create the directory, unmount and clean up   |
+# |                                                                            |
+# +------------------------------------4--------------------------------------*/
+
+- name:                                "2.6.10 usr/sap Mount - Create the per server directory on the share"
+  block:
+    - name:                            "2.6.10 usr/sap Mount - Create /saptmp_usrsap"
+      ansible.builtin.file:
+        path:                          "/saptmp_usrsap"
+        state:                         directory
+        group:                         sapsys
+        mode:                          '0755'
+
+    - name:                            "2.6.10 usr/sap Mount - Mount the share root (preparation)"
+      block:
+        - name:                        "2.6.10 usr/sap Mount - Mount the share root (preparation)"
+          ansible.posix.mount:
+            src:                       "{{ usr_sap_prep_root }}"
+            path:                      "/saptmp_usrsap"
+            fstype:                    "{{ usr_sap_fstype }}"
+            opts:                      "{{ usr_sap_opts }}"
+            state:                     mounted
+      rescue:
+        - name:                        "2.6.10 usr/sap Mount - Pause for 15 seconds"
+          ansible.builtin.pause:
+            seconds:                   15
+
+        - name:                        "2.6.10 usr/sap Mount - Mount the share root (preparation)"
+          ansible.posix.mount:
+            src:                       "{{ usr_sap_prep_root }}"
+            path:                      "/saptmp_usrsap"
+            fstype:                    "{{ usr_sap_fstype }}"
+            opts:                      "{{ usr_sap_opts }}"
+            state:                     mounted
+
+    - name:                            "2.6.10 usr/sap Mount - Create the per server directory"
+      ansible.builtin.file:
+        path:                          "/saptmp_usrsap/{{ usr_sap_prep_folder }}"
+        state:                         directory
+        owner:                         "{{ usr_sap_owner }}"
+        group:                         sapsys
+        mode:                          '0755'
+
+    - name:                            "2.6.10 usr/sap Mount - Unmount the share root (preparation)"
+      ansible.posix.mount:
+        src:                           "{{ usr_sap_prep_root }}"
+        path:                          "/saptmp_usrsap"
+        state:                         unmounted
+
+    - name:                            "2.6.10 usr/sap Mount - Cleanup fstab and directory (preparation)"
+      ansible.posix.mount:
+        src:                           "{{ usr_sap_prep_root }}"
+        path:                          "/saptmp_usrsap"
+        fstype:                        "{{ usr_sap_fstype }}"
+        opts:                          "{{ usr_sap_opts }}"
+        state:                         absent
+
+# /*---------------------------------------------------------------------------8
+# |                                                                            |
+# |         Mount the per server directory on /usr/sap                         |
+# |                                                                            |
+# +------------------------------------4--------------------------------------*/
+
+- name:                                "2.6.10 usr/sap Mount - usr/sap"
+  block:
+    - name:                            "2.6.10 usr/sap Mount - usr/sap"
+      ansible.posix.mount:
+        src:                           "{{ usr_sap_server_path }}"
+        path:                          "/usr/sap"
+        fstype:                        "{{ usr_sap_fstype }}"
+        opts:                          "{{ usr_sap_opts }}"
+        state:                         mounted
+  rescue:
+    - name:                            "2.6.10 usr/sap Mount - Pause for 15 seconds"
+      ansible.builtin.pause:
+        seconds:                       15
+
+    - name:                            "2.6.10 usr/sap Mount - usr/sap"
+      ansible.posix.mount:
+        src:                           "{{ usr_sap_server_path }}"
+        path:                          "/usr/sap"
+        fstype:                        "{{ usr_sap_fstype }}"
+        opts:                          "{{ usr_sap_opts }}"
+        state:                         mounted
+
+- name:                                "2.6.10 usr/sap Mount - Set the ownership of /usr/sap"
+  ansible.builtin.file:
+    path:                              "/usr/sap"
+    state:                             directory
+    owner:                             "{{ usr_sap_owner }}"
+    group:                             sapsys
+    mode:                              '0755'
+
+...

--- a/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.7-afs-mounts-simplemount.yaml
+++ b/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.7-afs-mounts-simplemount.yaml
@@ -270,7 +270,7 @@
 
 - name:                                "AFS Mount: usr/sap/{{ sap_sid | upper }}"
   when:
-    - node_tier in ['scs','ers', 'pas']
+    - node_tier in ['scs','ers']
     - sap_mnt is defined
     - use_simple_mount is defined and use_simple_mount
   block:

--- a/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.8-anf-mounts-simplemount.yaml
+++ b/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.8-anf-mounts-simplemount.yaml
@@ -8,10 +8,6 @@
 # +------------------------------------4--------------------------------------*/
 ---
 
-- name:                                "ANF Mount: Set the NFS Service name"
-  ansible.builtin.set_fact:
-    nfs_service:                       "{% if distribution_id in ['redhat8', 'redhat9', 'redhat10'] %}nfs-server{% else %}{% if distribution_id == 'redhat7' %}nfs{% else %}{% if distribution_id in ['oraclelinux8', 'oraclelinux9'] %}rpcbind{% else %}nfsserver{% endif %}{% endif %}{% endif %}"
-
 - name:                                "ANF Mount: Set the NFSmount options"
   ansible.builtin.set_fact:
     mnt_options:                       'rw,nfsvers=4.1,hard,timeo=600,rsize=262144,wsize=262144,noatime,lock,_netdev,sec=sys'
@@ -39,93 +35,14 @@
     all_sap_mounts:                    "{% if MULTI_SIDS is defined %}{{ MULTI_SIDS }}{% else %}{{ all_sap_mounts | default([]) + [this_sid] }}{% endif %}"
     db_hosts:                          "{{ query('inventory_hostnames', '{{ sap_sid | upper }}_DB') }}"
 
-- name:                                "ANF Mount: Ensure the NFS service is stopped"
-  ansible.builtin.systemd:
-    name:                              "{{ nfs_service }}"
-    state:                             stopped
-  when:
-    - "'scs' in supported_tiers"
-    - sap_mnt is not defined
-    - sap_trans is not defined
-
 # /*---------------------------------------------------------------------------8
 # |                                                                            |
 # |                            Mount the ANF Volumes                           |
-# | Make sure to set the NFS domain in /etc/idmapd.conf on the VM to match the |
-# | default domain configuration on Azure NetApp Files: defaultv4iddomain.com. |
-# | and the mapping is set to nobody                                           |
+# |                                                                            |
+# | NFSv4 identity mapping and the nfs_service fact are prepared ahead of every |
+# | mount by 2.6.9-nfs-idmap-prep.yaml, imported from main.yaml.                |
 # | We use tier in tasks as well, to treat any special scenarios that may arise|
 # +------------------------------------4--------------------------------------*/
-- name:                                "ANF Mount: Set idmapd.conf path"
-  ansible.builtin.set_fact:
-    idmapd_path:                       "{{ '/usr/etc/idmapd.conf' if (ansible_distribution_major_version | int >= 16 and ansible_os_family | upper == 'SUSE') else '/etc/idmapd.conf' }}"
-
-- name:                                "ANF Mount: NFS Domain Setting (ANF)"
-  block:
-    - name:                            "ANF Mount: Domain is configured as
-                                        the default Azure NetApp Files domain"
-      ansible.builtin.lineinfile:
-        path:                          "{{ idmapd_path }}"
-        regexp:                        '^[ #]*Domain = '
-        line:                          'Domain = defaultv4iddomain.com'
-        insertafter:                   '[General]'
-      when:
-        - tier == 'sapos'
-      register:                        id_mapping_changed
-
-    - name:                            "ANF Mount: Make sure that user
-                                        mapping is set to 'nobody'"
-      ansible.builtin.lineinfile:
-        path:                          "{{ idmapd_path }}"
-        regexp:                        '^[ #]*Nobody-User = '
-        line:                          'Nobody-User = nobody'
-        insertafter:                   '^[ #]*Nobody-User = '
-      when:
-        - tier == 'sapos'
-      register:                        id_mapping_changed
-
-    - name:                            "ANF Mount: Make sure that group
-                                        mapping is set to 'nobody'"
-      ansible.builtin.lineinfile:
-        path:                          "{{ idmapd_path }}"
-        regexp:                        '^[ #]*Nobody-Group = '
-        line:                          'Nobody-Group = nobody'
-        insertafter:                   '^[ #]*Nobody-Group = '
-      when:
-        - tier == 'sapos'
-      register:                        id_mapping_changed
-  when:
-    - tier == 'sapos'
-
-- name:                                "ANF Mount: Set nfs4_disable_idmapping to Y"
-  ansible.builtin.lineinfile:
-    path:                              /etc/modprobe.d/nfs.conf
-    line:                              'options nfs nfs4_disable_idmapping=Y'
-    create:                            true
-    mode:                              0644
-  when:
-    - tier == 'sapos'
-
-- name:                                "ANF Mount: Ensure the services are restarted"
-  block:
-    - name:                            "AF Mount: Ensure the rpcbind service is restarted"
-      ansible.builtin.systemd:
-        name:                          rpcbind
-        state:                         restarted
-    - name:                            "ANF Mount: Ensure the NFS ID Map service is restarted"
-      ansible.builtin.systemd:
-        name:                          "nfs-idmapd"
-        daemon-reload:                 true
-        state:                         restarted
-    - name:                            "ANF Mount: Pause for 5 seconds"
-      ansible.builtin.pause:
-        seconds:                       5
-    - name:                            "ANF Mount: Ensure the NFS service is restarted"
-      ansible.builtin.systemd:
-        name:                          "{{ nfs_service }}"
-        state:                         restarted
-  when:
-    - id_mapping_changed is changed
 
 # /*---------------------------------------------------------------------------8
 # |                                                                            |

--- a/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.8-anf-mounts-simplemount.yaml
+++ b/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.8-anf-mounts-simplemount.yaml
@@ -129,38 +129,12 @@
 
 # /*---------------------------------------------------------------------------8
 # |                                                                            |
-# |         Prepare for the /usr/sap mounts                                    |
-# |         Create temporary directory structure                               |
-# |         Mount the share, create the directory structure on share           |
-# |         Unmount and clean up temporary directory structure                 |
+# |         /usr/sap for the application tier is handled by                    |
+# |         2.6.10-usrsap-app-mounts.yaml, which is provider agnostic and      |
+# |         applies the same rule to the PAS and to every additional           |
+# |         application server.                                                |
 # |                                                                            |
 # +------------------------------------4--------------------------------------*/
-
-- name:                                "ANF Mount: install:Get the Server name list"
-  ansible.builtin.set_fact:
-    first_app_server_temp:             "{{ first_app_server_temp | default([]) + [item] }}"
-  with_items:
-    - "{{ query('inventory_hostnames', '{{ sap_sid | upper }}_PAS') }}"
-    - "{{ query('inventory_hostnames', '{{ sap_sid | upper }}_DB') }}"
-
-- name:                                "ANF Mount: usr/sap"
-  ansible.builtin.include_tasks:       2.6.1.1-anf-mount.yaml
-  loop:
-    - {
-      'type':              'usrsap',
-      'temppath':          'tmpusersap',
-      'mount':             '{{ usr_sap_mountpoint }}',
-      'opts':              'rw,hard,rsize=65536,wsize=65536,sec=sys,vers=4.1,tcp',
-      'path':              '/usr/sap',
-      'set_chattr_on_dir': false,
-      'target_nodes':      ['app','pas'],
-      'create_temp_folders': false
-    }
-  vars:
-    primary_host:                     "{{ first_app_server_temp | first }}"
-  when:
-    - tier == 'sapos'
-    - usr_sap_mountpoint is defined
 
 # /*---------------------------------------------------------------------------8
 # |                                                                            |

--- a/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.9-nfs-idmap-prep.yaml
+++ b/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.9-nfs-idmap-prep.yaml
@@ -1,0 +1,107 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# /*---------------------------------------------------------------------------8
+# |                                                                            |
+# |         NFSv4 identity mapping preparation for Azure NetApp Files          |
+# |                                                                            |
+# | This is host level NFS client configuration. It has no dependency on any   |
+# | mount, so it is imported early from main.yaml and must complete before the |
+# | first ANF volume is mounted or chowned - including the application tier    |
+# | /usr/sap mount performed by 2.6.10-usrsap-app-mounts.yaml.                 |
+# |                                                                            |
+# | Make sure to set the NFS domain in /etc/idmapd.conf on the VM to match the |
+# | default domain configuration on Azure NetApp Files: defaultv4iddomain.com. |
+# | and the mapping is set to nobody                                           |
+# | We use tier in tasks as well, to treat any special scenarios that may arise|
+# |                                                                            |
+# +------------------------------------4--------------------------------------*/
+---
+
+- name:                                "2.6.9 NFS ID Map - Set the NFS Service name"
+  ansible.builtin.set_fact:
+    nfs_service:                       "{% if distribution_id in ['redhat8', 'redhat9', 'redhat10'] %}nfs-server{% else %}{% if distribution_id == 'redhat7' %}nfs{% else %}{% if distribution_id in ['oraclelinux8', 'oraclelinux9'] %}rpcbind{% else %}nfsserver{% endif %}{% endif %}{% endif %}"
+
+# The NFS server is stopped before identity mapping is applied and restarted
+# after it, preserving the end state this task pair had when both halves lived
+# in 2.6.1-anf-mounts.yaml / 2.6.8-anf-mounts-simplemount.yaml. Note that on
+# Oracle Linux 8 and 9 nfs_service resolves to rpcbind, so the ordering matters.
+- name:                                "2.6.9 NFS ID Map - Ensure the NFS service is stopped"
+  ansible.builtin.systemd:
+    name:                              "{{ nfs_service }}"
+    state:                             stopped
+  when:
+    - "'scs' in supported_tiers"
+    - sap_mnt is not defined
+    - sap_trans is not defined
+
+- name:                                "2.6.9 NFS ID Map - Set idmapd.conf path"
+  ansible.builtin.set_fact:
+    idmapd_path:                       "{{ '/usr/etc/idmapd.conf' if (ansible_distribution_major_version | int >= 16 and ansible_os_family | upper == 'SUSE') else '/etc/idmapd.conf' }}"
+
+- name:                                "2.6.9 NFS ID Map - NFS Domain Setting (ANF)"
+  block:
+    - name:                            "2.6.9 NFS ID Map - Domain is configured as
+                                        the default Azure NetApp Files domain"
+      ansible.builtin.lineinfile:
+        path:                          "{{ idmapd_path }}"
+        regexp:                        '^[ #]*Domain = '
+        line:                          'Domain = defaultv4iddomain.com'
+        insertafter:                   '[General]'
+      when:
+        - tier == 'sapos'
+      register:                        id_mapping_changed
+
+    - name:                            "2.6.9 NFS ID Map - Make sure that user
+                                        mapping is set to 'nobody'"
+      ansible.builtin.lineinfile:
+        path:                          "{{ idmapd_path }}"
+        regexp:                        '^[ #]*Nobody-User = '
+        line:                          'Nobody-User = nobody'
+        insertafter:                   '^[ #]*Nobody-User = '
+      when:
+        - tier == 'sapos'
+      register:                        id_mapping_changed
+
+    - name:                            "2.6.9 NFS ID Map - Make sure that group
+                                        mapping is set to 'nobody'"
+      ansible.builtin.lineinfile:
+        path:                          "{{ idmapd_path }}"
+        regexp:                        '^[ #]*Nobody-Group = '
+        line:                          'Nobody-Group = nobody'
+        insertafter:                   '^[ #]*Nobody-Group = '
+      when:
+        - tier == 'sapos'
+      register:                        id_mapping_changed
+  when:
+    - tier == 'sapos'
+
+- name:                                "2.6.9 NFS ID Map - Set nfs4_disable_idmapping to Y"
+  ansible.builtin.lineinfile:
+    path:                              /etc/modprobe.d/nfs.conf
+    line:                              'options nfs nfs4_disable_idmapping=Y'
+    create:                            true
+    mode:                              0644
+  when:
+    - tier == 'sapos'
+
+- name:                                "2.6.9 NFS ID Map - Ensure the services are restarted"
+  block:
+    - name:                            "2.6.9 NFS ID Map - Ensure the rpcbind service is restarted"
+      ansible.builtin.systemd:
+        name:                          rpcbind
+        state:                         restarted
+    - name:                            "2.6.9 NFS ID Map - Ensure the NFS ID Map service is restarted"
+      ansible.builtin.systemd:
+        name:                          "nfs-idmapd"
+        daemon-reload:                 true
+        state:                         restarted
+    - name:                            "2.6.9 NFS ID Map - Pause for 5 seconds"
+      ansible.builtin.pause:
+        seconds:                       5
+    - name:                            "2.6.9 NFS ID Map - Ensure the NFS service is restarted"
+      ansible.builtin.systemd:
+        name:                          "{{ nfs_service }}"
+        state:                         restarted
+  when:
+    - id_mapping_changed is changed

--- a/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/main.yaml
+++ b/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/main.yaml
@@ -33,6 +33,11 @@
       - "Application tier /usr/sap mount point:       {{ usr_sap_mountpoint | default('') | ternary(usr_sap_mountpoint, 'Not set - using local storage') }}"
     verbosity:                         2
 
+- name:                                "2.6 SAP Mounts - Import NFSv4 identity mapping preparation"
+  ansible.builtin.import_tasks:        2.6.9-nfs-idmap-prep.yaml
+  when:
+    - NFS_provider == 'ANF'
+
 - name:                                "2.6 SAP Mounts - Check if the shared disk exists"
   ansible.builtin.set_fact:
     shareddisk:                        "{{ disks | selectattr('host', 'defined') |
@@ -96,6 +101,51 @@
     - sap_disk_exists == '1'
     - node_tier != 'observer'
     - not (node_tier in ['pas', 'app'] and usr_sap_on_shared_storage and MULTI_SIDS is undefined)
+
+# When the application tier /usr/sap moves to shared storage on a system that
+# previously used the local logical volume, the old xfs entry must be retired.
+# Leaving it in place would mount the logical volume at boot and land the
+# network mount on top of it - the stacked /usr/sap this design removes.
+# ansible_mounts reflects the state at play start, so the fstype test
+# identifies a genuinely local /usr/sap rather than one already on the share.
+- name:                                "2.6 SAP Mounts - Detect a local /usr/sap replaced by shared storage"
+  ansible.builtin.set_fact:
+    usr_sap_local_mount_present:       "{{ (ansible_mounts | default([]) |
+      selectattr('mount', 'equalto', '/usr/sap') |
+      selectattr('fstype', 'equalto', 'xfs') |
+      list | length) > 0 }}"
+  when:
+    - tier == 'sapos'
+    - node_tier in ['pas', 'app']
+    - MULTI_SIDS is undefined
+    - usr_sap_on_shared_storage
+
+- name:                                "2.6 SAP Mounts - Unmount the local /usr/sap replaced by shared storage"
+  ansible.posix.mount:
+    src:                               /dev/vg_sap/lv_usrsap
+    path:                              /usr/sap
+    state:                             unmounted
+  when:
+    - tier == 'sapos'
+    - node_tier in ['pas', 'app']
+    - MULTI_SIDS is undefined
+    - usr_sap_on_shared_storage
+    - usr_sap_local_mount_present | default(false)
+
+# absent_from_fstab matches on the mount point alone - src is ignored - so this
+# must stay behind usr_sap_local_mount_present. Without that guard it would
+# delete the network entry written by 2.6.10 on every converged run.
+- name:                                "2.6 SAP Mounts - Retire the local /usr/sap fstab entry"
+  ansible.posix.mount:
+    src:                               /dev/vg_sap/lv_usrsap
+    path:                              /usr/sap
+    state:                             absent_from_fstab
+  when:
+    - tier == 'sapos'
+    - node_tier in ['pas', 'app']
+    - MULTI_SIDS is undefined
+    - usr_sap_on_shared_storage
+    - usr_sap_local_mount_present | default(false)
 
 - name:                                "2.6 SAP Mounts - Mount /usr/sap on shared storage (pas & app)"
   ansible.builtin.include_tasks:       2.6.10-usrsap-app-mounts.yaml

--- a/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/main.yaml
+++ b/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/main.yaml
@@ -22,6 +22,17 @@
   ansible.builtin.include_tasks:
     file:                              "2.6-set_runtime_facts.yaml"
 
+- name:                                "2.6 SAP Mounts - Determine the application tier /usr/sap storage"
+  ansible.builtin.set_fact:
+    usr_sap_on_shared_storage:         "{{ (usr_sap_mountpoint | default('') | trim | length) > 0 }}"
+
+- name:                                "2.6 SAP Mounts - Show the application tier /usr/sap storage"
+  ansible.builtin.debug:
+    msg:
+      - "Application tier /usr/sap on shared storage: {{ usr_sap_on_shared_storage }}"
+      - "Application tier /usr/sap mount point:       {{ usr_sap_mountpoint | default('') | ternary(usr_sap_mountpoint, 'Not set - using local storage') }}"
+    verbosity:                         2
+
 - name:                                "2.6 SAP Mounts - Check if the shared disk exists"
   ansible.builtin.set_fact:
     shareddisk:                        "{{ disks | selectattr('host', 'defined') |
@@ -84,7 +95,14 @@
   when:
     - sap_disk_exists == '1'
     - node_tier != 'observer'
-    - ((node_tier == 'app' and usr_sap_mountpoint is undefined) or node_tier != 'app')
+    - not (node_tier in ['pas', 'app'] and usr_sap_on_shared_storage)
+
+- name:                                "2.6 SAP Mounts - Mount /usr/sap on shared storage (pas & app)"
+  ansible.builtin.include_tasks:       2.6.10-usrsap-app-mounts.yaml
+  when:
+    - tier == 'sapos'
+    - node_tier in ['pas', 'app']
+    - usr_sap_on_shared_storage
 
 - name:                                "2.6 SAP Mounts - Mount local kdump file path to save vmcore"
   ansible.posix.mount:

--- a/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/main.yaml
+++ b/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/main.yaml
@@ -95,13 +95,13 @@
   when:
     - sap_disk_exists == '1'
     - node_tier != 'observer'
-    - not (node_tier in ['pas', 'app'] and usr_sap_on_shared_storage)
+    - not (node_tier in ['pas', 'app'] and usr_sap_on_shared_storage and MULTI_SIDS is undefined)
 
 - name:                                "2.6 SAP Mounts - Mount /usr/sap on shared storage (pas & app)"
   ansible.builtin.include_tasks:       2.6.10-usrsap-app-mounts.yaml
   when:
-    - tier == 'sapos'
     - node_tier in ['pas', 'app']
+    - MULTI_SIDS is undefined
     - usr_sap_on_shared_storage
 
 - name:                                "2.6 SAP Mounts - Mount local kdump file path to save vmcore"

--- a/deploy/ansible/vars/ansible-input-api.yaml
+++ b/deploy/ansible/vars/ansible-input-api.yaml
@@ -250,6 +250,11 @@ NFS_version:                            "NFSv4.1"
 use_simple_mount:                       false
 # Indicate if Encryption in Transit is to be used for AFS shares
 use_eit_for_afs:                        false
+# Shared storage path for the application tier /usr/sap. When empty, the PAS and all
+# additional application servers use local storage. When set (by AFS_usr_sap or
+# ANF_usr_sap in Terraform), every application server mounts its own directory beneath
+# it. This is independent of sap_mnt and use_simple_mount.
+usr_sap_mountpoint:                     ""
 
 # Corosync defaults (Corosync v2)
 corosync_crypto_config:                 |-

--- a/deploy/terraform/run/sap_system/module.tf
+++ b/deploy/terraform/run/sap_system/module.tf
@@ -452,7 +452,7 @@ module "output_files" {
   hana_log                                      = module.hdb_node.hana_log_ANF_volumes
   hana_shared                                   = var.NFS_provider == "ANF" ? module.hdb_node.hana_shared : module.hdb_node.hana_shared_afs_path
   usr_sap                                       = var.NFS_provider == "AFS" && var.AFS_usr_sap && length(module.common_infrastructure.sapmnt_path) > 0 ? (
-                                                    format("%s/usrsap%s", module.common_infrastructure.sapmnt_path, local.sap_sid)) : (
+                                                    format("%s/usrsapapp%s", module.common_infrastructure.sapmnt_path, local.sap_sid)) : (
                                                     module.common_infrastructure.usrsap_path
                                                   )
   use_AFS_encryption_in_transit                 = module.common_infrastructure.use_AFS_encryption_in_transit

--- a/deploy/terraform/run/sap_system/module.tf
+++ b/deploy/terraform/run/sap_system/module.tf
@@ -451,7 +451,10 @@ module "output_files" {
   hana_data                                     = module.hdb_node.hana_data_ANF_volumes
   hana_log                                      = module.hdb_node.hana_log_ANF_volumes
   hana_shared                                   = var.NFS_provider == "ANF" ? module.hdb_node.hana_shared : module.hdb_node.hana_shared_afs_path
-  usr_sap                                       = module.common_infrastructure.usrsap_path
+  usr_sap                                       = var.NFS_provider == "AFS" && var.AFS_usr_sap && length(module.common_infrastructure.sapmnt_path) > 0 ? (
+                                                    format("%s/usrsap%s", module.common_infrastructure.sapmnt_path, local.sap_sid)) : (
+                                                    module.common_infrastructure.usrsap_path
+                                                  )
   use_AFS_encryption_in_transit                 = module.common_infrastructure.use_AFS_encryption_in_transit
 
   #########################################################################################

--- a/deploy/terraform/run/sap_system/tests/output_params.tftest.hcl
+++ b/deploy/terraform/run/sap_system/tests/output_params.tftest.hcl
@@ -896,8 +896,8 @@ run "params_usr_sap_mountpoint_present_when_afs_opt_in" {
   }
 
   assert {
-    condition     = strcontains(output.sap_parameters_content, "/usrsapABC")
-    error_message = "AFS_usr_sap=true must place the application tier /usr/sap on the sapmnt storage under /usrsap<SID>."
+    condition     = strcontains(output.sap_parameters_content, "/usrsapappABC")
+    error_message = "AFS_usr_sap=true must place the application tier /usr/sap on the sapmnt storage under /usrsapapp<SID>, kept separate from the ASCS/ERS /usrsap<SID> instance directory."
   }
 }
 

--- a/deploy/terraform/run/sap_system/tests/output_params.tftest.hcl
+++ b/deploy/terraform/run/sap_system/tests/output_params.tftest.hcl
@@ -854,3 +854,78 @@ run "params_simple_mount_disabled_without_scs_ha" {
   }
 }
 
+
+###############################################################################
+#                                                                             #
+#  Application tier /usr/sap storage selection                                 #
+#                                                                             #
+#  The app-tier /usr/sap location must be driven exclusively by the explicit   #
+#  AFS_usr_sap / ANF_usr_sap opt-in - never by NFS_provider, sap_mnt or        #
+#  use_simple_mount. When the opt-in is absent, sap-parameters must not carry  #
+#  a usr_sap_mountpoint line at all, so Ansible keeps the PAS and every        #
+#  additional application server on local storage.                            #
+#                                                                             #
+###############################################################################
+
+run "params_usr_sap_mountpoint_absent_by_default_on_afs" {
+  command = apply
+
+  variables {
+    NFS_provider          = "AFS"
+    scs_high_availability = true
+    use_simple_mount      = true
+  }
+
+  assert {
+    condition     = !strcontains(output.sap_parameters_content, "usr_sap_mountpoint:")
+    error_message = "AFS with simple mount but without AFS_usr_sap must not emit usr_sap_mountpoint; the application tier stays on local storage."
+  }
+}
+
+run "params_usr_sap_mountpoint_present_when_afs_opt_in" {
+  command = apply
+
+  variables {
+    NFS_provider = "AFS"
+    AFS_usr_sap  = true
+  }
+
+  assert {
+    condition     = strcontains(output.sap_parameters_content, "usr_sap_mountpoint:")
+    error_message = "AFS_usr_sap=true must emit usr_sap_mountpoint in sap-parameters."
+  }
+
+  assert {
+    condition     = strcontains(output.sap_parameters_content, "/usrsapABC")
+    error_message = "AFS_usr_sap=true must place the application tier /usr/sap on the sapmnt storage under /usrsap<SID>."
+  }
+}
+
+run "params_usr_sap_mountpoint_independent_of_simple_mount" {
+  command = apply
+
+  variables {
+    NFS_provider     = "AFS"
+    AFS_usr_sap      = true
+    use_simple_mount = false
+  }
+
+  assert {
+    condition     = strcontains(output.sap_parameters_content, "usr_sap_mountpoint:")
+    error_message = "AFS_usr_sap must be honored independently of use_simple_mount."
+  }
+}
+
+run "params_usr_sap_mountpoint_absent_when_provider_not_afs" {
+  command = apply
+
+  variables {
+    NFS_provider = "NONE"
+    AFS_usr_sap  = true
+  }
+
+  assert {
+    condition     = !strcontains(output.sap_parameters_content, "usr_sap_mountpoint:")
+    error_message = "AFS_usr_sap must have no effect when NFS_provider is not AFS."
+  }
+}

--- a/deploy/terraform/run/sap_system/tests/shard-manifest.json
+++ b/deploy/terraform/run/sap_system/tests/shard-manifest.json
@@ -2,11 +2,11 @@
   "module": "deploy/terraform/run/sap_system",
   "shards": [
     { "file": "output_hosts.tftest.hcl", "runs": 10 },
-    { "file": "output_params.tftest.hcl", "runs": 28 },
+    { "file": "output_params.tftest.hcl", "runs": 32 },
     { "file": "output_cross_sub.tftest.hcl", "runs": 6 },
     { "file": "plan_shape_core.tftest.hcl", "runs": 27 },
     { "file": "plan_shape_advanced.tftest.hcl", "runs": 22 },
     { "file": "validation.tftest.hcl", "runs": 35 }
   ],
-  "total_runs": 128
+  "total_runs": 132
 }

--- a/deploy/terraform/run/sap_system/tfvar_variables.tf
+++ b/deploy/terraform/run/sap_system/tfvar_variables.tf
@@ -1473,6 +1473,11 @@ variable "ANF_usr_sap_throughput"               {
                                                   default     = 128
                                                 }
 
+variable "AFS_usr_sap"                          {
+                                                  description = "If defined, will place /usr/sap for the application tier on the Azure Files sapmnt storage. Each application server, including the PAS, mounts its own directory on the share"
+                                                  default     = false
+                                                }
+
 
 # /sapmnt
 

--- a/deploy/terraform/run/sap_system/tfvar_variables.tf
+++ b/deploy/terraform/run/sap_system/tfvar_variables.tf
@@ -1474,7 +1474,7 @@ variable "ANF_usr_sap_throughput"               {
                                                 }
 
 variable "AFS_usr_sap"                          {
-                                                  description = "If defined, will place /usr/sap for the application tier on the Azure Files sapmnt storage. Each application server, including the PAS, mounts its own directory on the share"
+                                                  description = "If defined, will place /usr/sap for the application tier on the Azure Files sapmnt storage. Each application server, including the PAS, mounts its own directory on the share. The share is shared with /sapmnt, so increase 'sapmnt_volume_size' beyond the 128 GB default to allow for the application server work directories and traces"
                                                   default     = false
                                                 }
 

--- a/deploy/terraform/terraform-units/modules/sap_system/output_files/README.md
+++ b/deploy/terraform/terraform-units/modules/sap_system/output_files/README.md
@@ -112,7 +112,7 @@ No modules.
 | <a name="input_use_msi_for_clusters"></a> [use\_msi\_for\_clusters](#input\_use\_msi\_for\_clusters) | If true, the Pacemaker cluser will use a managed identity | `any` | n/a | yes |
 | <a name="input_use_secondary_ips"></a> [use\_secondary\_ips](#input\_use\_secondary\_ips) | Use secondary IPs for the SAP System | `any` | n/a | yes |
 | <a name="input_user_assigned_identity_id"></a> [user\_assigned\_identity\_id](#input\_user\_assigned\_identity\_id) | User assigned managed identity | `any` | n/a | yes |
-| <a name="input_usr_sap"></a> [usr\_sap](#input\_usr\_sap) | If defined provides the mount point for /usr/sap on ANF | `any` | n/a | yes |
+| <a name="input_usr_sap"></a> [usr\_sap](#input\_usr\_sap) | If defined provides the mount point for /usr/sap on ANF or on the Azure Files sapmnt storage | `any` | n/a | yes |
 | <a name="input_web_server_count"></a> [web\_server\_count](#input\_web\_server\_count) | Number of Web Dispatchers | `number` | n/a | yes |
 | <a name="input_webdispatcher_server_ips"></a> [webdispatcher\_server\_ips](#input\_webdispatcher\_server\_ips) | List of IP addresses for the Web dispatchers | `any` | n/a | yes |
 | <a name="input_webdispatcher_server_secondary_ips"></a> [webdispatcher\_server\_secondary\_ips](#input\_webdispatcher\_server\_secondary\_ips) | List of secondary IP addresses for the Web dispatchers | `any` | n/a | yes |

--- a/deploy/terraform/terraform-units/modules/sap_system/output_files/variables_global.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/output_files/variables_global.tf
@@ -212,7 +212,7 @@ variable "use_simple_mount"                     {
                                                   description = "Use simple mount"
                                                   default     = true
                                                 }
-variable "usr_sap"                              { description = "If defined provides the mount point for /usr/sap on ANF" }
+variable "usr_sap"                              { description = "If defined provides the mount point for /usr/sap on ANF or on the Azure Files sapmnt storage" }
 variable "user_assigned_identity_id"            { description = "User assigned managed identity" }
 variable "web_instance_number"                  {
                                                   description = "The Instance number for Web Dispatcher"


### PR DESCRIPTION
This pull request introduces a new, explicit option to place the application tier `/usr/sap` directory on shared storage (specifically, Azure Files sapmnt storage) via the `AFS_usr_sap` parameter. The implementation ensures that this behavior is opt-in only and is independent of other mounting options. The changes unify and simplify the logic for mounting `/usr/sap` for all application servers, improve maintainability, and add comprehensive tests to validate the new behavior.

**Application tier `/usr/sap` shared storage opt-in:**

* Added a new parameter `AFS_usr_sap` to the system model (`SystemModel.cs`) and parameter details (`SystemDetails.json`), allowing users to explicitly opt in to mounting `/usr/sap` for the application tier on Azure Files sapmnt storage. [[1]](diffhunk://#diff-d6ea131e8283649f0fcc8b3490bd5a5afb22cab1fb52dc561d73ec505ab95e86R758-R759) [[2]](diffhunk://#diff-3a853ba56f76cd34e7cae73e4e12ce6b589d063ce6bf711002b48224a0c8c5adR2184-R2192)
* Updated the Terraform module logic to set the `usr_sap` path on shared storage only when `AFS_usr_sap` is true and `NFS_provider` is `AFS`.
* Updated the Ansible variable defaults and templates to support the new `usr_sap_mountpoint` parameter, ensuring that it is only set when explicitly requested. [[1]](diffhunk://#diff-d9cca76007a90a0df0f87ef6d5e920c391d2df8098b98ff3bcd324088b4e3918R253-R257) [[2]](diffhunk://#diff-d8fccea592ae2e3986487f6ca0759e895ec7f2288635337b579bd07bb03c3da1R510-R515)

**Ansible role refactoring and logic unification:**

* Refactored Ansible tasks for `/usr/sap` mounts: removed legacy, provider-specific tasks for ANF and AFS mounts, and introduced a new, provider-agnostic task file (`2.6.10-usrsap-app-mounts.yaml`) that handles the opt-in logic and ensures each application server mounts its own directory. [[1]](diffhunk://#diff-71796226843a970d9fbdca171983f6020266419a45dba0e5429c09fb894d8c0eL135-L172) [[2]](diffhunk://#diff-a75722ba25834fa4407c2d9cbb1e0ee5e9f2c1572aaedd7a29ff9e140da51a8dL132-L164) [[3]](diffhunk://#diff-650cda5859d6b3f12817c0c7ab02b747ae1a61279dcb42fb9772ba2308ae1941R1-R153)
* Updated the main Ansible task flow to determine if `/usr/sap` should be on shared storage and to include the new unified mount logic only when the opt-in is present. [[1]](diffhunk://#diff-bf6b3f2ba510307c0386bdf37f360e45b2ba0a89f0895b491577d3c77c3a2e8fR25-R35) [[2]](diffhunk://#diff-bf6b3f2ba510307c0386bdf37f360e45b2ba0a89f0895b491577d3c77c3a2e8fL87-R105)

**Behavioral and test coverage improvements:**

* Modified existing AFS mounts to exclude the PAS from mounting `/usr/sap` unless explicitly opted in, ensuring the new behavior is not accidentally triggered.
* Added comprehensive tests to validate that the application tier `/usr/sap` is only placed on shared storage when the opt-in is set, and that the behavior is independent of other mount options like `use_simple_mount`.