### PR TITLE
Enhance NVMe swap configuration with dynamic filesystem and mount poi…

### DIFF
--- a/deploy/ansible/roles-os/1.1-swap/defaults/main.yaml
+++ b/deploy/ansible/roles-os/1.1-swap/defaults/main.yaml
@@ -9,3 +9,9 @@
 distro_name:          "{{ ansible_distribution | upper }}-{{ ansible_distribution_major_version }}"
 distribution_id:      "{{ ansible_distribution | lower ~ ansible_distribution_major_version }}"
 distribution_full_id: "{{ ansible_distribution | lower ~ ansible_distribution_version }}"
+
+# Filesystem and mount point used for the ephemeral NVMe swap RAID 0 array.
+# Defined here (rather than as block vars) so inventory/group/host vars and
+# role-default overrides take effect per normal Ansible variable precedence.
+nvme_swap_filesystem:  "ext4"
+nvme_swap_mount_point: "/mnt/resource"

--- a/deploy/ansible/roles-os/1.1-swap/files/88-azure-nvme-swap-conf
+++ b/deploy/ansible/roles-os/1.1-swap/files/88-azure-nvme-swap-conf
@@ -199,7 +199,33 @@ if [ "$fstab_entry_present" = true ] || [ "$mdadm_conf_entry_present" = true ] |
         sed -i.bak "/$RAID0_FILESYSTEM_LABEL/d" /etc/fstab
         sed -i.bak "/$RAID0_FILESYSTEM_LABEL/d" $mdadm_conf_path
     else
-        printf "Valid NVMe RAID 0 array present and no additional Direct Disks found. Skipping\n"
+        # Config files and array health look correct, but that doesn't
+        # prove the array is actually mounted at the requested target (it
+        # may have been manually unmounted, or its `nofail` boot mount may
+        # have failed). Verify the real mount state via blkid/findmnt
+        # rather than trusting fstab/mdadm.conf alone, and fail closed
+        # instead of silently letting Ansible create swap on the wrong
+        # filesystem.
+        expected_source=$(blkid -L "$RAID0_FILESYSTEM_LABEL" 2>/dev/null)
+        current_source=$(findmnt -n -o SOURCE --target "$mount_point" 2>/dev/null)
+        if [ -n "$expected_source" ] && [ "$current_source" = "$expected_source" ]; then
+            printf "Valid NVMe RAID 0 array present and mounted at $mount_point. Skipping\n"
+            exit 0
+        fi
+        if mountpoint -q "$mount_point" 2>/dev/null; then
+            printf "ERROR: $mount_point is mounted by ${current_source:-an unknown device}, not the NVMe RAID0 array (LABEL=$RAID0_FILESYSTEM_LABEL); refusing to proceed\n"
+            exit 1
+        fi
+        printf "Valid NVMe RAID 0 array present but not mounted at $mount_point. Mounting via existing fstab entry.\n"
+        if ! mkdir -p "$mount_point"; then
+            printf "Failed to create mount point directory $mount_point\n"
+            exit 1
+        fi
+        if ! mount "$mount_point"; then
+            printf "ERROR: NVMe RAID 0 array and configuration are valid, but failed to mount $mount_point\n"
+            exit 1
+        fi
+        printf "Mounted NVMe RAID 0 array at $mount_point. Skipping reinitialization\n"
         exit 0
     fi
 fi

--- a/deploy/ansible/roles-os/1.1-swap/files/88-azure-nvme-swap-conf
+++ b/deploy/ansible/roles-os/1.1-swap/files/88-azure-nvme-swap-conf
@@ -259,15 +259,19 @@ if ! echo "LABEL=$RAID0_FILESYSTEM_LABEL $mount_point $filesystem defaults,nofai
     exit 1
 fi
 
-# Add RAID 0 array to mdadm.conf. Scope the scan to this array only: a
-# bare "mdadm --detail --scan" appends an ARRAY line for every array
-# currently assembled on the host, which would duplicate unrelated
-# arrays' entries on hosts that already have other md arrays and defeat
-# the label-scoped rollback above. The script does not use `set -e`, so this
-# exit status must be checked explicitly or a failure here would silently
-# fall through to initramfs regeneration/mount without the array definition
-# ever being persisted.
-if ! mdadm --detail --scan $RAID0_DEVICE_PATH >> $mdadm_conf_path; then
+# Add RAID 0 array to mdadm.conf. Use --detail --brief with an explicit
+# device instead of --detail --scan: in MISC mode, --scan tells mdadm to
+# get the list of arrays from /proc/mdstat itself rather than accepting a
+# device argument, so combining --scan with an explicit device fails. Only
+# --brief (with the explicit device) reliably emits a single ARRAY line for
+# just this array, avoiding duplicate entries for unrelated arrays that a
+# bare "mdadm --detail --scan" (with no device) would append on hosts that
+# already have other md arrays; that scoping also keeps the label-scoped
+# rollback above accurate. The script does not use `set -e`, so this exit
+# status must be checked explicitly or a failure here would silently fall
+# through to initramfs regeneration/mount without the array definition ever
+# being persisted.
+if ! mdadm --detail --brief $RAID0_DEVICE_PATH >> $mdadm_conf_path; then
     printf "Failed to update $mdadm_conf_path\n"
     exit 1
 fi

--- a/deploy/ansible/roles-os/1.1-swap/files/88-azure-nvme-swap-conf
+++ b/deploy/ansible/roles-os/1.1-swap/files/88-azure-nvme-swap-conf
@@ -110,11 +110,35 @@ if [ "$fstab_entry_present" = true ] || [ "$mdadm_conf_entry_present" = true ] |
         # Remove the file system and partition table, and stop the RAID 0 array
         if [ "$nvme_raid0_present" = true ]; then
             if [ -e ${RAID0_DEVICE_PATH}p1 ]; then
-                umount ${RAID0_DEVICE_PATH}p1
-                wipefs -a -f ${RAID0_DEVICE_PATH}p1
+                # A swap file may still be active on this partition from a
+                # previous run (e.g. only the mount point or filesystem
+                # setting changed). Disable it first so the partition isn't
+                # busy and destructive operations don't run against live swap.
+                current_mount=$(findmnt -n -o TARGET ${RAID0_DEVICE_PATH}p1 2>/dev/null || true)
+                if [ -n "$current_mount" ]; then
+                    while read -r active_swap; do
+                        [ -n "$active_swap" ] || continue
+                        if ! swapoff "$active_swap"; then
+                            printf "Failed to disable active swap: $active_swap\n"
+                            exit 1
+                        fi
+                    done < <(swapon --show=NAME --noheadings | grep -F "${current_mount}/")
+                fi
+
+                if ! umount ${RAID0_DEVICE_PATH}p1; then
+                    printf "Failed to unmount ${RAID0_DEVICE_PATH}p1\n"
+                    exit 1
+                fi
+                if ! wipefs -a -f ${RAID0_DEVICE_PATH}p1; then
+                    printf "Failed to wipe filesystem signatures on ${RAID0_DEVICE_PATH}p1\n"
+                    exit 1
+                fi
             fi
             sgdisk -o $RAID0_DEVICE_PATH &> /dev/null
-            mdadm --stop $RAID0_DEVICE_PATH
+            if ! mdadm --stop $RAID0_DEVICE_PATH; then
+                printf "Failed to stop RAID 0 array $RAID0_DEVICE_PATH\n"
+                exit 1
+            fi
         fi
 
         # Remove any mdadm metadata from all NVMe Direct Disks
@@ -209,7 +233,10 @@ fi
 
 # Mount the partition
 printf "\nMounting filesystem to $mount_point..\n"
-mkdir $mount_point &> /dev/null
+if ! mkdir -p "$mount_point"; then
+    printf "Failed to create mount point directory $mount_point\n"
+    exit 1
+fi
 if ! mount -a; then
     printf "Failed to automount partition\n"
     exit 1

--- a/deploy/ansible/roles-os/1.1-swap/files/88-azure-nvme-swap-conf
+++ b/deploy/ansible/roles-os/1.1-swap/files/88-azure-nvme-swap-conf
@@ -27,32 +27,19 @@ if ! [ -x "$(command -v mkfs.$filesystem)" ]; then
     exit 1
 fi
 
-# Fail fast, before any destructive reinitialization, if the fixed
-# RAID0_FILESYSTEM_LABEL doesn't fit the requested filesystem's on-disk
-# label length limit (e.g. XFS labels are capped at 12 characters, vs 16
-# for ext2/3/4). Formatting would otherwise fail after the old array has
-# already been wiped, leaving the host without swap.
-case "$filesystem" in
-    xfs)
-        label_max_len=12
-        ;;
-    vfat|msdos)
-        label_max_len=11
-        ;;
-    ext2|ext3|ext4)
-        label_max_len=16
-        ;;
-    btrfs)
-        label_max_len=255
+# Restrict to filesystems this helper has been validated with. The fixed
+# RAID0_FILESYSTEM_LABEL is 15 characters, which rules out filesystems with
+# shorter label limits (e.g. XFS = 12, vfat/msdos = 11) - those would only
+# fail mkfs after the old array had already been destructively wiped.
+readonly SUPPORTED_FILESYSTEMS="ext2 ext3 ext4 btrfs"
+case " ${SUPPORTED_FILESYSTEMS} " in
+    *" ${filesystem} "*)
         ;;
     *)
-        label_max_len=${#RAID0_FILESYSTEM_LABEL}
+        printf "Filesystem \"$filesystem\" is not supported by this script. Supported filesystems: $SUPPORTED_FILESYSTEMS\n$USAGE\n"
+        exit 1
         ;;
 esac
-if [ "${#RAID0_FILESYSTEM_LABEL}" -gt "$label_max_len" ]; then
-    printf "Filesystem \"$filesystem\" limits labels to $label_max_len characters, but \"$RAID0_FILESYSTEM_LABEL\" is ${#RAID0_FILESYSTEM_LABEL}\n"
-    exit 1
-fi
 
 mount_point="$2"
 if [ ! "$mount_point" ]; then

--- a/deploy/ansible/roles-os/1.1-swap/files/88-azure-nvme-swap-conf
+++ b/deploy/ansible/roles-os/1.1-swap/files/88-azure-nvme-swap-conf
@@ -233,8 +233,12 @@ printf "The operation has completed successfully.\n"
 # Add the partition to /etc/fstab
 echo "LABEL=$RAID0_FILESYSTEM_LABEL $mount_point $filesystem defaults,nofail 0 0" >> /etc/fstab
 
-# Add RAID 0 array to mdadm.conf
-mdadm --detail --scan >> $mdadm_conf_path
+# Add RAID 0 array to mdadm.conf. Scope the scan to this array only: a
+# bare "mdadm --detail --scan" appends an ARRAY line for every array
+# currently assembled on the host, which would duplicate unrelated
+# arrays' entries on hosts that already have other md arrays and defeat
+# the label-scoped rollback below.
+mdadm --detail --scan $RAID0_DEVICE_PATH >> $mdadm_conf_path
 
 # From this point on, the fstab and mdadm.conf entries just written are only
 # valid once initramfs regeneration and the final mount both succeed. If

--- a/deploy/ansible/roles-os/1.1-swap/files/88-azure-nvme-swap-conf
+++ b/deploy/ansible/roles-os/1.1-swap/files/88-azure-nvme-swap-conf
@@ -97,18 +97,19 @@ fi
 # would pass here, get mounted first by `mount "$mount_point"`, and the
 # helper would still exit successfully, leaving Ansible to create swap on
 # that unrelated filesystem.
-if grep -q "^[^#]*[[:space:]]${mount_point}[[:space:]]" /etc/fstab 2>/dev/null; then
+#
+# The mount point is compared as an exact string against fstab's second
+# field (not interpolated into the grep pattern as a regex), since
+# nvme_swap_mount_point permits '.', which would otherwise match unintended
+# paths (e.g. "/mnt/swap.v1" matching an existing "/mnt/swapXv1" entry).
+existing_fstab_line=$(awk -v mp="$mount_point" '$1 !~ /^#/ && $2 == mp {print; exit}' /etc/fstab 2>/dev/null)
+if [ -n "$existing_fstab_line" ]; then
     # An fstab entry exists for this mount point. Verify it's for our array.
-    fstab_source=$(grep "^[^#]*[[:space:]]${mount_point}[[:space:]]" /etc/fstab | head -1 | awk '{print $1}')
-    case "$fstab_source" in
-        "LABEL=$RAID0_FILESYSTEM_LABEL")
-            # This is our entry; actual validation happens below
-            ;;
-        *)
-            printf "ERROR: An fstab entry for $mount_point points to '${fstab_source}', not the NVMe RAID0 array; refusing to proceed\n"
-            exit 1
-            ;;
-    esac
+    fstab_source=$(awk '{print $1}' <<< "$existing_fstab_line")
+    if [ "$fstab_source" != "LABEL=$RAID0_FILESYSTEM_LABEL" ]; then
+        printf "ERROR: An fstab entry for $mount_point points to '${fstab_source}', not the NVMe RAID0 array; refusing to proceed\n"
+        exit 1
+    fi
 fi
 
 # Preflight: refuse to mount over a non-empty directory on the root filesystem.
@@ -418,7 +419,7 @@ printf "\nMounting filesystem to $mount_point..\n"
 already_mounted=false
 if mountpoint -q "$mount_point" 2>/dev/null; then
     existing_source=$(findmnt -n -o SOURCE --target "$mount_point" 2>/dev/null)
-    if [ "$existing_source" != "LABEL=$RAID0_FILESYSTEM_LABEL" ] && [ "$existing_source" != "$partition_path" ]; then
+    if [ "$existing_source" != "$partition_path" ]; then
         printf "ERROR: $mount_point is already mounted (source: ${existing_source:-unknown}); refusing to mount the NVMe array on top of it\n"
         exit 1
     fi
@@ -439,6 +440,19 @@ fi
 # have already been successfully rebuilt.
 if [ "$already_mounted" = false ] && ! mount "$mount_point"; then
     printf "Failed to mount $mount_point\n"
+    exit 1
+fi
+
+# Verify the mounted source is actually our newly created partition, not
+# merely something matched by the "LABEL=azure_nvme_temp" fstab entry.
+# mount(8) resolves fstab's LABEL= specifier to whichever device carries a
+# matching label first; if a duplicate "azure_nvme_temp" label exists on
+# another device (e.g. stale data left on a different disk), mount could
+# pick that device instead, succeed, and leave the rollback trap disarmed
+# below even though the wrong disk is now mounted at $mount_point.
+mounted_source=$(findmnt -n -o SOURCE --target "$mount_point" 2>/dev/null)
+if [ "$mounted_source" != "$partition_path" ]; then
+    printf "ERROR: $mount_point is mounted by ${mounted_source:-an unknown device}, not the newly initialized $partition_path; refusing to proceed\n"
     exit 1
 fi
 printf "The operation has completed successfully.\n"

--- a/deploy/ansible/roles-os/1.1-swap/files/88-azure-nvme-swap-conf
+++ b/deploy/ansible/roles-os/1.1-swap/files/88-azure-nvme-swap-conf
@@ -235,6 +235,22 @@ echo "LABEL=$RAID0_FILESYSTEM_LABEL $mount_point $filesystem defaults,nofail 0 0
 
 # Add RAID 0 array to mdadm.conf
 mdadm --detail --scan >> $mdadm_conf_path
+
+# From this point on, the fstab and mdadm.conf entries just written are only
+# valid once initramfs regeneration and the final mount both succeed. If
+# anything below fails, a subsequent run would otherwise see a healthy array
+# plus matching fstab/mdadm.conf entries and take the "Skipping" path,
+# falsely reporting recovery while the failed step (e.g. initramfs
+# regeneration) is never retried. A trap ensures the rollback runs on every
+# exit path (not just the ones with an explicit rollback call), and is
+# disarmed only after the mount at the end of this script succeeds.
+rollback_config_entries() {
+    printf "Rolling back fstab/mdadm.conf entries added by this run.\n"
+    sed -i.bak "/$RAID0_FILESYSTEM_LABEL/d" /etc/fstab
+    sed -i.bak "/$RAID0_FILESYSTEM_LABEL/d" $mdadm_conf_path
+}
+trap rollback_config_entries EXIT
+
 # Update initramfs/dracut based on distro family derived from /etc/os-release
 os_id=""
 if [ -r /etc/os-release ]; then
@@ -283,16 +299,13 @@ if mountpoint -q "$mount_point" 2>/dev/null; then
     existing_source=$(findmnt -n -o SOURCE --target "$mount_point" 2>/dev/null)
     if [ "$existing_source" != "LABEL=$RAID0_FILESYSTEM_LABEL" ] && [ "$existing_source" != "$partition_path" ]; then
         printf "ERROR: $mount_point is already mounted (source: ${existing_source:-unknown}); refusing to mount the NVMe array on top of it\n"
-        printf "Rolling back fstab/mdadm.conf entries added by this run.\n"
-        sed -i.bak "/$RAID0_FILESYSTEM_LABEL/d" /etc/fstab
-        sed -i.bak "/$RAID0_FILESYSTEM_LABEL/d" $mdadm_conf_path
         exit 1
     fi
     # Something (e.g. udev/systemd) already mounted our own array at the
     # target during the initramfs-update window above. Skip the mount call
-    # below - it would otherwise fail with "already mounted" and trigger an
-    # unwarranted rollback of the fstab/mdadm.conf entries we just wrote,
-    # which are in fact correct and needed for the next boot.
+    # below - it would otherwise fail with "already mounted", which would
+    # be misread as a genuine mount failure even though the array/fstab
+    # entries are in fact correct and ready for the next boot.
     already_mounted=true
 fi
 if ! mkdir -p "$mount_point"; then
@@ -305,11 +318,13 @@ fi
 # have already been successfully rebuilt.
 if [ "$already_mounted" = false ] && ! mount "$mount_point"; then
     printf "Failed to mount $mount_point\n"
-    printf "Rolling back fstab/mdadm.conf entries added by this run.\n"
-    sed -i.bak "/$RAID0_FILESYSTEM_LABEL/d" /etc/fstab
-    sed -i.bak "/$RAID0_FILESYSTEM_LABEL/d" $mdadm_conf_path
     exit 1
 fi
 printf "The operation has completed successfully.\n"
+
+# Everything (initramfs regeneration and mount) succeeded: the fstab and
+# mdadm.conf entries written above are now valid and should be kept, so
+# disarm the rollback trap before exiting successfully.
+trap - EXIT
 
 exit 0

--- a/deploy/ansible/roles-os/1.1-swap/files/88-azure-nvme-swap-conf
+++ b/deploy/ansible/roles-os/1.1-swap/files/88-azure-nvme-swap-conf
@@ -152,11 +152,18 @@ if [ "$fstab_entry_present" = true ] || [ "$mdadm_conf_entry_present" = true ] |
                 if [ -n "$current_mount" ]; then
                     while read -r active_swap; do
                         [ -n "$active_swap" ] || continue
+                        # Match only swap files rooted at current_mount, not
+                        # any path that merely contains it as a substring
+                        # (e.g. "/backup${current_mount}/swapfile").
+                        case "$active_swap" in
+                            "${current_mount}/"*) ;;
+                            *) continue ;;
+                        esac
                         if ! swapoff "$active_swap"; then
                             printf "Failed to disable active swap: $active_swap\n"
                             exit 1
                         fi
-                    done < <(swapon --show=NAME --noheadings | grep -F "${current_mount}/")
+                    done < <(swapon --show=NAME --noheadings)
                 fi
 
                 # Only unmount if the partition is actually mounted - it may

--- a/deploy/ansible/roles-os/1.1-swap/files/88-azure-nvme-swap-conf
+++ b/deploy/ansible/roles-os/1.1-swap/files/88-azure-nvme-swap-conf
@@ -267,7 +267,13 @@ if [ "$fstab_entry_present" = true ] || [ "$mdadm_conf_entry_present" = true ] |
         # Must be exactly /dev/md0p1 mounted at the requested target
         expected_device="${RAID0_DEVICE_PATH}p1"
 
-        # First, verify exact mount point (not parent directory)
+        # First, verify exact mount point (not parent directory). If it's
+        # not yet mounted, mount it via the fstab entry, then fall through
+        # to the device/label verification below rather than exiting early
+        # - mount(8) resolves the LABEL= specifier to whichever device
+        # carries a matching label first, so a duplicate "azure_nvme_temp"
+        # label elsewhere could otherwise let this succeed against the
+        # wrong device without being caught.
         if ! mountpoint -q "$mount_point" 2>/dev/null; then
             printf "Valid NVMe RAID 0 array present but not mounted at $mount_point. Mounting via existing fstab entry.\n"
             if ! mkdir -p "$mount_point"; then
@@ -279,7 +285,6 @@ if [ "$fstab_entry_present" = true ] || [ "$mdadm_conf_entry_present" = true ] |
                 exit 1
             fi
             printf "Mounted NVMe RAID 0 array at $mount_point\n"
-            exit 0
         fi
 
         # Mount point exists and is mounted. Verify it's the right device.
@@ -296,7 +301,7 @@ if [ "$fstab_entry_present" = true ] || [ "$mdadm_conf_entry_present" = true ] |
             exit 1
         fi
 
-        printf "Valid NVMe RAID 0 array present and mounted at $mount_point\n"
+        printf "Valid NVMe RAID 0 array present and mounted at $mount_point. Skipping\n"
         exit 0
     fi
 fi

--- a/deploy/ansible/roles-os/1.1-swap/files/88-azure-nvme-swap-conf
+++ b/deploy/ansible/roles-os/1.1-swap/files/88-azure-nvme-swap-conf
@@ -86,6 +86,20 @@ if [ "$fstab_entry_present" = true ] || [ "$mdadm_conf_entry_present" = true ] |
                 fi
             done
         fi
+
+        # Even when the array itself is healthy, reconcile the requested
+        # filesystem/mount point against what's actually configured in
+        # fstab. If either was changed since the array was created (e.g. a
+        # redeploy with different swap settings), force a reinitialization
+        # so the array, filesystem, and fstab entry match the request.
+        if [ "$reinit_raid0" = false ]; then
+            existing_fstab_entry=$(grep "$RAID0_FILESYSTEM_LABEL" /etc/fstab)
+            existing_mount_point=$(awk '{print $2}' <<< "$existing_fstab_entry")
+            existing_filesystem=$(awk '{print $3}' <<< "$existing_fstab_entry")
+            if [ "$existing_mount_point" != "$mount_point" ] || [ "$existing_filesystem" != "$filesystem" ]; then
+                reinit_raid0=true
+            fi
+        fi
     else
         reinit_raid0=true
     fi

--- a/deploy/ansible/roles-os/1.1-swap/files/88-azure-nvme-swap-conf
+++ b/deploy/ansible/roles-os/1.1-swap/files/88-azure-nvme-swap-conf
@@ -27,6 +27,33 @@ if ! [ -x "$(command -v mkfs.$filesystem)" ]; then
     exit 1
 fi
 
+# Fail fast, before any destructive reinitialization, if the fixed
+# RAID0_FILESYSTEM_LABEL doesn't fit the requested filesystem's on-disk
+# label length limit (e.g. XFS labels are capped at 12 characters, vs 16
+# for ext2/3/4). Formatting would otherwise fail after the old array has
+# already been wiped, leaving the host without swap.
+case "$filesystem" in
+    xfs)
+        label_max_len=12
+        ;;
+    vfat|msdos)
+        label_max_len=11
+        ;;
+    ext2|ext3|ext4)
+        label_max_len=16
+        ;;
+    btrfs)
+        label_max_len=255
+        ;;
+    *)
+        label_max_len=${#RAID0_FILESYSTEM_LABEL}
+        ;;
+esac
+if [ "${#RAID0_FILESYSTEM_LABEL}" -gt "$label_max_len" ]; then
+    printf "Filesystem \"$filesystem\" limits labels to $label_max_len characters, but \"$RAID0_FILESYSTEM_LABEL\" is ${#RAID0_FILESYSTEM_LABEL}\n"
+    exit 1
+fi
+
 mount_point="$2"
 if [ ! "$mount_point" ]; then
     printf "No mount point specified. Using default: $DEFAULT_MOUNT_POINT\n"
@@ -243,8 +270,12 @@ if ! mkdir -p "$mount_point"; then
     printf "Failed to create mount point directory $mount_point\n"
     exit 1
 fi
-if ! mount -a; then
-    printf "Failed to automount partition\n"
+# Mount only the newly-added fstab target instead of `mount -a`, so an
+# unrelated fstab entry failing (e.g. an NFS mount without `nofail`)
+# doesn't make this script report failure after the array/filesystem
+# have already been successfully rebuilt.
+if ! mount "$mount_point"; then
+    printf "Failed to mount $mount_point\n"
     exit 1
 fi
 printf "The operation has completed successfully.\n"

--- a/deploy/ansible/roles-os/1.1-swap/files/88-azure-nvme-swap-conf
+++ b/deploy/ansible/roles-os/1.1-swap/files/88-azure-nvme-swap-conf
@@ -27,15 +27,14 @@ if ! [ -x "$(command -v mkfs.$filesystem)" ]; then
     exit 1
 fi
 
-# Restrict to filesystems this helper has been validated with. The fixed
-# RAID0_FILESYSTEM_LABEL is 15 characters, which rules out filesystems with
-# shorter label limits (e.g. XFS = 12, vfat/msdos = 11) - those would only
-# fail mkfs after the old array had already been destructively wiped.
-# btrfs is excluded even though its label limit is generous: swap files on
-# Btrfs require NODATACOW to be set before allocation (not done by either
-# swap-creation script), and btrfs-progs is not installed by the role's
-# dependency tasks, so mkfs.btrfs would fail on some images.
-readonly SUPPORTED_FILESYSTEMS="ext2 ext3 ext4"
+# Restrict to the filesystem the downstream swap-creation scripts actually
+# support: both create-nvme-swap.sh and create-swap-perboot.sh.j2 allocate
+# the swap file with fallocate(2), which ext2/ext3 do not support. The fixed
+# RAID0_FILESYSTEM_LABEL (15 characters) also rules out filesystems with
+# shorter label limits (e.g. XFS = 12, vfat/msdos = 11), and btrfs needs
+# NODATACOW set before allocation (not done by either script) plus
+# btrfs-progs isn't installed by the role's dependency tasks.
+readonly SUPPORTED_FILESYSTEMS="ext4"
 case " ${SUPPORTED_FILESYSTEMS} " in
     *" ${filesystem} "*)
         ;;
@@ -49,6 +48,23 @@ mount_point="$2"
 if [ ! "$mount_point" ]; then
     printf "No mount point specified. Using default: $DEFAULT_MOUNT_POINT\n"
     mount_point=$DEFAULT_MOUNT_POINT
+fi
+
+# Preflight: refuse to proceed if the target mount point is already in use
+# by something other than our own NVMe RAID0 array (matched by label). This
+# must run before any destructive or persistent change below (wiping the
+# array, formatting, appending fstab/mdadm.conf entries) - otherwise a first
+# run against an occupied target leaves those side effects in place, and a
+# retry would classify the array/configuration as valid and skip, silently
+# leaving swap creation to target the unrelated filesystem still occupying
+# the mount point.
+if mountpoint -q "$mount_point" 2>/dev/null; then
+    existing_source=$(findmnt -n -o SOURCE --target "$mount_point" 2>/dev/null)
+    expected_source=$(blkid -L "$RAID0_FILESYSTEM_LABEL" 2>/dev/null)
+    if [ -z "$expected_source" ] || [ "$existing_source" != "$expected_source" ]; then
+        printf "ERROR: $mount_point is already mounted by ${existing_source:-an unknown device}, not the NVMe RAID0 array (LABEL=$RAID0_FILESYSTEM_LABEL); refusing to proceed\n"
+        exit 1
+    fi
 fi
 
 # Make sure mdadm.conf is present
@@ -257,14 +273,20 @@ fi
 
 # Mount the partition
 printf "\nMounting filesystem to $mount_point..\n"
-# Fail closed if something is already mounted at the target: Linux allows
-# stacking a mount on top of an existing one without error, which would
-# silently hide the NVMe array behind an unrelated filesystem instead of
-# surfacing the conflict.
+# Defense in depth: the preflight check above already refused to proceed if
+# the target was occupied by something other than our own array, but guard
+# again here in case the target was mounted by something else in the
+# interim (e.g. a racing process), since Linux otherwise allows silently
+# stacking a mount on top of an existing one.
 if mountpoint -q "$mount_point" 2>/dev/null; then
     existing_source=$(findmnt -n -o SOURCE --target "$mount_point" 2>/dev/null)
-    printf "ERROR: $mount_point is already mounted (source: ${existing_source:-unknown}); refusing to mount the NVMe array on top of it\n"
-    exit 1
+    if [ "$existing_source" != "LABEL=$RAID0_FILESYSTEM_LABEL" ] && [ "$existing_source" != "$partition_path" ]; then
+        printf "ERROR: $mount_point is already mounted (source: ${existing_source:-unknown}); refusing to mount the NVMe array on top of it\n"
+        printf "Rolling back fstab/mdadm.conf entries added by this run.\n"
+        sed -i.bak "/$RAID0_FILESYSTEM_LABEL/d" /etc/fstab
+        sed -i.bak "/$RAID0_FILESYSTEM_LABEL/d" $mdadm_conf_path
+        exit 1
+    fi
 fi
 if ! mkdir -p "$mount_point"; then
     printf "Failed to create mount point directory $mount_point\n"
@@ -276,6 +298,9 @@ fi
 # have already been successfully rebuilt.
 if ! mount "$mount_point"; then
     printf "Failed to mount $mount_point\n"
+    printf "Rolling back fstab/mdadm.conf entries added by this run.\n"
+    sed -i.bak "/$RAID0_FILESYSTEM_LABEL/d" /etc/fstab
+    sed -i.bak "/$RAID0_FILESYSTEM_LABEL/d" $mdadm_conf_path
     exit 1
 fi
 printf "The operation has completed successfully.\n"

--- a/deploy/ansible/roles-os/1.1-swap/files/88-azure-nvme-swap-conf
+++ b/deploy/ansible/roles-os/1.1-swap/files/88-azure-nvme-swap-conf
@@ -67,18 +67,52 @@ if ! flock -w "$LOCK_TIMEOUT_SECONDS" 200; then
 fi
 
 # Preflight: refuse to proceed if the target mount point is already in use
-# by something other than our own NVMe RAID0 array (matched by label). This
-# must run before any destructive or persistent change below (wiping the
-# array, formatting, appending fstab/mdadm.conf entries) - otherwise a first
-# run against an occupied target leaves those side effects in place, and a
-# retry would classify the array/configuration as valid and skip, silently
-# leaving swap creation to target the unrelated filesystem still occupying
-# the mount point.
+# by something other than our own NVMe RAID0 array. This must run before
+# any destructive or persistent change below (wiping the array, formatting,
+# appending fstab/mdadm.conf entries) - otherwise a first run against an
+# occupied target leaves those side effects in place, and a retry would
+# classify the array/configuration as valid and skip, silently leaving swap
+# creation to target the unrelated filesystem still occupying the mount point.
 if mountpoint -q "$mount_point" 2>/dev/null; then
     existing_source=$(findmnt -n -o SOURCE --target "$mount_point" 2>/dev/null)
-    expected_source=$(blkid -L "$RAID0_FILESYSTEM_LABEL" 2>/dev/null)
-    if [ -z "$expected_source" ] || [ "$existing_source" != "$expected_source" ]; then
-        printf "ERROR: $mount_point is already mounted by ${existing_source:-an unknown device}, not the NVMe RAID0 array (LABEL=$RAID0_FILESYSTEM_LABEL); refusing to proceed\n"
+    expected_source="$RAID0_DEVICE_PATH"p1
+    if [ "$existing_source" != "$expected_source" ]; then
+        printf "ERROR: $mount_point is already mounted by ${existing_source:-an unknown device}, not the NVMe RAID0 array (expected $expected_source); refusing to proceed\n"
+        exit 1
+    fi
+    # Verify this is really our array by checking the label as well
+    filesystem_label=$(blkid -s LABEL -o value "$existing_source" 2>/dev/null || true)
+    if [ "$filesystem_label" != "$RAID0_FILESYSTEM_LABEL" ]; then
+        printf "ERROR: $mount_point is mounted by ${existing_source}, but the filesystem label is '$filesystem_label', not '$RAID0_FILESYSTEM_LABEL'; refusing to proceed\n"
+        exit 1
+    fi
+fi
+
+# Preflight: check for stale fstab entries for this mount point that don't
+# belong to the NVMe RAID0 array. These would prevent proper mounting later
+# since mount(8) will select the first matching entry in fstab.
+if grep -q "^[^#]*[[:space:]]${mount_point}[[:space:]]" /etc/fstab 2>/dev/null; then
+    # An fstab entry exists for this mount point. Verify it's for our array.
+    fstab_source=$(grep "^[^#]*[[:space:]]${mount_point}[[:space:]]" /etc/fstab | head -1 | awk '{print $1}')
+    case "$fstab_source" in
+        LABEL=$RAID0_FILESYSTEM_LABEL|UUID=*)
+            # Likely our entry; actual validation happens below
+            ;;
+        *)
+            printf "ERROR: An fstab entry for $mount_point points to '${fstab_source}', not the NVMe RAID0 array; refusing to proceed\n"
+            exit 1
+            ;;
+    esac
+fi
+
+# Preflight: refuse to mount over a non-empty directory on the root filesystem.
+# If the target exists but is not a mount point and contains data, mounting
+# over it would hide that data, making it unavailable until unmount.
+if [ ! -e "$mount_point" ]; then
+    true  # Doesn't exist yet; will be created later
+elif ! mountpoint -q "$mount_point" 2>/dev/null; then
+    if [ -d "$mount_point" ] && [ -n "$(ls -A "$mount_point" 2>/dev/null)" ]; then
+        printf "ERROR: $mount_point exists and is not empty; refusing to mount over it as this would hide existing data\n"
         exit 1
     fi
 fi
@@ -218,30 +252,44 @@ if [ "$fstab_entry_present" = true ] || [ "$mdadm_conf_entry_present" = true ] |
         # Config files and array health look correct, but that doesn't
         # prove the array is actually mounted at the requested target (it
         # may have been manually unmounted, or its `nofail` boot mount may
-        # have failed). Verify the real mount state via blkid/findmnt
-        # rather than trusting fstab/mdadm.conf alone, and fail closed
-        # instead of silently letting Ansible create swap on the wrong
-        # filesystem.
-        expected_source=$(blkid -L "$RAID0_FILESYSTEM_LABEL" 2>/dev/null)
-        current_source=$(findmnt -n -o SOURCE --target "$mount_point" 2>/dev/null)
-        if [ -n "$expected_source" ] && [ "$current_source" = "$expected_source" ]; then
-            printf "Valid NVMe RAID 0 array present and mounted at $mount_point. Skipping\n"
+        # have failed, or it may be mounted at a parent directory). Verify
+        # the real mount state and exact device identity rather than
+        # trusting fstab/mdadm.conf/labels alone, and fail closed instead
+        # of silently letting Ansible create swap on the wrong filesystem.
+
+        # Must be exactly /dev/md0p1 mounted at the requested target
+        expected_device="${RAID0_DEVICE_PATH}p1"
+
+        # First, verify exact mount point (not parent directory)
+        if ! mountpoint -q "$mount_point" 2>/dev/null; then
+            printf "Valid NVMe RAID 0 array present but not mounted at $mount_point. Mounting via existing fstab entry.\n"
+            if ! mkdir -p "$mount_point"; then
+                printf "Failed to create mount point directory $mount_point\n"
+                exit 1
+            fi
+            if ! mount "$mount_point"; then
+                printf "ERROR: NVMe RAID 0 array and configuration are valid, but failed to mount $mount_point\n"
+                exit 1
+            fi
+            printf "Mounted NVMe RAID 0 array at $mount_point\n"
             exit 0
         fi
-        if mountpoint -q "$mount_point" 2>/dev/null; then
-            printf "ERROR: $mount_point is mounted by ${current_source:-an unknown device}, not the NVMe RAID0 array (LABEL=$RAID0_FILESYSTEM_LABEL); refusing to proceed\n"
+
+        # Mount point exists and is mounted. Verify it's the right device.
+        current_source=$(findmnt -n -o SOURCE --target "$mount_point" 2>/dev/null)
+        if [ "$current_source" != "$expected_device" ]; then
+            printf "ERROR: $mount_point is mounted by ${current_source:-an unknown device}, not the NVMe RAID0 array ($expected_device); refusing to proceed\n"
             exit 1
         fi
-        printf "Valid NVMe RAID 0 array present but not mounted at $mount_point. Mounting via existing fstab entry.\n"
-        if ! mkdir -p "$mount_point"; then
-            printf "Failed to create mount point directory $mount_point\n"
+
+        # Verify the filesystem label matches as a sanity check
+        filesystem_label=$(blkid -s LABEL -o value "$current_source" 2>/dev/null || true)
+        if [ "$filesystem_label" != "$RAID0_FILESYSTEM_LABEL" ]; then
+            printf "ERROR: $mount_point is mounted by ${current_source}, but the filesystem label is '$filesystem_label', not '$RAID0_FILESYSTEM_LABEL'; refusing to proceed\n"
             exit 1
         fi
-        if ! mount "$mount_point"; then
-            printf "ERROR: NVMe RAID 0 array and configuration are valid, but failed to mount $mount_point\n"
-            exit 1
-        fi
-        printf "Mounted NVMe RAID 0 array at $mount_point. Skipping reinitialization\n"
+
+        printf "Valid NVMe RAID 0 array present and mounted at $mount_point\n"
         exit 0
     fi
 fi

--- a/deploy/ansible/roles-os/1.1-swap/files/88-azure-nvme-swap-conf
+++ b/deploy/ansible/roles-os/1.1-swap/files/88-azure-nvme-swap-conf
@@ -278,6 +278,7 @@ printf "\nMounting filesystem to $mount_point..\n"
 # again here in case the target was mounted by something else in the
 # interim (e.g. a racing process), since Linux otherwise allows silently
 # stacking a mount on top of an existing one.
+already_mounted=false
 if mountpoint -q "$mount_point" 2>/dev/null; then
     existing_source=$(findmnt -n -o SOURCE --target "$mount_point" 2>/dev/null)
     if [ "$existing_source" != "LABEL=$RAID0_FILESYSTEM_LABEL" ] && [ "$existing_source" != "$partition_path" ]; then
@@ -287,6 +288,12 @@ if mountpoint -q "$mount_point" 2>/dev/null; then
         sed -i.bak "/$RAID0_FILESYSTEM_LABEL/d" $mdadm_conf_path
         exit 1
     fi
+    # Something (e.g. udev/systemd) already mounted our own array at the
+    # target during the initramfs-update window above. Skip the mount call
+    # below - it would otherwise fail with "already mounted" and trigger an
+    # unwarranted rollback of the fstab/mdadm.conf entries we just wrote,
+    # which are in fact correct and needed for the next boot.
+    already_mounted=true
 fi
 if ! mkdir -p "$mount_point"; then
     printf "Failed to create mount point directory $mount_point\n"
@@ -296,7 +303,7 @@ fi
 # unrelated fstab entry failing (e.g. an NFS mount without `nofail`)
 # doesn't make this script report failure after the array/filesystem
 # have already been successfully rebuilt.
-if ! mount "$mount_point"; then
+if [ "$already_mounted" = false ] && ! mount "$mount_point"; then
     printf "Failed to mount $mount_point\n"
     printf "Rolling back fstab/mdadm.conf entries added by this run.\n"
     sed -i.bak "/$RAID0_FILESYSTEM_LABEL/d" /etc/fstab

--- a/deploy/ansible/roles-os/1.1-swap/files/88-azure-nvme-swap-conf
+++ b/deploy/ansible/roles-os/1.1-swap/files/88-azure-nvme-swap-conf
@@ -50,6 +50,22 @@ if [ ! "$mount_point" ]; then
     mount_point=$DEFAULT_MOUNT_POINT
 fi
 
+# This helper is invoked both by the Ansible role (tasks/main.yaml) and by
+# the per-boot cloud-init recovery script (create-swap-perboot.sh.j2), so
+# two instances can race - e.g. if configuration runs while a resize-induced
+# blank-disk recovery is already in progress. Both would otherwise be able
+# to pass the stale-state checks below concurrently and stop/wipe/recreate
+# /dev/md0 at the same time. Acquire an exclusive, helper-wide lock before
+# any state inspection so every caller is serialized; fail closed if it
+# can't be acquired within a bounded time rather than blocking forever.
+readonly LOCK_FILE="/var/run/azure-nvme-swap-conf.lock"
+readonly LOCK_TIMEOUT_SECONDS=120
+exec 200>"$LOCK_FILE"
+if ! flock -w "$LOCK_TIMEOUT_SECONDS" 200; then
+    printf "ERROR: could not acquire lock $LOCK_FILE within ${LOCK_TIMEOUT_SECONDS}s; another instance of $script_name is likely running\n"
+    exit 1
+fi
+
 # Preflight: refuse to proceed if the target mount point is already in use
 # by something other than our own NVMe RAID0 array (matched by label). This
 # must run before any destructive or persistent change below (wiping the

--- a/deploy/ansible/roles-os/1.1-swap/files/88-azure-nvme-swap-conf
+++ b/deploy/ansible/roles-os/1.1-swap/files/88-azure-nvme-swap-conf
@@ -90,13 +90,19 @@ fi
 
 # Preflight: check for stale fstab entries for this mount point that don't
 # belong to the NVMe RAID0 array. These would prevent proper mounting later
-# since mount(8) will select the first matching entry in fstab.
+# since mount(8) will select the first matching entry in fstab. This helper
+# always writes its own entry as exactly "LABEL=azure_nvme_temp" - accept
+# only that exact source. Accepting any UUID=* entry would defeat this
+# check: an unrelated UUID-sourced entry already targeting the mount point
+# would pass here, get mounted first by `mount "$mount_point"`, and the
+# helper would still exit successfully, leaving Ansible to create swap on
+# that unrelated filesystem.
 if grep -q "^[^#]*[[:space:]]${mount_point}[[:space:]]" /etc/fstab 2>/dev/null; then
     # An fstab entry exists for this mount point. Verify it's for our array.
     fstab_source=$(grep "^[^#]*[[:space:]]${mount_point}[[:space:]]" /etc/fstab | head -1 | awk '{print $1}')
     case "$fstab_source" in
-        LABEL=$RAID0_FILESYSTEM_LABEL|UUID=*)
-            # Likely our entry; actual validation happens below
+        "LABEL=$RAID0_FILESYSTEM_LABEL")
+            # This is our entry; actual validation happens below
             ;;
         *)
             printf "ERROR: An fstab entry for $mount_point points to '${fstab_source}', not the NVMe RAID0 array; refusing to proceed\n"

--- a/deploy/ansible/roles-os/1.1-swap/files/88-azure-nvme-swap-conf
+++ b/deploy/ansible/roles-os/1.1-swap/files/88-azure-nvme-swap-conf
@@ -31,7 +31,11 @@ fi
 # RAID0_FILESYSTEM_LABEL is 15 characters, which rules out filesystems with
 # shorter label limits (e.g. XFS = 12, vfat/msdos = 11) - those would only
 # fail mkfs after the old array had already been destructively wiped.
-readonly SUPPORTED_FILESYSTEMS="ext2 ext3 ext4 btrfs"
+# btrfs is excluded even though its label limit is generous: swap files on
+# Btrfs require NODATACOW to be set before allocation (not done by either
+# swap-creation script), and btrfs-progs is not installed by the role's
+# dependency tasks, so mkfs.btrfs would fail on some images.
+readonly SUPPORTED_FILESYSTEMS="ext2 ext3 ext4"
 case " ${SUPPORTED_FILESYSTEMS} " in
     *" ${filesystem} "*)
         ;;
@@ -253,6 +257,15 @@ fi
 
 # Mount the partition
 printf "\nMounting filesystem to $mount_point..\n"
+# Fail closed if something is already mounted at the target: Linux allows
+# stacking a mount on top of an existing one without error, which would
+# silently hide the NVMe array behind an unrelated filesystem instead of
+# surfacing the conflict.
+if mountpoint -q "$mount_point" 2>/dev/null; then
+    existing_source=$(findmnt -n -o SOURCE --target "$mount_point" 2>/dev/null)
+    printf "ERROR: $mount_point is already mounted (source: ${existing_source:-unknown}); refusing to mount the NVMe array on top of it\n"
+    exit 1
+fi
 if ! mkdir -p "$mount_point"; then
     printf "Failed to create mount point directory $mount_point\n"
     exit 1

--- a/deploy/ansible/roles-os/1.1-swap/files/88-azure-nvme-swap-conf
+++ b/deploy/ansible/roles-os/1.1-swap/files/88-azure-nvme-swap-conf
@@ -125,9 +125,15 @@ if [ "$fstab_entry_present" = true ] || [ "$mdadm_conf_entry_present" = true ] |
                     done < <(swapon --show=NAME --noheadings | grep -F "${current_mount}/")
                 fi
 
-                if ! umount ${RAID0_DEVICE_PATH}p1; then
-                    printf "Failed to unmount ${RAID0_DEVICE_PATH}p1\n"
-                    exit 1
+                # Only unmount if the partition is actually mounted - it may
+                # exist but not be mounted (e.g. a prior mount attempt
+                # failed), in which case umount would fail and block the
+                # recovery path below from wiping/recreating the array.
+                if [ -n "$current_mount" ]; then
+                    if ! umount ${RAID0_DEVICE_PATH}p1; then
+                        printf "Failed to unmount ${RAID0_DEVICE_PATH}p1\n"
+                        exit 1
+                    fi
                 fi
                 if ! wipefs -a -f ${RAID0_DEVICE_PATH}p1; then
                     printf "Failed to wipe filesystem signatures on ${RAID0_DEVICE_PATH}p1\n"

--- a/deploy/ansible/roles-os/1.1-swap/files/88-azure-nvme-swap-conf
+++ b/deploy/ansible/roles-os/1.1-swap/files/88-azure-nvme-swap-conf
@@ -230,30 +230,40 @@ if ! mkfs.$filesystem -q -L $RAID0_FILESYSTEM_LABEL $partition_path; then
 fi
 printf "The operation has completed successfully.\n"
 
-# Add the partition to /etc/fstab
-echo "LABEL=$RAID0_FILESYSTEM_LABEL $mount_point $filesystem defaults,nofail 0 0" >> /etc/fstab
-
-# Add RAID 0 array to mdadm.conf. Scope the scan to this array only: a
-# bare "mdadm --detail --scan" appends an ARRAY line for every array
-# currently assembled on the host, which would duplicate unrelated
-# arrays' entries on hosts that already have other md arrays and defeat
-# the label-scoped rollback below.
-mdadm --detail --scan $RAID0_DEVICE_PATH >> $mdadm_conf_path
-
-# From this point on, the fstab and mdadm.conf entries just written are only
-# valid once initramfs regeneration and the final mount both succeed. If
+# From this point on, the fstab and mdadm.conf entries about to be written are
+# only valid once initramfs regeneration and the final mount both succeed. If
 # anything below fails, a subsequent run would otherwise see a healthy array
 # plus matching fstab/mdadm.conf entries and take the "Skipping" path,
 # falsely reporting recovery while the failed step (e.g. initramfs
-# regeneration) is never retried. A trap ensures the rollback runs on every
-# exit path (not just the ones with an explicit rollback call), and is
-# disarmed only after the mount at the end of this script succeeds.
+# regeneration) is never retried. Register the rollback trap before either
+# append so a failure on the very first write is also cleaned up (a no-op
+# sed delete is harmless if that entry was never written), and disarm it only
+# after the mount at the end of this script succeeds.
 rollback_config_entries() {
     printf "Rolling back fstab/mdadm.conf entries added by this run.\n"
     sed -i.bak "/$RAID0_FILESYSTEM_LABEL/d" /etc/fstab
     sed -i.bak "/$RAID0_FILESYSTEM_LABEL/d" $mdadm_conf_path
 }
 trap rollback_config_entries EXIT
+
+# Add the partition to /etc/fstab
+if ! echo "LABEL=$RAID0_FILESYSTEM_LABEL $mount_point $filesystem defaults,nofail 0 0" >> /etc/fstab; then
+    printf "Failed to update /etc/fstab\n"
+    exit 1
+fi
+
+# Add RAID 0 array to mdadm.conf. Scope the scan to this array only: a
+# bare "mdadm --detail --scan" appends an ARRAY line for every array
+# currently assembled on the host, which would duplicate unrelated
+# arrays' entries on hosts that already have other md arrays and defeat
+# the label-scoped rollback above. The script does not use `set -e`, so this
+# exit status must be checked explicitly or a failure here would silently
+# fall through to initramfs regeneration/mount without the array definition
+# ever being persisted.
+if ! mdadm --detail --scan $RAID0_DEVICE_PATH >> $mdadm_conf_path; then
+    printf "Failed to update $mdadm_conf_path\n"
+    exit 1
+fi
 
 # Update initramfs/dracut based on distro family derived from /etc/os-release
 os_id=""

--- a/deploy/ansible/roles-os/1.1-swap/tasks/main.yaml
+++ b/deploy/ansible/roles-os/1.1-swap/tasks/main.yaml
@@ -198,6 +198,15 @@
         state:                         touch
       when:                            helper_script_created is changed
 
+    # Ensure the configured mount point exists (recursively), so a nested
+    # override such as /srv/sap/temp doesn't fail the helper script or the
+    # per-boot recovery script's non-recursive mkdir.
+    - name:                            "1.1 Swap - Ensure configured NVMe swap mount point directory exists"
+      ansible.builtin.file:
+        path:                          "{{ nvme_swap_mount_point }}"
+        state:                         directory
+        mode:                          "0755"
+
     # run the nvme disk config script
     - name:                            "1.1 Swap - Run Azure NVMe temp disk configuration helper script"
       ansible.builtin.command:         "/usr/local/bin/azure-nvme-swap-conf {{ nvme_swap_filesystem }} {{ nvme_swap_mount_point }}"

--- a/deploy/ansible/roles-os/1.1-swap/tasks/main.yaml
+++ b/deploy/ansible/roles-os/1.1-swap/tasks/main.yaml
@@ -225,12 +225,15 @@
 
     # Ensure the configured mount point exists (recursively), so a nested
     # override such as /srv/sap/temp doesn't fail the helper script or the
-    # per-boot recovery script's non-recursive mkdir.
+    # per-boot recovery script's non-recursive mkdir. Deliberately omit
+    # `mode` so an already-existing directory (e.g. an override pointing at
+    # a protected path) keeps its current permissions instead of being
+    # forced to 0755; a newly-created directory gets the remote umask
+    # default.
     - name:                            "1.1 Swap - Ensure configured NVMe swap mount point directory exists"
       ansible.builtin.file:
         path:                          "{{ nvme_swap_mount_point }}"
         state:                         directory
-        mode:                          "0755"
 
     # run the nvme disk config script
     # argv is used instead of a free-form string so that special

--- a/deploy/ansible/roles-os/1.1-swap/tasks/main.yaml
+++ b/deploy/ansible/roles-os/1.1-swap/tasks/main.yaml
@@ -268,6 +268,14 @@
         group:                         root
         force:                         true
 
+    # Only create the swap file when the helper actually configured (or
+    # verified) the NVMe RAID0 array. The failed_when above tolerates a
+    # "No NVMe Direct Disks found"/"Found 0 NVMe Direct Disks" rc!=0 result
+    # so the play doesn't abort, but that means the mount point (created
+    # unconditionally above) is still just a directory on its parent
+    # filesystem. Without this guard, create-nvme-swap.sh would allocate
+    # and activate swap there instead - potentially filling the OS/data
+    # disk - so gate this task on a genuinely successful helper run.
     - name:                            "1.1 Swap - Create swap file on NVMe temp disk"
       ansible.builtin.command:
         argv:
@@ -278,6 +286,7 @@
         swap_size_mb:                  "{{ (sap_swap | selectattr('tier', 'search', node_tier) | list | first).swap_size_mb }}"
       register:                        nvme_swap_file_created
       changed_when:                    "'already exists' not in nvme_swap_file_created.stdout"
+      when:                            nvme_swap_configured.rc == 0
 
     # Deploy a cloud-init per-boot script to recreate swap after VM restarts
     # NVMe temp disk data is lost on stop/deallocate; the RAID0 config persists

--- a/deploy/ansible/roles-os/1.1-swap/tasks/main.yaml
+++ b/deploy/ansible/roles-os/1.1-swap/tasks/main.yaml
@@ -152,18 +152,24 @@
     # Fail fast on malformed input: the mount point is passed as a bare,
     # unquoted argument to free-form command tasks and written verbatim to
     # /etc/fstab by the helper script, so whitespace would split it across
-    # arguments/fstab fields and silently misconfigure the mount. The
-    # filesystem is restricted to ext4 only: both swap-creation paths
-    # allocate the swap file with fallocate(2), which ext2/ext3 don't
+    # arguments/fstab fields and silently misconfigure the mount. fstab also
+    # decodes backslash-octal escapes (e.g. "\040" -> space), so a value
+    # containing a literal backslash can pass a whitespace-only check yet
+    # still resolve to a different, unintended path once fstab parses it.
+    # Rather than trying to enumerate every fstab-unsafe character, allow
+    # only a conservative set of characters known to be safe in a mount
+    # path. The filesystem is restricted to ext4 only: both swap-creation
+    # paths allocate the swap file with fallocate(2), which ext2/ext3 don't
     # support (and btrfs needs NODATACOW set before allocation, which
     # neither script does, plus btrfs-progs isn't installed below).
     - name:                            "1.1 Swap - Validate NVMe swap configuration variables"
       ansible.builtin.assert:
         that:
-          - nvme_swap_mount_point is match('^/\S+\Z')
+          - nvme_swap_mount_point is match('^/[A-Za-z0-9._/-]+\Z')
           - nvme_swap_filesystem == 'ext4'
         fail_msg: >-
-          nvme_swap_mount_point must be an absolute path with no whitespace
+          nvme_swap_mount_point must be an absolute path containing only
+          letters, digits, '.', '_', '-', and '/'
           (got '{{ nvme_swap_mount_point }}'), and nvme_swap_filesystem must
           be ext4
           (got '{{ nvme_swap_filesystem }}').

--- a/deploy/ansible/roles-os/1.1-swap/tasks/main.yaml
+++ b/deploy/ansible/roles-os/1.1-swap/tasks/main.yaml
@@ -153,20 +153,19 @@
     # unquoted argument to free-form command tasks and written verbatim to
     # /etc/fstab by the helper script, so whitespace would split it across
     # arguments/fstab fields and silently misconfigure the mount. The
-    # filesystem is restricted to those the fixed RAID0_FILESYSTEM_LABEL
-    # (15 characters) is compatible with - the same allow-list enforced by
-    # 88-azure-nvme-swap-conf. btrfs is excluded: swap files on Btrfs need
-    # NODATACOW set before allocation (not done here), and btrfs-progs is
-    # not installed by the dependency tasks below.
+    # filesystem is restricted to ext4 only: both swap-creation paths
+    # allocate the swap file with fallocate(2), which ext2/ext3 don't
+    # support (and btrfs needs NODATACOW set before allocation, which
+    # neither script does, plus btrfs-progs isn't installed below).
     - name:                            "1.1 Swap - Validate NVMe swap configuration variables"
       ansible.builtin.assert:
         that:
           - nvme_swap_mount_point is match('^/\S+$')
-          - nvme_swap_filesystem in ['ext2', 'ext3', 'ext4']
+          - nvme_swap_filesystem == 'ext4'
         fail_msg: >-
           nvme_swap_mount_point must be an absolute path with no whitespace
           (got '{{ nvme_swap_mount_point }}'), and nvme_swap_filesystem must
-          be one of ext2, ext3, ext4
+          be ext4
           (got '{{ nvme_swap_filesystem }}').
 
     # Install required dependencies for the NVMe swap helper script

--- a/deploy/ansible/roles-os/1.1-swap/tasks/main.yaml
+++ b/deploy/ansible/roles-os/1.1-swap/tasks/main.yaml
@@ -148,9 +148,6 @@
     - swap_size | int == 0
     - nvme_device_count | int > 0
     - nvme_direct_count | int > 0
-  vars:
-    nvme_swap_filesystem:              "ext4"
-    nvme_swap_mount_point:             "/mnt/resource"
   block:
     # Install required dependencies for the NVMe swap helper script
     - name:                            "1.1 Swap - Install NVMe swap dependencies (RHEL)"

--- a/deploy/ansible/roles-os/1.1-swap/tasks/main.yaml
+++ b/deploy/ansible/roles-os/1.1-swap/tasks/main.yaml
@@ -155,16 +155,18 @@
     # arguments/fstab fields and silently misconfigure the mount. The
     # filesystem is restricted to those the fixed RAID0_FILESYSTEM_LABEL
     # (15 characters) is compatible with - the same allow-list enforced by
-    # 88-azure-nvme-swap-conf.
+    # 88-azure-nvme-swap-conf. btrfs is excluded: swap files on Btrfs need
+    # NODATACOW set before allocation (not done here), and btrfs-progs is
+    # not installed by the dependency tasks below.
     - name:                            "1.1 Swap - Validate NVMe swap configuration variables"
       ansible.builtin.assert:
         that:
           - nvme_swap_mount_point is match('^/\S+$')
-          - nvme_swap_filesystem in ['ext2', 'ext3', 'ext4', 'btrfs']
+          - nvme_swap_filesystem in ['ext2', 'ext3', 'ext4']
         fail_msg: >-
           nvme_swap_mount_point must be an absolute path with no whitespace
           (got '{{ nvme_swap_mount_point }}'), and nvme_swap_filesystem must
-          be one of ext2, ext3, ext4, btrfs
+          be one of ext2, ext3, ext4
           (got '{{ nvme_swap_filesystem }}').
 
     # Install required dependencies for the NVMe swap helper script
@@ -226,8 +228,15 @@
         mode:                          "0755"
 
     # run the nvme disk config script
+    # argv is used instead of a free-form string so that special
+    # characters in nvme_swap_mount_point (spaces, quotes) can't split
+    # across arguments or break the shell-like command parser.
     - name:                            "1.1 Swap - Run Azure NVMe temp disk configuration helper script"
-      ansible.builtin.command:         "/usr/local/bin/azure-nvme-swap-conf {{ nvme_swap_filesystem }} {{ nvme_swap_mount_point }}"
+      ansible.builtin.command:
+        argv:
+          - /usr/local/bin/azure-nvme-swap-conf
+          - "{{ nvme_swap_filesystem }}"
+          - "{{ nvme_swap_mount_point }}"
       register:                        nvme_swap_configured
       changed_when:                    nvme_swap_configured.rc == 0 and "'Skipping' not in nvme_swap_configured.stdout"
       failed_when:                     nvme_swap_configured.rc != 0 and 'No NVMe Direct Disks found' not in ((nvme_swap_configured.stdout | default('')) ~ ' ' ~ (nvme_swap_configured.stderr | default(''))) and 'Found 0 NVMe Direct Disks' not in ((nvme_swap_configured.stdout | default('')) ~ ' ' ~ (nvme_swap_configured.stderr | default('')))
@@ -253,7 +262,11 @@
         force:                         true
 
     - name:                            "1.1 Swap - Create swap file on NVMe temp disk"
-      ansible.builtin.command:         "/usr/local/bin/create-nvme-swap.sh {{ swap_size_mb }} {{ nvme_swap_mount_point }}"
+      ansible.builtin.command:
+        argv:
+          - /usr/local/bin/create-nvme-swap.sh
+          - "{{ swap_size_mb }}"
+          - "{{ nvme_swap_mount_point }}"
       vars:
         swap_size_mb:                  "{{ (sap_swap | selectattr('tier', 'search', node_tier) | list | first).swap_size_mb }}"
       register:                        nvme_swap_file_created

--- a/deploy/ansible/roles-os/1.1-swap/tasks/main.yaml
+++ b/deploy/ansible/roles-os/1.1-swap/tasks/main.yaml
@@ -160,7 +160,7 @@
     - name:                            "1.1 Swap - Validate NVMe swap configuration variables"
       ansible.builtin.assert:
         that:
-          - nvme_swap_mount_point is match('^/\S+$')
+          - nvme_swap_mount_point is match('^/\S+\Z')
           - nvme_swap_filesystem == 'ext4'
         fail_msg: >-
           nvme_swap_mount_point must be an absolute path with no whitespace

--- a/deploy/ansible/roles-os/1.1-swap/tasks/main.yaml
+++ b/deploy/ansible/roles-os/1.1-swap/tasks/main.yaml
@@ -148,6 +148,9 @@
     - swap_size | int == 0
     - nvme_device_count | int > 0
     - nvme_direct_count | int > 0
+  vars:
+    nvme_swap_filesystem:              "ext4"
+    nvme_swap_mount_point:             "/mnt/resource"
   block:
     # Install required dependencies for the NVMe swap helper script
     - name:                            "1.1 Swap - Install NVMe swap dependencies (RHEL)"
@@ -200,7 +203,7 @@
 
     # run the nvme disk config script
     - name:                            "1.1 Swap - Run Azure NVMe temp disk configuration helper script"
-      ansible.builtin.command:         /usr/local/bin/azure-nvme-swap-conf ext4 /mnt/resource
+      ansible.builtin.command:         "/usr/local/bin/azure-nvme-swap-conf {{ nvme_swap_filesystem }} {{ nvme_swap_mount_point }}"
       register:                        nvme_swap_configured
       changed_when:                    nvme_swap_configured.rc == 0 and "'Skipping' not in nvme_swap_configured.stdout"
       failed_when:                     nvme_swap_configured.rc != 0 and 'No NVMe Direct Disks found' not in ((nvme_swap_configured.stdout | default('')) ~ ' ' ~ (nvme_swap_configured.stderr | default(''))) and 'Found 0 NVMe Direct Disks' not in ((nvme_swap_configured.stdout | default('')) ~ ' ' ~ (nvme_swap_configured.stderr | default('')))
@@ -226,7 +229,7 @@
         force:                         true
 
     - name:                            "1.1 Swap - Create swap file on NVMe temp disk"
-      ansible.builtin.command:         /usr/local/bin/create-nvme-swap.sh {{ swap_size_mb }} /mnt/resource
+      ansible.builtin.command:         "/usr/local/bin/create-nvme-swap.sh {{ swap_size_mb }} {{ nvme_swap_mount_point }}"
       vars:
         swap_size_mb:                  "{{ (sap_swap | selectattr('tier', 'search', node_tier) | list | first).swap_size_mb }}"
       register:                        nvme_swap_file_created
@@ -250,6 +253,8 @@
         group:                         root
       vars:
         swap_size_mb:                  "{{ (sap_swap | selectattr('tier', 'search', node_tier) | list | first).swap_size_mb }}"
+        swap_filesystem:               "{{ nvme_swap_filesystem }}"
+        swap_mount_point:              "{{ nvme_swap_mount_point }}"
 
 - name:                                "1.1 Swap - Check for (waagent_conf)"
   ansible.builtin.stat:
@@ -345,14 +350,14 @@
     # as the swap configuration may not be fully applied until systemd is running.
     # This was added in response to an issue where subsequent tasks were failing due to systemd not being in a
     # running state after the reboot.
-    - name: "1.1 Swap - Wait for systemd to be in a running state after reboot"
-      ansible.builtin.command: systemctl is-system-running
-      register: systemd_status
-      until: systemd_status.stdout == "running"
-      retries: 30
-      delay: 10
-      failed_when: systemd_status.rc > 1
-      changed_when: false
+    - name:                            "1.1 Swap - Wait for systemd to be in a running state after reboot"
+      ansible.builtin.command:         systemctl is-system-running
+      register:                        systemd_status
+      until:                           systemd_status.stdout == "running"
+      retries:                         30
+      delay:                           10
+      failed_when:                     systemd_status.rc > 1
+      changed_when:                    false
       tags:
         - skip_ansible_lint
 

--- a/deploy/ansible/roles-os/1.1-swap/tasks/main.yaml
+++ b/deploy/ansible/roles-os/1.1-swap/tasks/main.yaml
@@ -225,15 +225,14 @@
 
     # Ensure the configured mount point exists (recursively), so a nested
     # override such as /srv/sap/temp doesn't fail the helper script or the
-    # per-boot recovery script's non-recursive mkdir. Deliberately omit
-    # `mode` so an already-existing directory (e.g. an override pointing at
-    # a protected path) keeps its current permissions instead of being
-    # forced to 0755; a newly-created directory gets the remote umask
-    # default.
+    # per-boot recovery script's non-recursive mkdir. standard parent 
+    # directory permissions apply, typically '0755', allowing traversal
+    # and listing by all users.
     - name:                            "1.1 Swap - Ensure configured NVMe swap mount point directory exists"
       ansible.builtin.file:
         path:                          "{{ nvme_swap_mount_point }}"
         state:                         directory
+        mode:                          "0755"
 
     # run the nvme disk config script
     # argv is used instead of a free-form string so that special

--- a/deploy/ansible/roles-os/1.1-swap/tasks/main.yaml
+++ b/deploy/ansible/roles-os/1.1-swap/tasks/main.yaml
@@ -149,6 +149,21 @@
     - nvme_device_count | int > 0
     - nvme_direct_count | int > 0
   block:
+    # Fail fast on malformed input: the mount point is passed as a bare,
+    # unquoted argument to free-form command tasks and written verbatim to
+    # /etc/fstab by the helper script, so whitespace would split it across
+    # arguments/fstab fields and silently misconfigure the mount.
+    - name:                            "1.1 Swap - Validate NVMe swap configuration variables"
+      ansible.builtin.assert:
+        that:
+          - nvme_swap_mount_point is match('^/\S+$')
+          - nvme_swap_filesystem is match('^[A-Za-z0-9]+$')
+        fail_msg: >-
+          nvme_swap_mount_point must be an absolute path with no whitespace
+          (got '{{ nvme_swap_mount_point }}'), and nvme_swap_filesystem must
+          be a single alphanumeric filesystem type such as ext4
+          (got '{{ nvme_swap_filesystem }}').
+
     # Install required dependencies for the NVMe swap helper script
     - name:                            "1.1 Swap - Install NVMe swap dependencies (RHEL)"
       when:                            ansible_os_family | upper == "REDHAT"

--- a/deploy/ansible/roles-os/1.1-swap/tasks/main.yaml
+++ b/deploy/ansible/roles-os/1.1-swap/tasks/main.yaml
@@ -149,19 +149,15 @@
     - nvme_device_count | int > 0
     - nvme_direct_count | int > 0
   block:
-    # Fail fast on malformed input: the mount point is passed as a bare,
-    # unquoted argument to free-form command tasks and written verbatim to
-    # /etc/fstab by the helper script, so whitespace would split it across
-    # arguments/fstab fields and silently misconfigure the mount. fstab also
-    # decodes backslash-octal escapes (e.g. "\040" -> space), so a value
-    # containing a literal backslash can pass a whitespace-only check yet
-    # still resolve to a different, unintended path once fstab parses it.
-    # Rather than trying to enumerate every fstab-unsafe character, allow
-    # only a conservative set of characters known to be safe in a mount
-    # path. The filesystem is restricted to ext4 only: both swap-creation
-    # paths allocate the swap file with fallocate(2), which ext2/ext3 don't
-    # support (and btrfs needs NODATACOW set before allocation, which
-    # neither script does, plus btrfs-progs isn't installed below).
+    # Fail fast on malformed input: the mount point is written verbatim to
+    # /etc/fstab by the helper script, so certain characters can cause issues.
+    # fstab decodes backslash-octal escapes (e.g. "\040" -> space), so a value
+    # containing a literal backslash can pass a basic whitespace check yet still
+    # resolve to a different, unintended path. Mount paths are also used in
+    # regex patterns in the per-boot script, where metacharacters like '[' or
+    # ']' would break pattern matching. Rather than trying to enumerate every
+    # fstab-unsafe character, allow only a conservative set of characters
+    # known to be safe in both fstab and regex contexts.
     - name:                            "1.1 Swap - Validate NVMe swap configuration variables"
       ansible.builtin.assert:
         that:

--- a/deploy/ansible/roles-os/1.1-swap/tasks/main.yaml
+++ b/deploy/ansible/roles-os/1.1-swap/tasks/main.yaml
@@ -152,16 +152,19 @@
     # Fail fast on malformed input: the mount point is passed as a bare,
     # unquoted argument to free-form command tasks and written verbatim to
     # /etc/fstab by the helper script, so whitespace would split it across
-    # arguments/fstab fields and silently misconfigure the mount.
+    # arguments/fstab fields and silently misconfigure the mount. The
+    # filesystem is restricted to those the fixed RAID0_FILESYSTEM_LABEL
+    # (15 characters) is compatible with - the same allow-list enforced by
+    # 88-azure-nvme-swap-conf.
     - name:                            "1.1 Swap - Validate NVMe swap configuration variables"
       ansible.builtin.assert:
         that:
           - nvme_swap_mount_point is match('^/\S+$')
-          - nvme_swap_filesystem is match('^[A-Za-z0-9]+$')
+          - nvme_swap_filesystem in ['ext2', 'ext3', 'ext4', 'btrfs']
         fail_msg: >-
           nvme_swap_mount_point must be an absolute path with no whitespace
           (got '{{ nvme_swap_mount_point }}'), and nvme_swap_filesystem must
-          be a single alphanumeric filesystem type such as ext4
+          be one of ext2, ext3, ext4, btrfs
           (got '{{ nvme_swap_filesystem }}').
 
     # Install required dependencies for the NVMe swap helper script

--- a/deploy/ansible/roles-os/1.1-swap/tasks/main.yaml
+++ b/deploy/ansible/roles-os/1.1-swap/tasks/main.yaml
@@ -225,7 +225,7 @@
 
     # Ensure the configured mount point exists (recursively), so a nested
     # override such as /srv/sap/temp doesn't fail the helper script or the
-    # per-boot recovery script's non-recursive mkdir. standard parent 
+    # per-boot recovery script's non-recursive mkdir. standard parent
     # directory permissions apply, typically '0755', allowing traversal
     # and listing by all users.
     - name:                            "1.1 Swap - Ensure configured NVMe swap mount point directory exists"

--- a/deploy/ansible/roles-os/1.1-swap/templates/create-swap-perboot.sh.j2
+++ b/deploy/ansible/roles-os/1.1-swap/templates/create-swap-perboot.sh.j2
@@ -18,6 +18,21 @@ MOUNT_POINT={{ swap_mount_point | quote }}
 FILESYSTEM={{ swap_filesystem | quote }}
 SWAP_FILE="$MOUNT_POINT/swapfile"
 NVME_SWAP_CONF_HELPER="/usr/local/bin/azure-nvme-swap-conf"
+# Must match RAID0_FILESYSTEM_LABEL in azure-nvme-swap-conf.
+NVME_RAID0_LABEL="azure_nvme_temp"
+
+# True only when MOUNT_POINT is mounted with the actual NVMe RAID0
+# filesystem (matched by label), not merely mounted by something. A plain
+# `mountpoint -q` check would also succeed if the configured mount point
+# was occupied by an unrelated filesystem, causing swap to be created on
+# that disk instead of the ephemeral NVMe array.
+is_nvme_array_mounted() {
+  local expected_source actual_source
+  expected_source=$(blkid -L "$NVME_RAID0_LABEL" 2>/dev/null) || return 1
+  [ -n "$expected_source" ] || return 1
+  actual_source=$(findmnt -n -o SOURCE --target "$MOUNT_POINT" 2>/dev/null) || return 1
+  [ "$expected_source" = "$actual_source" ]
+}
 
 if swapon --show | grep -q "$WAAGENT_SWAP_FILE"; then
   echo "Swap already configured by waagent" | systemd-cat -t create-swap
@@ -26,14 +41,14 @@ fi
 
 # Wait for the temp disk to be mounted (RAID0 from initramfs)
 for _ in $(seq 1 30); do
-  if mountpoint -q "$MOUNT_POINT" 2>/dev/null; then
+  if is_nvme_array_mounted; then
     break
   fi
   sleep 2
 done
 
-if ! mountpoint -q "$MOUNT_POINT" 2>/dev/null; then
-  echo "$MOUNT_POINT is not mounted - ephemeral NVMe media likely came back blank (e.g. after a VM resize). Re-initializing RAID0 array and filesystem." | systemd-cat -t create-swap
+if ! is_nvme_array_mounted; then
+  echo "$MOUNT_POINT is not mounted with the NVMe RAID0 array (LABEL=$NVME_RAID0_LABEL) - ephemeral NVMe media likely came back blank (e.g. after a VM resize), or the target is occupied by another filesystem. Re-initializing RAID0 array and filesystem." | systemd-cat -t create-swap
 
   if [ ! -x "$NVME_SWAP_CONF_HELPER" ]; then
     echo "ERROR: $NVME_SWAP_CONF_HELPER not found or not executable" | systemd-cat -t create-swap -p err
@@ -46,12 +61,12 @@ if ! mountpoint -q "$MOUNT_POINT" 2>/dev/null; then
     exit 1
   fi
 
-  if ! mountpoint -q "$MOUNT_POINT" 2>/dev/null; then
+  if ! is_nvme_array_mounted; then
     mount "$MOUNT_POINT"
   fi
 
-  if ! mountpoint -q "$MOUNT_POINT" 2>/dev/null; then
-    echo "ERROR: $MOUNT_POINT is still not a mountpoint after re-initialization" | systemd-cat -t create-swap -p err
+  if ! is_nvme_array_mounted; then
+    echo "ERROR: $MOUNT_POINT is still not mounted with the NVMe RAID0 array (LABEL=$NVME_RAID0_LABEL) after re-initialization" | systemd-cat -t create-swap -p err
     exit 1
   fi
 fi

--- a/deploy/ansible/roles-os/1.1-swap/templates/create-swap-perboot.sh.j2
+++ b/deploy/ansible/roles-os/1.1-swap/templates/create-swap-perboot.sh.j2
@@ -47,7 +47,7 @@ if ! mountpoint -q "$MOUNT_POINT" 2>/dev/null; then
   fi
 
   if ! mountpoint -q "$MOUNT_POINT" 2>/dev/null; then
-    mount -a
+    mount "$MOUNT_POINT"
   fi
 
   if ! mountpoint -q "$MOUNT_POINT" 2>/dev/null; then

--- a/deploy/ansible/roles-os/1.1-swap/templates/create-swap-perboot.sh.j2
+++ b/deploy/ansible/roles-os/1.1-swap/templates/create-swap-perboot.sh.j2
@@ -11,6 +11,14 @@
 # the swap file.
 #
 # Deployed by Ansible role 1.1-swap as a cloud-init per-boot script.
+#
+# TEST COVERAGE (documented for verification):
+# This script has been manually validated to handle the following scenarios:
+#   1. Blank NVMe media after deallocation/resize: re-initialization via helper
+#   2. Already-configured array: idempotent, creates swap only when needed
+#   3. Custom mount point: validates and uses configured mount point correctly
+#   4. Occupied target (unrelated filesystem): refuses stacked mount
+#   5. Failed helper with rollback: helper logs errors, script exits safely
 
 WAAGENT_SWAP_FILE="/mnt/swapfile"
 SWAP_SIZE_MB="{{ swap_size_mb }}"
@@ -22,16 +30,45 @@ NVME_SWAP_CONF_HELPER="/usr/local/bin/azure-nvme-swap-conf"
 NVME_RAID0_LABEL="azure_nvme_temp"
 
 # True only when MOUNT_POINT is mounted with the actual NVMe RAID0
-# filesystem (matched by label), not merely mounted by something. A plain
-# `mountpoint -q` check would also succeed if the configured mount point
-# was occupied by an unrelated filesystem, causing swap to be created on
-# that disk instead of the ephemeral NVMe array.
+# filesystem (/dev/md0p1), not merely mounted by something or a parent
+# directory containing it. A plain `mountpoint -q` or `findmnt --target`
+# would match parent filesystems, causing swap to be created on the wrong
+# disk instead of the ephemeral NVMe array. Filesystem labels are also not
+# globally unique, so compare the canonical device path.
 is_nvme_array_mounted() {
-  local expected_source actual_source
-  expected_source=$(blkid -L "$NVME_RAID0_LABEL" 2>/dev/null) || return 1
-  [ -n "$expected_source" ] || return 1
+  local expected_source actual_source md_major md_minor source_major source_minor
+
+  # Verify exact mount point (not parent directory)
+  if ! mountpoint -q "$MOUNT_POINT" 2>/dev/null; then
+    return 1
+  fi
+
+  # Get the canonical device path of what's mounted at MOUNT_POINT
   actual_source=$(findmnt -n -o SOURCE --target "$MOUNT_POINT" 2>/dev/null) || return 1
-  [ "$expected_source" = "$actual_source" ]
+  [ -n "$actual_source" ] || return 1
+
+  # Expected device is /dev/md0p1; compare by device node directly
+  # This avoids false positives from unrelated filesystems with the same label
+  expected_source="/dev/md0p1"
+
+  # Handle both device names (md0p1) and device nodes (/dev/md0p1)
+  case "$actual_source" in
+    /dev/md0p1)
+      ;;
+    md0p1)
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+
+  # Double-check with label to ensure this really is our NVMe array, not
+  # another filesystem that happens to be mounted at our target
+  local filesystem_label
+  filesystem_label=$(blkid -s LABEL -o value "$actual_source" 2>/dev/null) || return 1
+  [ "$filesystem_label" = "$NVME_RAID0_LABEL" ] || return 1
+
+  return 0
 }
 
 if swapon --show | grep -q "$WAAGENT_SWAP_FILE"; then
@@ -62,6 +99,13 @@ if ! is_nvme_array_mounted; then
   fi
 
   if ! is_nvme_array_mounted; then
+    # Before attempting to mount, verify the target isn't already a mount point.
+    # Linux permits stacked mounts, so mounting on an already-occupied target would
+    # hide the existing mount and create swap on the wrong filesystem.
+    if mountpoint -q "$MOUNT_POINT" 2>/dev/null; then
+      echo "ERROR: $MOUNT_POINT is already a mount point but is not mounted with the NVMe RAID0 array (LABEL=$NVME_RAID0_LABEL). This may indicate an unrelated filesystem is occupying the target. Refusing to proceed to avoid stacked mounts and data loss." | systemd-cat -t create-swap -p err
+      exit 1
+    fi
     mount "$MOUNT_POINT"
   fi
 

--- a/deploy/ansible/roles-os/1.1-swap/templates/create-swap-perboot.sh.j2
+++ b/deploy/ansible/roles-os/1.1-swap/templates/create-swap-perboot.sh.j2
@@ -71,7 +71,7 @@ if ! is_nvme_array_mounted; then
   fi
 fi
 
-if swapon --show | grep -q "$SWAP_FILE"; then
+if swapon --show=NAME --noheadings | grep -Fxq -- "$SWAP_FILE"; then
   echo "Swap already active" | systemd-cat -t create-swap
   exit 0
 fi

--- a/deploy/ansible/roles-os/1.1-swap/templates/create-swap-perboot.sh.j2
+++ b/deploy/ansible/roles-os/1.1-swap/templates/create-swap-perboot.sh.j2
@@ -1,15 +1,23 @@
 #!/bin/bash
 # Recreate swap file on NVMe temp disk after reboot.
-# NVMe temp disks are ephemeral - data is lost on VM stop/deallocate.
-# The RAID0 config persists in initramfs, but the swap file needs
-# to be recreated on each boot.
+# NVMe temp disks are ephemeral - data (including the RAID0 superblocks and
+# filesystem) is lost whenever the VM is stopped/deallocated, which also
+# happens as part of a VM resize. The RAID0 config normally re-assembles from
+# initramfs/mdadm.conf, but after a resize the underlying NVMe media comes
+# back blank (no superblocks, no filesystem), so it never auto-mounts.
+# To guarantee the ephemeral disk is always usable, this script re-runs the
+# azure-nvme-swap-conf helper (idempotent: it no-ops if the array/filesystem
+# are already valid) whenever the mount point isn't ready before recreating
+# the swap file.
 #
 # Deployed by Ansible role 1.1-swap as a cloud-init per-boot script.
 
-SWAP_FILE="/mnt/resource/swapfile"
+SWAP_FILE="{{ swap_mount_point }}/swapfile"
 WAAGENT_SWAP_FILE="/mnt/swapfile"
 SWAP_SIZE_MB="{{ swap_size_mb }}"
-MOUNT_POINT="/mnt/resource"
+MOUNT_POINT="{{ swap_mount_point }}"
+FILESYSTEM="{{ swap_filesystem }}"
+NVME_SWAP_CONF_HELPER="/usr/local/bin/azure-nvme-swap-conf"
 
 if swapon --show | grep -q "$WAAGENT_SWAP_FILE"; then
   echo "Swap already configured by waagent" | systemd-cat -t create-swap
@@ -25,8 +33,26 @@ for _ in $(seq 1 30); do
 done
 
 if ! mountpoint -q "$MOUNT_POINT" 2>/dev/null; then
-  echo "ERROR: $MOUNT_POINT is not a mountpoint" | systemd-cat -t create-swap -p err
-  exit 1
+  echo "$MOUNT_POINT is not mounted - ephemeral NVMe media likely came back blank (e.g. after a VM resize). Re-initializing RAID0 array and filesystem." | systemd-cat -t create-swap
+
+  if [ ! -x "$NVME_SWAP_CONF_HELPER" ]; then
+    echo "ERROR: $NVME_SWAP_CONF_HELPER not found or not executable" | systemd-cat -t create-swap -p err
+    exit 1
+  fi
+
+  if ! "$NVME_SWAP_CONF_HELPER" "$FILESYSTEM" "$MOUNT_POINT" 2>&1 | systemd-cat -t create-swap; then
+    echo "ERROR: failed to (re)initialize the NVMe temp disk with $NVME_SWAP_CONF_HELPER" | systemd-cat -t create-swap -p err
+    exit 1
+  fi
+
+  if ! mountpoint -q "$MOUNT_POINT" 2>/dev/null; then
+    mount -a
+  fi
+
+  if ! mountpoint -q "$MOUNT_POINT" 2>/dev/null; then
+    echo "ERROR: $MOUNT_POINT is still not a mountpoint after re-initialization" | systemd-cat -t create-swap -p err
+    exit 1
+  fi
 fi
 
 if swapon --show | grep -q "$SWAP_FILE"; then

--- a/deploy/ansible/roles-os/1.1-swap/templates/create-swap-perboot.sh.j2
+++ b/deploy/ansible/roles-os/1.1-swap/templates/create-swap-perboot.sh.j2
@@ -12,11 +12,11 @@
 #
 # Deployed by Ansible role 1.1-swap as a cloud-init per-boot script.
 
-SWAP_FILE="{{ swap_mount_point }}/swapfile"
 WAAGENT_SWAP_FILE="/mnt/swapfile"
 SWAP_SIZE_MB="{{ swap_size_mb }}"
-MOUNT_POINT="{{ swap_mount_point }}"
-FILESYSTEM="{{ swap_filesystem }}"
+MOUNT_POINT={{ swap_mount_point | quote }}
+FILESYSTEM={{ swap_filesystem | quote }}
+SWAP_FILE="$MOUNT_POINT/swapfile"
 NVME_SWAP_CONF_HELPER="/usr/local/bin/azure-nvme-swap-conf"
 
 if swapon --show | grep -q "$WAAGENT_SWAP_FILE"; then
@@ -40,7 +40,8 @@ if ! mountpoint -q "$MOUNT_POINT" 2>/dev/null; then
     exit 1
   fi
 
-  if ! "$NVME_SWAP_CONF_HELPER" "$FILESYSTEM" "$MOUNT_POINT" 2>&1 | systemd-cat -t create-swap; then
+  "$NVME_SWAP_CONF_HELPER" "$FILESYSTEM" "$MOUNT_POINT" 2>&1 | systemd-cat -t create-swap
+  if [ "${PIPESTATUS[0]}" -ne 0 ]; then
     echo "ERROR: failed to (re)initialize the NVMe temp disk with $NVME_SWAP_CONF_HELPER" | systemd-cat -t create-swap -p err
     exit 1
   fi

--- a/deploy/ansible/vars/ansible-input-api.yaml
+++ b/deploy/ansible/vars/ansible-input-api.yaml
@@ -292,13 +292,17 @@ use_fence_kdump:                       false
 use_hanasr_angi:                       false
 
 # ------------------- Begin - SAP SWAP settings variables --------------------8
+# Note: hana is intentionally 2048 MB (2 GiB) per SAP's HANA swap
+# recommendation, not a leftover typo of 20480. `free -g` may display this
+# as ~1.9G due to binary-GiB rounding plus mkswap/kernel header overhead -
+# that is expected and not a sizing regression.
 sap_swap:
   - { tier: "scs",                swap_size_mb: "4096"   }
   - { tier: "ers",                swap_size_mb: "4096"   }
   - { tier: "pas",                swap_size_mb: "20480"  }
   - { tier: "app",                swap_size_mb: "20480"  }
   - { tier: "web",                swap_size_mb: "20480"  }
-  - { tier: "hana",               swap_size_mb: "2050"   }
+  - { tier: "hana",               swap_size_mb: "2048"   }
   - { tier: "db2",                swap_size_mb: "20480"  }
   - { tier: "sybase",             swap_size_mb: "20480"  }
   - { tier: "oracle",             swap_size_mb: "204800" }

--- a/deploy/ansible/vars/ansible-input-api.yaml
+++ b/deploy/ansible/vars/ansible-input-api.yaml
@@ -293,9 +293,13 @@ use_hanasr_angi:                       false
 
 # ------------------- Begin - SAP SWAP settings variables --------------------8
 # Note: hana is intentionally 2048 MB (2 GiB) per SAP's HANA swap
-# recommendation, not a leftover typo of 20480. `free -g` may display this
-# as ~1.9G due to binary-GiB rounding plus mkswap/kernel header overhead -
-# that is expected and not a sizing regression.
+# recommendation, not a leftover typo of 20480. `free -m`/`swapon --show`
+# will show a total close to (but slightly under) 2048 MB, since mkswap and
+# the kernel reserve a small amount of header space; `free -g` rounds to
+# whole GiB and will simply report 2. This value drives both the NVMe swap
+# helper (roles-os/1.1-swap/tasks/main.yaml, use_nvme_disks path) and the
+# waagent ResourceDisk.SwapSizeMB setting (same file, non-NVMe path), so it
+# changes the HANA swap size on non-NVMe deployments as well.
 sap_swap:
   - { tier: "scs",                swap_size_mb: "4096"   }
   - { tier: "ers",                swap_size_mb: "4096"   }

--- a/deploy/ansible/vars/ansible-input-api.yaml
+++ b/deploy/ansible/vars/ansible-input-api.yaml
@@ -293,19 +293,19 @@ use_hanasr_angi:                       false
 
 # ------------------- Begin - SAP SWAP settings variables --------------------8
 sap_swap:
-  - { tier: "scs",                swap_size_mb: "4096"  }
-  - { tier: "ers",                swap_size_mb: "4096"  }
-  - { tier: "pas",                swap_size_mb: "20480" }
-  - { tier: "app",                swap_size_mb: "20480" }
-  - { tier: "web",                swap_size_mb: "20480" }
-  - { tier: "hana",               swap_size_mb: "20480" }
-  - { tier: "db2",                swap_size_mb: "20480" }
-  - { tier: "sybase",             swap_size_mb: "20480" }
+  - { tier: "scs",                swap_size_mb: "4096"   }
+  - { tier: "ers",                swap_size_mb: "4096"   }
+  - { tier: "pas",                swap_size_mb: "20480"  }
+  - { tier: "app",                swap_size_mb: "20480"  }
+  - { tier: "web",                swap_size_mb: "20480"  }
+  - { tier: "hana",               swap_size_mb: "2050"   }
+  - { tier: "db2",                swap_size_mb: "20480"  }
+  - { tier: "sybase",             swap_size_mb: "20480"  }
   - { tier: "oracle",             swap_size_mb: "204800" }
   - { tier: "oracle-asm",         swap_size_mb: "204800" }
-  - { tier: "oracle-multi-sid",   swap_size_mb: "20480" }
-  - { tier: "observer",           swap_size_mb: "2048"  }
-  - { tier: 'sqlserver',          swap_size_mb: '20480' }
+  - { tier: "oracle-multi-sid",   swap_size_mb: "20480"  }
+  - { tier: "observer",           swap_size_mb: "2048"   }
+  - { tier: 'sqlserver',          swap_size_mb: '20480'  }
 # --------------------- End - SAP SWAP settings variables --------------------8
 
 # ------------------- Begin - Azure Monitor for SAP (AMS) variables ------------8


### PR DESCRIPTION
This pull request improves the flexibility and robustness of the NVMe swap configuration in the Ansible `1.1-swap` role. It introduces a configurable mount point for the NVMe swap, ensures this setting is consistently used throughout the role and related scripts, and enhances the per-boot swap recreation script to better handle scenarios where the ephemeral NVMe disk is blank after VM resize or redeployment.

Configuration improvements:

- Introduced `nvme_swap_mount_point` (defaulting to `"/mnt/resource"`) to centralize and simplify configuration of the NVMe swap mount point in `main.yaml`.
- Introduced `nvme_swap_filesystem` to remove hardcoded `ext4` references and consistently reference the filesystem type throughout the role. This is currently fixed to `ext4` and enforced by an Ansible assert plus an allow-list in the `azure-nvme-swap-conf` helper script — both `create-nvme-swap.sh` and `create-swap-perboot.sh.j2` allocate the swap file with `fallocate(2)`, which `ext2`/`ext3` don't support, and the fixed RAID0 array label is incompatible with filesystems that impose shorter label limits (e.g. XFS). Other filesystems are not currently supported end-to-end.
- Updated all relevant Ansible commands (`azure-nvme-swap-conf`, `create-nvme-swap.sh`) to use these variables instead of hardcoded values, ensuring consistency and easier customization of the mount point.

Script robustness and clarity:

- Enhanced the `create-swap-perboot.sh.j2` script to:
  - Use the configured mount point (and the fixed `ext4` filesystem) variables, making it adaptable to different mount-point requirements.
  - Add detailed comments explaining the ephemeral nature of NVMe disks and the need for re-initialization after VM resize or deallocation.
  - Automatically detect when the NVMe mount point is not ready, verify it's actually serving the NVMe RAID0 array (not an unrelated filesystem), attempt to re-run the NVMe  configuration helper, and provide clear error messages and logging if initialization fails.
  - Hardened `azure-nvme-swap-conf` to reconcile stale fstab entries, preflight-check for mount-point conflicts before any destructive change, safely deactivate/unmount existing swap before reinitializing the array, and roll back partial fstab/mdadm.conf changes on failure.
