### PR TITLE
Fix skill validation failures on release pull requests

### DIFF
--- a/.github/workflows/skill-validation.yml
+++ b/.github/workflows/skill-validation.yml
@@ -161,6 +161,10 @@ jobs:
   evaluate:
     name: Evaluate skill routing
     needs: prepare
+    # Fork pull requests are granted a read-only GITHUB_TOKEN, so the
+    # `copilot-requests: write` permission requested below is silently dropped
+    # and every model call fails. Skip rather than report 54 false failures.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 120
     permissions:

--- a/evals/evals.json
+++ b/evals/evals.json
@@ -870,7 +870,7 @@
         },
         {
           "id": "workspace-positive-02",
-          "prompt": "How should I name the workspace and region/location portions of these parameter files?",
+          "prompt": "In the SDAF WORKSPACES tree, what is the naming convention for the workspace directory names and the region code portion of each tfvars filename?",
           "expected_output": "Copilot loads sdaf-workspace-and-tfvars.",
           "assertions": [
             "With-skill run emits at least one skill.invoked event naming sdaf-workspace-and-tfvars.",

--- a/evals/evals.py
+++ b/evals/evals.py
@@ -785,6 +785,14 @@ def report_batch(summaries: list[dict[str, Any]], output_dir: Path) -> int:
             handle.write(report)
     for item in failures:
         print(f"failed: {item['case_id']} {item.get('error', '')}".rstrip(), file=sys.stderr)
+    if failures and len(summaries) > 1 and len(failures) == len(summaries):
+        print(
+            "hint: every case failed, which is characteristic of a credential or "
+            "environment problem rather than a skill routing regression. Confirm the "
+            "job was granted 'CopilotRequests: write' -- a pull request from a fork "
+            "receives a read-only token and cannot call the Copilot API.",
+            file=sys.stderr,
+        )
     return 1 if failures else 0
 
 

--- a/tests/evals/test_evals.py
+++ b/tests/evals/test_evals.py
@@ -325,6 +325,34 @@ def test_report_batch_reports_retry_counts(tmp_path: Path) -> None:
     assert document["cases"][0]["attempts"] == 3
 
 
+def test_report_batch_flags_total_failure_as_environment_problem(tmp_path: Path, capsys) -> None:
+    """Every case failing points at credentials, not at skill routing."""
+
+    summaries = [
+        {"case_id": "a-case", "passed": False},
+        {"case_id": "b-case", "passed": False},
+    ]
+
+    code = EVALS.report_batch(summaries, tmp_path / "out")
+
+    assert code == 1
+    assert "CopilotRequests: write" in capsys.readouterr().err
+
+
+def test_report_batch_omits_environment_hint_for_partial_failure(tmp_path: Path, capsys) -> None:
+    """A genuine routing regression must not be blamed on credentials."""
+
+    summaries = [
+        {"case_id": "a-case", "passed": False},
+        {"case_id": "b-case", "passed": True},
+    ]
+
+    code = EVALS.report_batch(summaries, tmp_path / "out")
+
+    assert code == 1
+    assert "CopilotRequests: write" not in capsys.readouterr().err
+
+
 def test_report_batch_writes_summary_and_fails_on_any_case(tmp_path: Path, monkeypatch) -> None:
     """A single failing case fails the batch and is named in the report."""
 


### PR DESCRIPTION
## Problem

The skill validation workflow was failing on release pull requests for two unrelated reasons.

### 1. Fork pull requests can never run the evaluation

GitHub grants a pull request from a fork a **read-only** `GITHUB_TOKEN`. The `copilot-requests: write` permission the `evaluate` job requests is silently dropped, so the Copilot SDK cannot make a single model call and all 54 cases fail in ~2 seconds each.

Proof, from the job logs:

| | PR #1287 (fork `devanshjainms`), run 33020863371 | PR #1288 (same repo), run 33021010670 |
| --- | --- | --- |
| Granted | `Contents: read`, `Metadata: read` | `Contents: read`, **`CopilotRequests: write`**, `Metadata: read` |
| Secret source | `None` | `Actions` |
| Result | 54/54 fail | 53/54 pass |

This is not fixable on a fork pull request, so the job is now skipped there rather than reporting 54 false failures.

### 2. The `workspace-positive-02` prompt was defective

> How should I name the workspace and region/location portions of these parameter files?

The prompt has no SDAF anchor, `"these parameter files"` refers to nothing, and `"workspace"` reads as a generic Terraform workspace. The model answered about Terraform stacks and AWS regions and loaded no skill at all - **zero** invocations across all three attempts, consistently.

## Changes

- Skip `evaluate` on fork pull requests via `github.event.pull_request.head.repo.full_name == github.repository`.
- Reword `workspace-positive-02` using vocabulary `sdaf-workspace-and-tfvars` documents for itself (SDAF, WORKSPACES, region code, tfvars filename).
- Print a clear diagnostic when *every* case fails, so a credential or environment outage is no longer indistinguishable from a routing regression.

**No assertion is weakened.** Only the defective prompt changed; the skill documents were not edited to fit the test.

## Validation

- Live model run of the reworded prompt: **passes on the first attempt**, with exactly one `sdaf-workspace-and-tfvars` invocation, no stray companions, and the baseline correctly not invoking it.
- `pytest -o addopts="" tests/evals/test_evals.py` - 28 passed (26 before, +2 covering the new diagnostic).
- `pylint evals/evals.py` - 10.00/10.
- `black --check` - clean.
- Workflow YAML parsed and the guard expression asserted.
